### PR TITLE
feat(ci): add TestPyPI publish workflow

### DIFF
--- a/.github/workflows/publish-testpypi.yml
+++ b/.github/workflows/publish-testpypi.yml
@@ -1,0 +1,65 @@
+name: Publish to TestPyPI
+
+# Triggered by release-please tags (e.g. `instro-v0.6.1`, `instro-daq-ni-v0.4.1`).
+# The package name is derived from the tag by stripping the trailing `-v<version>`.
+#
+# One-time setup on TestPyPI (https://test.pypi.org/manage/account/publishing/):
+#   For each package, register a trusted publisher with:
+#     Owner:           nominal-io
+#     Repository:      instro
+#     Workflow:        publish-testpypi.yml
+#     Environment:     testpypi
+
+on:
+  push:
+    tags:
+      - "instro-v*"
+      - "instro-*-v*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    outputs:
+      package: ${{ steps.parse.outputs.package }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: "0.8.x"
+          enable-cache: false
+      - name: Parse package name from tag
+        id: parse
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          package="${tag%-v*}"
+          if [[ -z "$package" || "$package" == "$tag" ]]; then
+            echo "::error::Could not parse package name from tag '$tag'"
+            exit 1
+          fi
+          echo "package=$package" >> "$GITHUB_OUTPUT"
+          echo "Building package: $package"
+      - name: Build distributions
+        run: uv build --package "${{ steps.parse.outputs.package }}"
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment: testpypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Publish to TestPyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
## Summary
- New `.github/workflows/publish-testpypi.yml` that fires on `instro*-v*` tag pushes, derives the package name by stripping `-v*` from the tag, builds with `uv build --package`, and publishes to TestPyPI via OIDC trusted publishing.
- Split into `build` and `publish` jobs; `publish` runs in a `testpypi` deployment environment so we can require manual approval later without changing the workflow.

Refs #16. Depends on #15 (`instro-*` tag format) being merged before any tag will match.

## One-time setup before this can publish
For each package, register a trusted publisher at https://test.pypi.org/manage/account/publishing/ with:

| Field | Value |
|---|---|
| Owner | `nominal-io` |
| Repository | `instro` |
| Workflow | `publish-testpypi.yml` |
| Environment | `testpypi` |

Packages to register: `instro`, `instro-daq-ni`, `instro-daq-labjack`, `instro-daq-mcc`, `instro-i2c-aardvark`.

Also create a `testpypi` deployment environment on the repo (Settings → Environments) — required reviewers optional.

## Test plan
- [ ] Register TestPyPI trusted publishers (above).
- [ ] Create the `testpypi` GitHub environment.
- [ ] Merge #15, then merge the next release-please Release PR to push a tag.
- [ ] Confirm the workflow fires, the wheel publishes, and `pip install --index-url https://test.pypi.org/simple/ <package>` works in a clean venv.

## Out of scope
- Real PyPI publish workflow (separate ticket once we've validated end-to-end on TestPyPI).
- Cross-package install testing (workspace deps won't resolve from TestPyPI alone on first publish).