### PR TITLE
docs: update README for PyPI release

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,21 +2,25 @@
 
 Python library for talking to test-and-measurement instruments — power supplies, multimeters, electronic loads, DAQs, oscilloscopes, PLCs — from a unified, typed API.
 
-> **Coming soon to PyPI.** `instro` is being prepared for open-source release. Until then, install from source as shown below; once the package is published, `pip install instro` will be the supported install path.
+[![PyPI](https://img.shields.io/pypi/v/instro.svg)](https://pypi.org/project/instro/)
 
 ## Installation
 
 ```bash
-# After the OSS launch (PyPI):
 pip install instro
+```
 
-# Source install (works today):
+Requires [Python 3.10+](https://www.python.org/downloads/).
+
+To work on `instro` itself, clone and install with [uv](https://docs.astral.sh/uv/):
+
+```bash
 git clone https://github.com/nominal-io/instro.git
 cd instro
 uv sync --extra all
 ```
 
-The source install requires [Python 3.10+](https://www.python.org/downloads/) and [uv](https://docs.astral.sh/uv/). It creates a virtual environment, installs the core library, all optional vendor drivers, and dev dependencies. Run with `uv run python your_script.py` or activate via `source .venv/bin/activate` (Unix) / `.venv\Scripts\activate` (Windows).
+This creates a virtual environment with the core library, all optional vendor drivers, and dev dependencies. Run with `uv run python your_script.py` or activate via `source .venv/bin/activate` (Unix) / `.venv\Scripts\activate` (Windows).
 
 ### Optional vendor extras
 


### PR DESCRIPTION
Closes #23. Supersedes #24 (closed when its source branch was renamed to match the documented `issue-N-…` convention).

## Summary
- Drop the "Coming soon to PyPI" callout — `instro` is live on PyPI (v0.7.0).
- Make `pip install instro` the primary install path; demote the `uv sync` source install to a "to work on instro itself" section.
- Add a PyPI version badge.
- Confirmed the optional-extras table still matches what's published.

## Test plan
- [x] Render `README.md` on the PR page and confirm the badge, install block, and extras table look right.