### PR TITLE
feat(daq): implement digital port read/write for NI and Keysight drivers

### DIFF
--- a/docs/guides/docs.json
+++ b/docs/guides/docs.json
@@ -96,7 +96,9 @@
               "instrumentation/examples/daq/daq_read_digital_line",
               "instrumentation/examples/daq/daq_relays",
               "instrumentation/examples/daq/daq_write_analog_sw_timed",
-              "instrumentation/examples/daq/daq_write_digital_line"
+              "instrumentation/examples/daq/daq_write_digital_line",
+              "instrumentation/examples/daq/daq_read_digital_port",
+              "instrumentation/examples/daq/daq_write_digital_port"
             ]
           },
           {

--- a/docs/guides/instrumentation/daq.mdx
+++ b/docs/guides/instrumentation/daq.mdx
@@ -524,7 +524,7 @@ print(f"Port value: {int(measurement.latest)}")
 ```
 
 <Note>
-Port-based I/O is currently implemented for **MCC** devices. For NI DAQmx, LabJack, and Keysight, `write_digital_port()` and `read_digital_port()` raise `NotImplementedError`. Use `write_digital_line()` / `read_digital_line()` to address individual lines on those vendors.
+Port-based I/O is implemented for **MCC**, **NI DAQmx**, and **Keysight** devices. On **LabJack**, `write_digital_port()` and `read_digital_port()` raise `NotImplementedError`; use `write_digital_line()` / `read_digital_line()` to address individual lines instead. Keysight groups a single port into one channel of at most 32 bits, so `DigitalPortWidth.WIDTH_64` is rejected — configure a 64-bit span as two channels.
 </Note>
 
 ## Complete Examples
@@ -652,8 +652,8 @@ The base `Instrument` background worker additionally publishes per-iteration dia
 | `read_analog()` | Read analog input (SW-timed) or fetch from buffer (HW-timed) |
 | `read_digital_line(channel)` | Read digital input line |
 | `write_digital_line(channel, data)` | Write to digital output line |
-| `read_digital_port(channel)` | Read all lines on a digital input port as a single integer (MCC only) |
-| `write_digital_port(channel, data)` | Write all lines on a digital output port as a single integer (MCC only) |
+| `read_digital_port(channel)` | Read all lines on a digital input port as a single integer |
+| `write_digital_port(channel, data)` | Write all lines on a digital output port as a single integer |
 | `add_publisher(publisher)` | Attach a publisher for data routing |
 | `get_points_in_buffer()` | Get number of samples in hardware buffer |
 

--- a/docs/guides/instrumentation/examples/daq/daq_read_digital_port.mdx
+++ b/docs/guides/instrumentation/examples/daq/daq_read_digital_port.mdx
@@ -1,0 +1,61 @@
+---
+title: "Read a digital port (all lines as one N-bit integer)"
+---
+
+```python daq_read_digital_port.py
+"""Example: Read a digital port (all lines as one N-bit integer)."""
+
+from instro.daq import InstroDAQ
+from instro.daq.types import DAQVendor, DigitalPortWidth, Direction, Logic
+from instro.lib.publishers import NominalCorePublisher
+
+# Configuration: Choose your vendor. Port-mode I/O is supported on NI, Keysight, and MCC.
+VENDOR = DAQVendor.NI
+
+# Vendor-specific configuration. Each vendor driver lives in its own package and
+# owns its transport at construction time.
+match VENDOR:
+    case DAQVendor.NI:
+        from instro.daq.drivers.ni import NIDAQDriver
+
+        PORT = "Dev1/port0"
+        driver = NIDAQDriver(device_id="Dev1")
+    case DAQVendor.KEYSIGHT_34980:
+        from instro.daq.drivers import Keysight34980A
+
+        PORT = "5101"
+        driver = Keysight34980A("USB0::0x0957::0x0507::MY44001757::INSTR")
+    case DAQVendor.MCC:
+        from instro.daq.drivers.mcc import MCCDriver
+
+        PORT = "FIRSTPORTB"
+        driver = MCCDriver(
+            device_id="344371:0"
+        )  # MCC DAQ device ID, optionally suffixed with ":<board_number>" (default 0)
+
+# Nominal Core dataset to send data to as the instrument is operated.
+DATASET_RID = "<dataset_rid>"  # Replace with your dataset RID.
+
+### Main code
+
+daq = InstroDAQ(name="myDAQ", driver=driver)
+daq.add_publisher(NominalCorePublisher(dataset_rid=DATASET_RID))
+
+daq.open()
+
+try:
+    daq.configure_digital_port(
+        direction=Direction.INPUT,
+        physical_channel=PORT,
+        alias="di_port",
+        logic=Logic.HIGH,
+        port_width=DigitalPortWidth.WIDTH_8,
+    )
+
+    measurement = daq.read_digital_port(channel="di_port")
+    print(f"Port value: {int(measurement.latest)}")
+
+finally:
+    print("Closing DAQ")
+    daq.close()
+```

--- a/docs/guides/instrumentation/examples/daq/daq_write_digital_port.mdx
+++ b/docs/guides/instrumentation/examples/daq/daq_write_digital_port.mdx
@@ -1,0 +1,62 @@
+---
+title: "Write a digital port (all lines as one N-bit integer)"
+---
+
+```python daq_write_digital_port.py
+"""Example: Write a digital port (all lines as one N-bit integer)."""
+
+from instro.daq import InstroDAQ
+from instro.daq.types import DAQVendor, DigitalPortWidth, Direction, Logic
+from instro.lib.publishers import NominalCorePublisher
+
+# Configuration: Choose your vendor. Port-mode I/O is supported on NI, Keysight, and MCC.
+VENDOR = DAQVendor.NI
+
+# Vendor-specific configuration. Each vendor driver lives in its own package and
+# owns its transport at construction time.
+match VENDOR:
+    case DAQVendor.NI:
+        from instro.daq.drivers.ni import NIDAQDriver
+
+        PORT = "Dev1/port0"
+        driver = NIDAQDriver(device_id="Dev1")
+    case DAQVendor.KEYSIGHT_34980:
+        from instro.daq.drivers import Keysight34980A
+
+        PORT = "5101"
+        driver = Keysight34980A("USB0::0x0957::0x0507::MY44001757::INSTR")
+    case DAQVendor.MCC:
+        from instro.daq.drivers.mcc import MCCDriver
+
+        PORT = "FIRSTPORTA"
+        driver = MCCDriver(
+            device_id="344371:0"
+        )  # MCC DAQ device ID, optionally suffixed with ":<board_number>" (default 0)
+
+# Nominal Core dataset to send data to as the instrument is operated.
+DATASET_RID = "<dataset_rid>"  # Replace with your dataset RID.
+
+### Main code
+
+daq = InstroDAQ(name="myDAQ", driver=driver)
+daq.add_publisher(NominalCorePublisher(dataset_rid=DATASET_RID))
+
+daq.open()
+
+try:
+    daq.configure_digital_port(
+        direction=Direction.OUTPUT,
+        physical_channel=PORT,
+        alias="do_port",
+        logic=Logic.HIGH,
+        port_width=DigitalPortWidth.WIDTH_8,
+        logic_level=5.0,
+    )
+
+    # Drive lines 0-3 high, 4-7 low.
+    daq.write_digital_port(channel="do_port", data=0x0F)
+
+finally:
+    print("Closing DAQ")
+    daq.close()
+```

--- a/examples/daq/daq_read_digital_port.py
+++ b/examples/daq/daq_read_digital_port.py
@@ -1,0 +1,55 @@
+"""Example: Read a digital port (all lines as one N-bit integer)."""
+
+from instro.daq import InstroDAQ
+from instro.daq.types import DAQVendor, DigitalPortWidth, Direction, Logic
+from instro.lib.publishers import NominalCorePublisher
+
+# Configuration: Choose your vendor. Port-mode I/O is supported on NI, Keysight, and MCC.
+VENDOR = DAQVendor.NI
+
+# Vendor-specific configuration. Each vendor driver lives in its own package and
+# owns its transport at construction time.
+match VENDOR:
+    case DAQVendor.NI:
+        from instro.daq.drivers.ni import NIDAQDriver
+
+        PORT = "Dev1/port0"
+        driver = NIDAQDriver(device_id="Dev1")
+    case DAQVendor.KEYSIGHT_34980:
+        from instro.daq.drivers import Keysight34980A
+
+        PORT = "5101"
+        driver = Keysight34980A("USB0::0x0957::0x0507::MY44001757::INSTR")
+    case DAQVendor.MCC:
+        from instro.daq.drivers.mcc import MCCDriver
+
+        PORT = "FIRSTPORTB"
+        driver = MCCDriver(
+            device_id="344371:0"
+        )  # MCC DAQ device ID, optionally suffixed with ":<board_number>" (default 0)
+
+# Nominal Core dataset to send data to as the instrument is operated.
+DATASET_RID = "<dataset_rid>"  # Replace with your dataset RID.
+
+### Main code
+
+daq = InstroDAQ(name="myDAQ", driver=driver)
+daq.add_publisher(NominalCorePublisher(dataset_rid=DATASET_RID))
+
+daq.open()
+
+try:
+    daq.configure_digital_port(
+        direction=Direction.INPUT,
+        physical_channel=PORT,
+        alias="di_port",
+        logic=Logic.HIGH,
+        port_width=DigitalPortWidth.WIDTH_8,
+    )
+
+    measurement = daq.read_digital_port(channel="di_port")
+    print(f"Port value: {int(measurement.latest)}")
+
+finally:
+    print("Closing DAQ")
+    daq.close()

--- a/examples/daq/daq_write_digital_port.py
+++ b/examples/daq/daq_write_digital_port.py
@@ -1,0 +1,56 @@
+"""Example: Write a digital port (all lines as one N-bit integer)."""
+
+from instro.daq import InstroDAQ
+from instro.daq.types import DAQVendor, DigitalPortWidth, Direction, Logic
+from instro.lib.publishers import NominalCorePublisher
+
+# Configuration: Choose your vendor. Port-mode I/O is supported on NI, Keysight, and MCC.
+VENDOR = DAQVendor.NI
+
+# Vendor-specific configuration. Each vendor driver lives in its own package and
+# owns its transport at construction time.
+match VENDOR:
+    case DAQVendor.NI:
+        from instro.daq.drivers.ni import NIDAQDriver
+
+        PORT = "Dev1/port0"
+        driver = NIDAQDriver(device_id="Dev1")
+    case DAQVendor.KEYSIGHT_34980:
+        from instro.daq.drivers import Keysight34980A
+
+        PORT = "5101"
+        driver = Keysight34980A("USB0::0x0957::0x0507::MY44001757::INSTR")
+    case DAQVendor.MCC:
+        from instro.daq.drivers.mcc import MCCDriver
+
+        PORT = "FIRSTPORTA"
+        driver = MCCDriver(
+            device_id="344371:0"
+        )  # MCC DAQ device ID, optionally suffixed with ":<board_number>" (default 0)
+
+# Nominal Core dataset to send data to as the instrument is operated.
+DATASET_RID = "<dataset_rid>"  # Replace with your dataset RID.
+
+### Main code
+
+daq = InstroDAQ(name="myDAQ", driver=driver)
+daq.add_publisher(NominalCorePublisher(dataset_rid=DATASET_RID))
+
+daq.open()
+
+try:
+    daq.configure_digital_port(
+        direction=Direction.OUTPUT,
+        physical_channel=PORT,
+        alias="do_port",
+        logic=Logic.HIGH,
+        port_width=DigitalPortWidth.WIDTH_8,
+        logic_level=5.0,
+    )
+
+    # Drive lines 0-3 high, 4-7 low.
+    daq.write_digital_port(channel="do_port", data=0x0F)
+
+finally:
+    print("Closing DAQ")
+    daq.close()

--- a/instro/daq/daq.py
+++ b/instro/daq/daq.py
@@ -733,6 +733,13 @@ class InstroDAQ(Instrument):
                 f"Configured digital output channels: {list(self.do_channels.keys())}. "
                 f"Call configure_digital_port(Direction.OUTPUT, ...) first."
             )
+        if (width := getattr(digital_channel, "width", None)) is not None:
+            max_value = (1 << int(width)) - 1
+            if not 0 <= data <= max_value:
+                raise ValueError(
+                    f"Value {data} does not fit the {int(width)}-bit port '{channel}'; "
+                    f"valid range is 0 to {max_value} (0x{max_value:X})."
+                )
         self._driver.write_digital_port(digital_channel, data)
         timestamp = time.time_ns()
 

--- a/instro/daq/drivers/keysight_34980a.py
+++ b/instro/daq/drivers/keysight_34980a.py
@@ -22,6 +22,14 @@ from instro.daq.types import (
 from instro.lib.transports.visa import VisaConfig, VisaDriver
 from instro.lib.types import Measurement
 
+# A single grouped 34950A digital channel addresses at most 32 bits (LWORd). WIDTH_64 spans
+# separate banks and must be configured as two channels, so it is rejected at configure time.
+_PORT_WIDTH_TOKENS = {
+    DigitalPortWidth.WIDTH_8: "BYTE",
+    DigitalPortWidth.WIDTH_16: "WORD",
+    DigitalPortWidth.WIDTH_32: "LWOR",
+}
+
 
 @dataclass
 class KeysightData:
@@ -285,6 +293,11 @@ class Keysight34980A(DAQDriverBase):
                 "Define the physical channel as MNNN where M is the slot and NNN is the channel. ex '5101'."
                 f" Received {physical_channel}."
             )
+        if port_width not in _PORT_WIDTH_TOKENS:
+            raise ValueError(
+                f"Keysight 34980A digital ports support up to 32-bit ({DigitalPortWidth.WIDTH_32!r}); "
+                f"got {port_width!r}. Configure a 64-bit span as two separate channels."
+            )
         return DigitalPortChannel(
             physical_channel=physical_channel,
             alias=alias or physical_channel,
@@ -296,8 +309,9 @@ class Keysight34980A(DAQDriverBase):
 
     def _program_port(self, channel: DigitalChannel, direction: Direction) -> None:
         dir_token = "INP" if direction is Direction.INPUT else "OUTP"
+        width_token = _PORT_WIDTH_TOKENS[channel.width] if isinstance(channel, DigitalPortChannel) else "BYTE"
         with self._visa.lock():
-            self._visa.write(f"CONF:DIG:WIDT BYTE,(@{channel.physical_channel})")
+            self._visa.write(f"CONF:DIG:WIDT {width_token},(@{channel.physical_channel})")
             self._visa.write(f"CONF:DIG:DIR {dir_token},(@{channel.physical_channel})")
             self._visa.write(
                 f"CONF:DIG:POL {'INV' if channel.logic is Logic.LOW else 'NORM'},(@{channel.physical_channel})"
@@ -331,10 +345,30 @@ class Keysight34980A(DAQDriverBase):
         return int(response)
 
     def write_digital_port(self, channel: DigitalChannel, data: int):
-        raise NotImplementedError("write_digital_port is not yet implemented for Keysight 34980A.")
+        """Drive a DO port as one N-bit integer. Active-low is applied in hardware via CONF:DIG:POL."""
+        if not isinstance(channel, DigitalPortChannel):
+            raise TypeError(
+                f"write_digital_port expects a DigitalPortChannel, got {type(channel).__name__}. "
+                "Use write_digital_line for single-bit writes."
+            )
+        width_token = _PORT_WIDTH_TOKENS[channel.width]
+        with self._visa.lock():
+            self._visa.write(f"SOUR:DIG:DATA:{width_token} {data},(@{channel.physical_channel})")
+            self._check_errors()
 
     def read_digital_port(self, channel: DigitalChannel) -> int:
-        raise NotImplementedError("read_digital_port is not yet implemented for Keysight 34980A.")
+        """Sample a DI port as one N-bit integer. Active-low is applied in hardware via CONF:DIG:POL."""
+        if not isinstance(channel, DigitalPortChannel):
+            raise TypeError(
+                f"read_digital_port expects a DigitalPortChannel, got {type(channel).__name__}. "
+                "Use read_digital_line for single-bit reads."
+            )
+        width_token = _PORT_WIDTH_TOKENS[channel.width]
+        with self._visa.lock():
+            response = self._visa.query(f"SENS:DIG:DATA:{width_token}? (@{channel.physical_channel})")
+            self._check_errors()
+
+        return int(response)
 
     # ====== RELAY ========
 

--- a/packages/instro-daq-ni/instro/daq/drivers/ni/nidaq.py
+++ b/packages/instro-daq-ni/instro/daq/drivers/ni/nidaq.py
@@ -44,9 +44,16 @@ class NIDAQDriver(DAQDriverBase):
         self._actual_sample_rate: float | None = None
         self._timestamper: HWTimestamper | None = None  # None until first hw-timed read
 
-        self._do_data_state: dict[str, bool] = {}  # Keep track of all do data in task
-        self._di_data_state: dict[str, bool] = {}  # Keep track of all di data in task
+        # Per-line state for the shared DO/DI line tasks: NI writes/reads the whole task at once,
+        # so we cache every line's value to address a single line.
+        self._do_lines_state: dict[str, bool] = {}
+        self._di_lines_state: dict[str, bool] = {}
         self._running_channel_types: set[ChannelType] = set()
+
+        # Port channels get a dedicated task each: CHAN_FOR_ALL_LINES wants an int payload,
+        # which can't share a task with the bool-list line payload. Keyed by channel alias.
+        self._di_port_tasks: dict[str, nidaqmx.Task] = {}
+        self._do_port_tasks: dict[str, nidaqmx.Task] = {}
 
     def open(self):
         """NI-DAQmx has no explicit connect — verifies the device is present in ``niSystem.local()``."""
@@ -70,8 +77,12 @@ class NIDAQDriver(DAQDriverBase):
             self._close_task(task)
         for task in self._ao_sw_tasks.values():
             self._close_task(task)
+        for task in (*self._di_port_tasks.values(), *self._do_port_tasks.values()):
+            self._close_task(task)
         self._tasks.clear()
         self._ao_sw_tasks.clear()
+        self._di_port_tasks.clear()
+        self._do_port_tasks.clear()
         self._running_channel_types.clear()
 
     def _close_task(self, task: nidaqmx.Task):
@@ -181,9 +192,16 @@ class NIDAQDriver(DAQDriverBase):
         logic_level: float | None = None,
         alias: str | None = None,
     ):
-        """Parse ``DevN/portM/lineP``, add as CHAN_PER_LINE to the DI task, and register the line."""
+        """Parse ``DevN/portM/lineP``, add as CHAN_PER_LINE to the shared DI line task, and register the line."""
         channel = self._build_line_channel(physical_channel, Direction.INPUT, logic, logic_level, alias)
-        self._add_di_channel(channel, LineGrouping.CHAN_PER_LINE)
+        task = self._get_task(ChannelType.DIGITAL_INPUT)
+        self._di_lines_state[channel.alias] = False
+        task.di_channels.add_di_chan(
+            lines=channel.physical_channel,
+            name_to_assign_to_lines=channel.alias,
+            line_grouping=LineGrouping.CHAN_PER_LINE,
+        )
+        self.di_channels[channel.alias] = channel
 
     def configure_do_line_channel(
         self,
@@ -192,9 +210,16 @@ class NIDAQDriver(DAQDriverBase):
         logic_level: float | None = None,
         alias: str | None = None,
     ):
-        """Parse ``DevN/portM/lineP``, add as CHAN_PER_LINE to the DO task, and register the line."""
+        """Parse ``DevN/portM/lineP``, add as CHAN_PER_LINE to the shared DO line task, and register the line."""
         channel = self._build_line_channel(physical_channel, Direction.OUTPUT, logic, logic_level, alias)
-        self._add_do_channel(channel, LineGrouping.CHAN_PER_LINE)
+        task = self._get_task(ChannelType.DIGITAL_OUTPUT)
+        self._do_lines_state[channel.alias] = False
+        task.do_channels.add_do_chan(
+            lines=channel.physical_channel,
+            name_to_assign_to_lines=channel.alias,
+            line_grouping=LineGrouping.CHAN_PER_LINE,
+        )
+        self.do_channels[channel.alias] = channel
 
     def configure_di_port_channel(
         self,
@@ -204,9 +229,16 @@ class NIDAQDriver(DAQDriverBase):
         logic_level: float | None = None,
         alias: str | None = None,
     ):
-        """Parse ``DevN/portM``, add as CHAN_FOR_ALL_LINES to the DI task, and register the port."""
+        """Parse ``DevN/portM``, add as CHAN_FOR_ALL_LINES to a dedicated DI task, and register the port."""
         channel = self._build_port_channel(physical_channel, Direction.INPUT, logic, port_width, logic_level, alias)
-        self._add_di_channel(channel, LineGrouping.CHAN_FOR_ALL_LINES)
+        task = nidaqmx.Task(f"{self._device_id}_di_port_{channel.alias}")
+        task.di_channels.add_di_chan(
+            lines=channel.physical_channel,
+            name_to_assign_to_lines=channel.alias,
+            line_grouping=LineGrouping.CHAN_FOR_ALL_LINES,
+        )
+        self._di_port_tasks[channel.alias] = task
+        self.di_channels[channel.alias] = channel
 
     def configure_do_port_channel(
         self,
@@ -216,9 +248,16 @@ class NIDAQDriver(DAQDriverBase):
         logic_level: float | None = None,
         alias: str | None = None,
     ):
-        """Parse ``DevN/portM``, add as CHAN_FOR_ALL_LINES to the DO task, and register the port."""
+        """Parse ``DevN/portM``, add as CHAN_FOR_ALL_LINES to a dedicated DO task, and register the port."""
         channel = self._build_port_channel(physical_channel, Direction.OUTPUT, logic, port_width, logic_level, alias)
-        self._add_do_channel(channel, LineGrouping.CHAN_FOR_ALL_LINES)
+        task = nidaqmx.Task(f"{self._device_id}_do_port_{channel.alias}")
+        task.do_channels.add_do_chan(
+            lines=channel.physical_channel,
+            name_to_assign_to_lines=channel.alias,
+            line_grouping=LineGrouping.CHAN_FOR_ALL_LINES,
+        )
+        self._do_port_tasks[channel.alias] = task
+        self.do_channels[channel.alias] = channel
 
     def _build_line_channel(
         self,
@@ -264,26 +303,6 @@ class NIDAQDriver(DAQDriverBase):
             logic=logic,
             width=port_width,
         )
-
-    def _add_di_channel(self, channel: DigitalChannel, line_grouping: LineGrouping) -> None:
-        task = self._get_task(ChannelType.DIGITAL_INPUT)
-        self._di_data_state[channel.alias] = False
-        task.di_channels.add_di_chan(
-            lines=channel.physical_channel,
-            name_to_assign_to_lines=channel.alias,
-            line_grouping=line_grouping,
-        )
-        self.di_channels[channel.alias] = channel
-
-    def _add_do_channel(self, channel: DigitalChannel, line_grouping: LineGrouping) -> None:
-        task = self._get_task(ChannelType.DIGITAL_OUTPUT)
-        self._do_data_state[channel.alias] = False
-        task.do_channels.add_do_chan(
-            lines=channel.physical_channel,
-            name_to_assign_to_lines=channel.alias,
-            line_grouping=line_grouping,
-        )
-        self.do_channels[channel.alias] = channel
 
     def start(self, **kwargs):
         """Start the DAQ device for data acquisition."""
@@ -378,16 +397,26 @@ class NIDAQDriver(DAQDriverBase):
 
     def write_digital_line(self, channel: DigitalChannel, data: int):
         """Write to digital output channels."""
+        if not isinstance(channel, DigitalLineChannel):
+            raise TypeError(
+                f"write_digital_line expects a DigitalLineChannel, got {type(channel).__name__}. "
+                "Use write_digital_port for whole-port writes."
+            )
         task = self._tasks[ChannelType.DIGITAL_OUTPUT]
 
         if channel.logic is Logic.LOW:
             data = 1 - data
 
-        self._do_data_state[channel.alias] = bool(data)  # update state with new value
+        self._do_lines_state[channel.alias] = bool(data)  # update state with new value
 
-        task.write(list(self._do_data_state.values()))  # Send everything
+        task.write(list(self._do_lines_state.values()))  # Send everything
 
     def read_digital_line(self, channel: DigitalChannel) -> int:
+        if not isinstance(channel, DigitalLineChannel):
+            raise TypeError(
+                f"read_digital_line expects a DigitalLineChannel, got {type(channel).__name__}. "
+                "Use read_digital_port for whole-port reads."
+            )
         task = self._tasks[ChannelType.DIGITAL_INPUT]
 
         response: bool | list[bool] = (
@@ -395,21 +424,38 @@ class NIDAQDriver(DAQDriverBase):
         )  # DAQmx returns a scalar for one channel or a list for multiple channels in the task.
         response = response if isinstance(response, list) else [response]
 
-        # Update self._di_data_state with the latest response values
+        # Update self._di_lines_state with the latest response values
         # Do not update with active high/low calculation
-        for i, key in enumerate(self._di_data_state.keys()):
-            self._di_data_state[key] = response[i]
+        for i, key in enumerate(self._di_lines_state.keys()):
+            self._di_lines_state[key] = response[i]
 
-        index = list(self._di_data_state.keys()).index(channel.alias)
+        index = list(self._di_lines_state.keys()).index(channel.alias)
 
         data = not response[index] if channel.logic is Logic.LOW else response[index]
         return int(data)
 
     def write_digital_port(self, channel: DigitalChannel, data: int):
-        raise NotImplementedError("write_digital_port is not yet implemented for NI DAQmx.")
+        """Drive a DO port as one N-bit integer; bit ``i`` controls line ``i``."""
+        if not isinstance(channel, DigitalPortChannel):
+            raise TypeError(
+                f"write_digital_port expects a DigitalPortChannel, got {type(channel).__name__}. "
+                "Use write_digital_line for single-bit writes."
+            )
+        if channel.logic is Logic.LOW:
+            data ^= (1 << int(channel.width)) - 1
+        self._do_port_tasks[channel.alias].write(int(data))
 
     def read_digital_port(self, channel: DigitalChannel) -> int:
-        raise NotImplementedError("read_digital_port is not yet implemented for NI DAQmx.")
+        """Sample a DI port as one N-bit integer; bit ``i`` reflects line ``i``."""
+        if not isinstance(channel, DigitalPortChannel):
+            raise TypeError(
+                f"read_digital_port expects a DigitalPortChannel, got {type(channel).__name__}. "
+                "Use read_digital_line for single-bit reads."
+            )
+        data = int(self._di_port_tasks[channel.alias].read())
+        if channel.logic is Logic.LOW:
+            data ^= (1 << int(channel.width)) - 1
+        return data
 
     def _read_to_measurements(
         self,

--- a/tests/daq/test_daq_drivers.py
+++ b/tests/daq/test_daq_drivers.py
@@ -187,6 +187,28 @@ def test_write_digital_port_configured_channel():
     mock_driver.write_digital_port.assert_called_once()
 
 
+def test_write_digital_port_value_exceeds_width():
+    """Test that writing a value wider than the configured port raises ValueError."""
+    mock_driver = _make_mock_driver()
+
+    daq = InstroDAQ(
+        name="Test DAQ",
+        driver=mock_driver,
+    )
+
+    daq.configure_digital_port(
+        direction=Direction.OUTPUT, physical_channel="port0", logic=Logic.HIGH, port_width=8, alias="test_port"
+    )
+
+    with pytest.raises(ValueError, match="does not fit the 8-bit port 'test_port'"):
+        daq.write_digital_port("test_port", 0x100)
+
+    with pytest.raises(ValueError, match="does not fit the 8-bit port 'test_port'"):
+        daq.write_digital_port("test_port", -1)
+
+    mock_driver.write_digital_port.assert_not_called()
+
+
 def test_write_digital_port_unconfigured_channel():
     """Test that writing to an unconfigured port channel raises KeyError."""
     mock_driver = _make_mock_driver()


### PR DESCRIPTION
## Summary

Both the NI (`NIDAQDriver`) and Keysight (`Keysight34980A`) drivers configured digital port channels but raised `NotImplementedError` on `read_digital_port` / `write_digital_port` — MCC was the only driver with working port-mode I/O. This implements port read/write on both, mirroring MCC's semantics.

### NI (`packages/instro-daq-ni/instro/daq/drivers/ni/nidaq.py`)
- Each port channel gets its own dedicated DAQmx task. A `CHAN_FOR_ALL_LINES` port needs a single-int payload, which can't share a task with the bool-list line payload. New per-alias registries `_di_port_tasks` / `_do_port_tasks`, cleaned up in `close()`.
- `write_digital_port` / `read_digital_port` write/read a single integer; active-low is applied via XOR with `(1 << width) - 1`, mirroring MCC.

### Keysight (`instro/daq/drivers/keysight_34980a.py`)
- Map `DigitalPortWidth` → SCPI width token (`WIDTH_8`→BYTE, `WIDTH_16`→WORD, `WIDTH_32`→LWORd).
- **Bug fix:** `_program_port` hardcoded `CONF:DIG:WIDT BYTE`, silently configuring `WIDTH_16`/`WIDTH_32` ports as 8-bit. It now emits the correct token for port channels (line channels stay BYTE).
- Reject `WIDTH_64` at configure time — a single grouped 34950A channel maxes at 32-bit; a 64-bit span must be two channels.
- Active-low is applied in hardware via `CONF:DIG:POL` at configure time, consistent with the line path.

### Both drivers
- Line and port methods now reject the wrong channel type with a clear `TypeError`.

### Examples & docs
- Add `examples/daq/daq_read_digital_port.py` and `daq_write_digital_port.py` (NI / Keysight / MCC).
- Update `docs/guides/instrumentation/daq.mdx`: port I/O now supported on MCC, NI, and Keysight (LabJack still raises); drop the "(MCC only)" annotations; note the Keysight 32-bit cap.

## Testing
- `just check` (ruff format, mypy, ruff lint) — clean
- `just test` — 427 passed
- Hardware loopback verification (NI/Keysight wiring) to be done separately. One item to confirm on hardware: Keysight active-low ports rely on `CONF:DIG:POL` inverting the grouped `DATA:BYTE/WORD/LWORd` path, whereas NI/MCC invert in software.
- 
## Verification

### NI - Digital Loopback w/ USB-6002
<img width="4800" height="3600" alt="image" src="https://github.com/user-attachments/assets/5ccb2e5f-8d9b-48c0-bc03-f8e319a2d9f9" />


Closes #42