### PR TITLE
docs: require tracking issue and document branch naming

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ If `just check` and `just test` both pass, CI will pass.
 
 ## Conventions
 
+- **Every change has a tracking issue/ticket.** Branch off `main`; name the branch after the GitHub issue or ticket ID (e.g. `issue-142-siglent-spd-driver`, `con-2498-docstring-cleanup`). No untracked work — open an issue first if one doesn't exist.
 - **Conventional Commits** for PR titles and commits: `<type>(<scope>): <imperative description>`. Types: `feat`, `fix`, `chore`, `docs`, `refactor`. Append `!` for breaking changes. Title under 72 chars, no trailing period.
 - **No multi-paragraph docstrings.** One short line max. Don't reintroduce verbose docstrings — the repo went through a deliberate cleanup pass (CON-2498).
 - **No comments unless the *why* is non-obvious.** Don't restate what the code does.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,18 +25,27 @@ just test     # unit tests (no hardware required)
 
 ## Issues and discussion
 
-For anything beyond a small fix, **open a [GitHub issue](https://github.com/nominal-io/instrumentation/issues) first** to align on scope before writing code. Good candidates for an issue-first discussion:
+**Every change is tracked by a GitHub issue or ticket — no exceptions, including typos and one-line fixes.** Open a [GitHub issue](https://github.com/nominal-io/instrumentation/issues) before starting work so scope, ownership, and history are all traceable from the issue → branch → PR chain.
+
+For larger or cross-cutting work, use the issue to align on scope before writing code. Good candidates for an explicit issue-first discussion:
 
 - A new driver — especially one that requires a native vendor SDK we don't already wrap.
 - A new instrument category (PSU, DMM, etc. aren't an exhaustive list).
 - Anything touching public API or cross-cutting abstractions.
 - Behaviour changes to existing drivers.
 
-Small, self-contained fixes (typos, obvious bugs with a clear repro) can go straight to a PR.
-
 If you find an unrelated issue while working on something else, open a separate issue and keep your current PR focused. That keeps reviews quick and avoids scope creep.
 
 ## Submitting a pull request
+
+### Branches
+
+Every change must be tracked by a GitHub issue or ticket — see [Issues and discussion](#issues-and-discussion). Branch off `main` and name the branch after that issue/ticket ID. Examples:
+
+```
+issue-142-siglent-spd-driver
+con-2498-docstring-cleanup
+```
 
 ### Pull request titles
 


### PR DESCRIPTION
## Summary

- Adds a **Branches** subsection to CONTRIBUTING.md: branch off `main`, name the branch after the GitHub issue or ticket ID (`issue-142-siglent-spd-driver`, `con-2498-docstring-cleanup`).
- Tightens the *Issues and discussion* section so every change — including typos and one-line fixes — has a tracking issue. Removes the previous "small fixes can go straight to a PR" escape hatch.
- Mirrors the rule in AGENTS.md as a single dense bullet at the top of *Conventions*.

Closes #6.

## Test plan

- [x] Skim rendered Markdown in both files to confirm headings/links resolve.
- [x] Reviewer confirms wording reflects the intended policy (no untracked work).