### PR TITLE
feat: add PyPI project URLs

### DIFF
--- a/packages/instro-daq-labjack/pyproject.toml
+++ b/packages/instro-daq-labjack/pyproject.toml
@@ -7,6 +7,11 @@ license-files = ["LICENSE"]
 requires-python = ">=3.10,<4.0"
 dependencies = ["instro", "labjack-ljm>=1.23.0"]
 
+[project.urls]
+Homepage = "https://github.com/nominal-io/instro"
+Repository = "https://github.com/nominal-io/instro"
+Issues = "https://github.com/nominal-io/instro/issues"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/packages/instro-daq-mcc/pyproject.toml
+++ b/packages/instro-daq-mcc/pyproject.toml
@@ -7,6 +7,11 @@ license-files = ["LICENSE"]
 requires-python = ">=3.10,<4.0"
 dependencies = ["instro", "mcculw>=1.0.0"]
 
+[project.urls]
+Homepage = "https://github.com/nominal-io/instro"
+Repository = "https://github.com/nominal-io/instro"
+Issues = "https://github.com/nominal-io/instro/issues"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/packages/instro-daq-ni/pyproject.toml
+++ b/packages/instro-daq-ni/pyproject.toml
@@ -7,6 +7,11 @@ license-files = ["LICENSE"]
 requires-python = ">=3.10,<4.0"
 dependencies = ["instro", "nidaqmx>=1.2.0"]
 
+[project.urls]
+Homepage = "https://github.com/nominal-io/instro"
+Repository = "https://github.com/nominal-io/instro"
+Issues = "https://github.com/nominal-io/instro/issues"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/packages/instro-i2c-aardvark/pyproject.toml
+++ b/packages/instro-i2c-aardvark/pyproject.toml
@@ -7,6 +7,11 @@ license-files = ["LICENSE"]
 requires-python = ">=3.10,<4.0"
 dependencies = ["instro", "pyaardvark>=0.8.1"]
 
+[project.urls]
+Homepage = "https://github.com/nominal-io/instro"
+Repository = "https://github.com/nominal-io/instro"
+Issues = "https://github.com/nominal-io/instro/issues"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,11 @@ all = [
     "instro-i2c-aardvark",
 ]
 
+[project.urls]
+Homepage = "https://github.com/nominal-io/instro"
+Repository = "https://github.com/nominal-io/instro"
+Issues = "https://github.com/nominal-io/instro/issues"
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"


### PR DESCRIPTION
## Summary
- Adds `[project.urls]` to all 5 publishable packages so the PyPI project page surfaces Homepage / Repository / Issues links.
- Touches every package's `pyproject.toml` so release-please attributes the `feat:` to all five components — this PR also serves as the bootstrap that wakes up release-please for the first time.

## Expected release-please behavior
On merge to `main`, release-please should open a release PR proposing:
- `instro` 0.6.0 → 0.7.0
- `instro-daq-ni` 0.4.0 → 0.5.0
- `instro-daq-labjack` 0.4.0 → 0.5.0
- `instro-daq-mcc` 0.2.0 → 0.3.0
- `instro-i2c-aardvark` 0.1.0 → 0.2.0

## Test plan
- [x] CI green (`build-check-test.yml`)
- [x] After merge to main, release-please opens a release PR with the five expected bumps
- [x] On merging the release PR, publish job fans out and uploads to PyPI (requires trusted publishers configured)