### PR TITLE
chore: update CON references to INSTRO ticket slugs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,9 +30,9 @@ If `just check` and `just test` both pass, CI will pass.
 
 ## Conventions
 
-- **Every change has a tracking issue/ticket.** Branch off `main`; name the branch after the GitHub issue or ticket ID (e.g. `issue-142-siglent-spd-driver`, `con-2498-docstring-cleanup`). No untracked work — open an issue first if one doesn't exist.
+- **Every change has a tracking issue/ticket.** Branch off `main`; name the branch after the GitHub issue or ticket ID (e.g. `issue-142-siglent-spd-driver`, `instro-248-docstring-cleanup`). No untracked work — open an issue first if one doesn't exist.
 - **Conventional Commits** for PR titles and commits: `<type>(<scope>): <imperative description>`. Types: `feat`, `fix`, `chore`, `docs`, `refactor`. Append `!` for breaking changes. Title under 72 chars, no trailing period.
-- **No multi-paragraph docstrings.** One short line max. Don't reintroduce verbose docstrings — the repo went through a deliberate cleanup pass (CON-2498).
+- **No multi-paragraph docstrings.** One short line max. Don't reintroduce verbose docstrings — the repo went through a deliberate cleanup pass (INSTRO-248).
 - **No comments unless the *why* is non-obvious.** Don't restate what the code does.
 - **Type hints required** on all public methods. `mypy` is enforced.
 - **`ruff format` and `ruff check` are enforced.** Run `just check` before pushing.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ Every change must be tracked by a GitHub issue or ticket — see [Issues and dis
 
 ```
 issue-142-siglent-spd-driver
-con-2498-docstring-cleanup
+instro-248-docstring-cleanup
 ```
 
 ### Pull request titles

--- a/docs/guides/migration/migrate_to_instro.py
+++ b/docs/guides/migration/migrate_to_instro.py
@@ -15,7 +15,7 @@ import sys
 from pathlib import Path
 
 REPLACEMENTS: list[tuple[str, str]] = [
-    # --- structural import-path rewrites (CON-2349) ---
+    # --- structural import-path rewrites (INSTRO-51) ---
     # `nominal_instro.instruments.<cat>` collapses to `instro.<cat>`. Each
     # category's instrument class and its driver base now live together in
     # `instro/<cat>/<cat>.py` (no separate driver module). Concrete vendor
@@ -88,7 +88,7 @@ REPLACEMENTS: list[tuple[str, str]] = [
     ("NominalInstrumentationErrorCodes", "InstrumentationErrorCodes"),
     ("NominalDAQFacade", "InstroDAQFacade"),
     # `NominalDMMFacade`, `NominalI2CFacade`, and `NominalPSUFacade` were
-    # removed in CON-2287, CON-2289, and CON-2288 respectively. Keep these
+    # removed in INSTRO-158, INSTRO-156, and INSTRO-157 respectively. Keep these
     # rows as passthroughs so the shorter category-class alternatives below
     # (NominalDMM, NominalI2C, NominalPSU) cannot match inside the facade
     # names and silently produce a now-nonexistent symbol. Users keep the

--- a/docs/guides/migration/v1.mdx
+++ b/docs/guides/migration/v1.mdx
@@ -86,14 +86,14 @@ The conventions are:
 
 ### Removed classes
 
-These facade classes were removed entirely as part of the CON-564 driver-shape refactor — they have **no replacement**. The codemod deliberately leaves these names unchanged so you hit a clear `ImportError` and can migrate away from the facade pattern (drivers now compose `VisaDriver` directly).
+These facade classes were removed entirely as part of the INSTRO-231 driver-shape refactor — they have **no replacement**. The codemod deliberately leaves these names unchanged so you hit a clear `ImportError` and can migrate away from the facade pattern (drivers now compose `VisaDriver` directly).
 
 | Removed                | Removed in | Migration                                                                    |
 | ---------------------- | ---------- | ---------------------------------------------------------------------------- |
-| `NominalDMMFacade`     | CON-2287   | Drop the facade. Driver methods take the configuration they need directly.   |
-| `NominalPSUFacade`     | CON-2288   | Drop the facade. Driver methods take the configuration they need directly.   |
-| `NominalI2CFacade`     | CON-2289   | Drop the facade. Driver methods take the configuration they need directly.   |
-| `NominalScopeFacade`   | CON-2410   | Drop the facade. Driver methods take the configuration they need directly.   |
+| `NominalDMMFacade`     | INSTRO-158 | Drop the facade. Driver methods take the configuration they need directly.   |
+| `NominalPSUFacade`     | INSTRO-157 | Drop the facade. Driver methods take the configuration they need directly.   |
+| `NominalI2CFacade`     | INSTRO-156 | Drop the facade. Driver methods take the configuration they need directly.   |
+| `NominalScopeFacade`   | INSTRO-171 | Drop the facade. Driver methods take the configuration they need directly.   |
 
 ## Automated codemod
 

--- a/instro/daq/daq.py
+++ b/instro/daq/daq.py
@@ -487,7 +487,7 @@ class InstroDAQ(Instrument):
             if not self._background_config.enabled:
                 return self._fetch_analog(**kwargs)
             # Background daemon running. The user can't pull from the buffer mid-flight.
-            # TODO revisit with CON-793 issue ticket.
+            # TODO revisit with INSTRO-149 issue ticket.
             raise RuntimeError("Cannot read analog data while background acquisition daemon is running")
 
         return self._software_timed_read(**kwargs)

--- a/packages/instro-daq-labjack/instro/daq/drivers/labjack/t_series.py
+++ b/packages/instro-daq-labjack/instro/daq/drivers/labjack/t_series.py
@@ -20,7 +20,7 @@ from instro.daq.types import (
 from instro.utils import Measurement
 from labjack import ljm
 
-# TODO: Remove this for [CON-987: Add Context Managers](https://linear.app/nominal-io/issue/CON-987/add-context-managers)
+# TODO: Remove this for [INSTRO-89: Add Context Managers](https://linear.app/nominal-io/issue/INSTRO-89/add-context-managers)
 # We use a callback functionality of the LJM driver. This is for performance reasons vs. python threading.
 # Registering this python callback to the c library
 # can create python segmentation faults when the python interpreter is shutting down.

--- a/packages/instro-daq-ni/instro/daq/drivers/ni/nidaq.py
+++ b/packages/instro-daq-ni/instro/daq/drivers/ni/nidaq.py
@@ -74,8 +74,6 @@ class NIDAQDriver(DAQDriverBase):
 
     def _get_task(self, channel_type: ChannelType) -> nidaqmx.Task:
         """Return (creating if missing) the DAQmx task for ``channel_type``."""
-        # TODO CON-953: refactor this to seperate out hw and sw timed. Only reason to group based on ChannelType
-        # is due to sharing a timing engine per ChannelType, which is not relevant and is restricting for sw timed tasks.
         task = self._tasks.get(channel_type, None)
         if not task:
             # Task does not yet exist for that channel_type
@@ -119,7 +117,6 @@ class NIDAQDriver(DAQDriverBase):
         )
 
     def configure_ao_channel(self, channel: AnalogChannel):
-        # TODO CON-953
         # Bypassing self._tasks in favor of our own task registry until hardware timed analog output is implemented.
 
         task = self._ao_sw_tasks.get(channel.alias, None)

--- a/tests/daq/test_daq_drivers.py
+++ b/tests/daq/test_daq_drivers.py
@@ -350,7 +350,7 @@ def test_hw_timestamper_many_batches_no_drift():
 def test_hw_timestamper_rapid_reads_no_overlap():
     """Regression: two reads returning 0.5ms apart still produce non-overlapping timestamps.
 
-    This is the exact bug scenario from CON-1531. At 1kHz with 100 samples per batch,
+    This is the exact bug scenario from INSTRO-150. At 1kHz with 100 samples per batch,
     each batch covers 100ms of data. If a second read returns only 0.5ms after the first,
     HWTimestamper must still place batch2 entirely after batch1.
     """

--- a/uv.lock
+++ b/uv.lock
@@ -444,7 +444,7 @@ wheels = [
 
 [[package]]
 name = "instro"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastavro", extra = ["snappy"] },
@@ -551,7 +551,7 @@ requires-dist = [{ name = "instro", editable = "." }]
 
 [[package]]
 name = "instro-daq-labjack"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "packages/instro-daq-labjack" }
 dependencies = [
     { name = "instro" },
@@ -566,7 +566,7 @@ requires-dist = [
 
 [[package]]
 name = "instro-daq-mcc"
-version = "0.2.0"
+version = "0.3.0"
 source = { editable = "packages/instro-daq-mcc" }
 dependencies = [
     { name = "instro" },
@@ -581,7 +581,7 @@ requires-dist = [
 
 [[package]]
 name = "instro-daq-ni"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "packages/instro-daq-ni" }
 dependencies = [
     { name = "instro" },
@@ -607,7 +607,7 @@ requires-dist = [{ name = "instro", editable = "." }]
 
 [[package]]
 name = "instro-i2c-aardvark"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "packages/instro-i2c-aardvark" }
 dependencies = [
     { name = "instro" },


### PR DESCRIPTION
## Summary

Linear team identifier changed from CON to INSTRO. Updates every in-repo reference (comments, docstrings, branch-name examples, migration-guide table, Linear URL) to the new slug.

Ticket numbers were re-assigned (not 1:1) — each reference was looked up via Linear's old-slug redirect to find the correct new ID:

| Old | New | What it was |
|---|---|---|
| CON-2498 | INSTRO-248 | Trim docstrings |
| CON-793  | INSTRO-149 | Background-daemon data access |
| CON-1531 | INSTRO-150 | DAQ timestamp fix |
| CON-2349 | INSTRO-51  | Category-first layout |
| CON-2287 | INSTRO-158 | dmm: VisaDriver |
| CON-2289 | INSTRO-156 | i2c: transport-driver |
| CON-2288 | INSTRO-157 | psu: VisaDriver |
| CON-564  | INSTRO-231 | Composable instruments |
| CON-2410 | INSTRO-171 | Scope: VisaDriver |
| CON-953  | (canceled) | nidaq task mgmt — TODOs deleted |
| CON-987  | INSTRO-89  | Context managers |

The two `nidaq.py` TODOs pointed at what is now INSTRO-302, which is in Canceled status — removed those rather than re-pointing to a dead ticket. Kept the descriptive `# Bypassing self._tasks ...` comment that explains the current behavior.

Closes INSTRO-310.

## Test plan

- [x] `just check` clean (ruff format, mypy, ruff lint)
- [x] `grep` for `CON-[0-9]` returns zero hits