### PR TITLE
docs: update README clone URL to new repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Python library for talking to test-and-measurement instruments — power supplie
 pip install instro
 
 # Source install (works today):
-git clone https://github.com/nominal-io/instrumentation.git
-cd instrumentation
+git clone https://github.com/nominal-io/instro.git
+cd instro
 uv sync --extra all
 ```
 


### PR DESCRIPTION
## Summary

- Updates the source-install clone URL in README.md from the old `nominal-io/instrumentation` repo to `nominal-io/instro`.

Fixes #2

## Test plan

- [x] Verified the diff is scoped to README.md:20-21