### PR TITLE
fix(release): align release-please paths and components with workspace

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -11,34 +11,34 @@
   "packages": {
     ".": {
       "release-type": "python",
-      "component": "nominal-instro"
+      "component": "instro"
     },
-    "packages/nominal-instro-daq-ni": {
+    "packages/instro-daq-ni": {
       "release-type": "python",
-      "component": "nominal-instro-daq-ni"
+      "component": "instro-daq-ni"
     },
-    "packages/nominal-instro-daq-labjack": {
+    "packages/instro-daq-labjack": {
       "release-type": "python",
-      "component": "nominal-instro-daq-labjack"
+      "component": "instro-daq-labjack"
     },
-    "packages/nominal-instro-daq-mcc": {
+    "packages/instro-daq-mcc": {
       "release-type": "python",
-      "component": "nominal-instro-daq-mcc"
+      "component": "instro-daq-mcc"
     },
-    "packages/nominal-instro-i2c-aardvark": {
+    "packages/instro-i2c-aardvark": {
       "release-type": "python",
-      "component": "nominal-instro-i2c-aardvark"
+      "component": "instro-i2c-aardvark"
     }
   },
   "groups": [
     {
-      "name": "nominal-instro",
+      "name": "instro",
       "packages": [
         ".",
-        "packages/nominal-instro-daq-ni",
-        "packages/nominal-instro-daq-labjack",
-        "packages/nominal-instro-daq-mcc",
-        "packages/nominal-instro-i2c-aardvark"
+        "packages/instro-daq-ni",
+        "packages/instro-daq-labjack",
+        "packages/instro-daq-mcc",
+        "packages/instro-i2c-aardvark"
       ]
     }
   ]

--- a/.github/release-please-manifest.json
+++ b/.github/release-please-manifest.json
@@ -1,7 +1,7 @@
 {
   ".": "0.6.0",
-  "packages/nominal-instro-daq-ni": "0.4.0",
-  "packages/nominal-instro-daq-labjack": "0.4.0",
-  "packages/nominal-instro-daq-mcc": "0.2.0",
-  "packages/nominal-instro-i2c-aardvark": "0.1.0"
+  "packages/instro-daq-ni": "0.4.0",
+  "packages/instro-daq-labjack": "0.4.0",
+  "packages/instro-daq-mcc": "0.2.0",
+  "packages/instro-i2c-aardvark": "0.1.0"
 }


### PR DESCRIPTION
## Summary
- Renames `packages/nominal-instro-*` keys in `.github/release-please-config.json` and `.github/release-please-manifest.json` to match the real workspace directories (`packages/instro-*`).
- Drops the `nominal-` prefix from `component` values and the group name so future tags will be `instro-daq-ni-v0.4.1` etc., aligned with the PyPI package names.
- Unblocks release PRs for the workspace packages (none have been opening) and clears the way for PyPI publish automation.

Closes #14.

## Heads-up for the first Release PR
No tags exist yet matching the new `instro-*` components, so release-please will scan further back than usual when it opens the first Release PR after this merges. Expect to hand-edit that first changelog to trim noise. After it cuts the first tag with the new component name, subsequent Release PRs anchor on that tag and steady state is clean.

The `nominal-instro-i2c-aardvark-v0.2.0` git tag exists but the manifest pins `0.1.0` — pre-existing inconsistency, left as-is here; flag if it should be tracked separately.

## Test plan
- [ ] Merge and confirm next release-please run opens a Release PR covering the workspace packages.
- [ ] Hand-trim the first changelog before merging the Release PR.
- [ ] Confirm subsequent Release PRs scope changelogs to commits since the last `instro-*-v*` tag.