### PR TITLE
refactor: consolidate daemon/worker/background-thread terminology

### DIFF
--- a/docs/guides/docs.json
+++ b/docs/guides/docs.json
@@ -109,7 +109,7 @@
             "group": "PSU",
             "pages": [
               "instrumentation/examples/psu/psu",
-              "instrumentation/examples/psu/psu_background_worker"
+              "instrumentation/examples/psu/psu_background_daemon"
             ]
           },
           {

--- a/docs/guides/instrumentation/daq.mdx
+++ b/docs/guides/instrumentation/daq.mdx
@@ -53,7 +53,7 @@ InstroDAQ supports two acquisition modes:
 **Hardware-Timed (Buffered Acquisition)**
 - Configure sample rate with `configure_ai_sample_rate()`
 - Call `start()` to begin background acquisition
-- Data automatically published via background thread, OR manually fetch with `read_analog()`
+- Data automatically published via the background daemon, OR manually fetch with `read_analog()`
 - Use case: Mid to high frequency continuous monitoring with deterministic sample timing.
 
 ## Creating a InstroDAQ Instance
@@ -356,7 +356,7 @@ while True:
         sensor_1 = daq.get_channel(
             channel_name = "myDAQ.sensor_1",
             length = 10,
-            wait_for_latest = True)  # This will block for the next 10 samples from the background worker
+            wait_for_latest = True)  # This will block for the next 10 samples from the background daemon
         print("Stopping acquisition")
         break
     except KeyboardInterrupt:
@@ -368,7 +368,7 @@ daq.close()
 ```
 
 In this mode:
-- `start()` begins hardware-timed acquisition in a background thread
+- `start()` begins hardware-timed acquisition in the background daemon
 - `stop()` ends the background acquisition
 
 <Note>
@@ -378,12 +378,12 @@ Data is published as a direct result of an instrument method being called.
 
 For example, when you call `read_analog()`, this not only returns the DAQ data but also causes all attached Publishers to publish the measurements automatically.
 
-Therefore the background worker, which is calling instrument methods, is publishing the data!
+Therefore the background daemon, which is calling instrument methods, is publishing the data!
 </Note>
 
 ### Hardware-Timed Acquisition with Manual Fetching
 
-For hardware-timed acquisition where you control when to fetch buffered data. Disable the Background Worker and manually call `read_analog()`.
+For hardware-timed acquisition where you control when to fetch buffered data. Disable the Background Daemon and manually call `read_analog()`.
 
 ```python
 
@@ -634,7 +634,7 @@ Every measurement/command call produces a channel keyed under `{name}.{descripto
 | `open_relay(channel)` | `{alias}.cmd` (value `"OPEN"`) | command |
 | `get_points_in_buffer()` | `buffer` | telemetry |
 
-The base `Instrument` background worker additionally publishes per-iteration diagnostic telemetry on `loop_time` and `daemon_work_time`. Those descriptors are shared across all instruments and are not affected by `legacy_naming`.
+The base `Instrument` background daemon additionally publishes per-iteration diagnostic telemetry on `loop_time` and `daemon_work_time`. Those descriptors are shared across all instruments and are not affected by `legacy_naming`.
 
 ## Method Reference
 
@@ -647,7 +647,7 @@ The base `Instrument` background worker additionally publishes per-iteration dia
 | `configure_digital_line(direction, physical_channel, logic, logic_level=None, alias=None)` | Configure a single digital I/O line |
 | `configure_digital_port(direction, physical_channel, logic, port_width, logic_level=None, alias=None)` | Configure a digital I/O port (multi-line) |
 | `configure_ai_sample_rate(sample_rate, samples_per_channel=None)` | Set hardware timing for analog input |
-| `start()` | Begin hardware-timed acquisition (background thread) |
+| `start()` | Begin hardware-timed acquisition (background daemon) |
 | `stop()` | End hardware-timed acquisition |
 | `read_analog()` | Read analog input (SW-timed) or fetch from buffer (HW-timed) |
 | `read_digital_line(channel)` | Read digital input line |
@@ -692,7 +692,7 @@ A DAQ driver shall:
 1. **Hardware connection lifecycle**: Implement `open()` and `close()` for establishing and terminating hardware connections.
 2. **Channel and state tracking**: The driver is the single source of truth for what's configured. `DAQDriverBase.__init__` initializes the dicts (`ai_channels`, `ao_channels`, `di_channels`, `do_channels`, `relay_channels`) and the timing-config slots (`ai_hw_timing_config`, plus AO/DI/DO slots); concrete drivers call `super().__init__()`, then populate those dicts inside their `configure_*` methods and read from them in `read_analog`, `fetch_analog`, `start`, `write_analog_value`, etc. `InstroDAQ` exposes the same state to end users via `@property` proxies (`daq.ai_channels`, `daq.ai_hw_timing_config`, …) — no duplication. See [Driver-owned state](#driver-owned-state) below.
 3. **Channel configuration**: Translate generic channel configurations into vendor-specific setup.
-4. **Timing abstraction**: Implement both software-timed reads and hardware-timed buffered acquisition. `InstroDAQ` will manage the background thread for the hardware-timed acquisition.
+4. **Timing abstraction**: Implement both software-timed reads and hardware-timed buffered acquisition. `InstroDAQ` will manage the background daemon for the hardware-timed acquisition.
 5. **Data format conversion**: Convert vendor-specific data formats to `Measurement` objects.
 6. **Constraint validation**: Handle vendor-specific hardware constraints and raise clear exceptions when the vendor library cannot.
 

--- a/docs/guides/instrumentation/eload.mdx
+++ b/docs/guides/instrumentation/eload.mdx
@@ -33,8 +33,8 @@ The typical InstroELoad workflow:
 1. **Construct**: instantiate the vendor driver and pass it to `InstroELoad`.
 2. **`open()`**: establishes the VISA connection.
 3. **Configure and measure**: set operating mode, level, range, and read measurements.
-4. **`start()`**: begins a periodic background worker. (Optional)
-5. **`stop()`**: ends the background worker (if started).
+4. **`start()`**: begins a periodic background daemon. (Optional)
+5. **`stop()`**: ends the background daemon (if started).
 6. **`close()`**: disconnects from hardware.
 
 ### Operating Modes
@@ -133,7 +133,7 @@ eload.output_enable(False, channel=1)
 eload.close()
 ```
 
-### Background Worker for Continuous Monitoring
+### Background Daemon for Continuous Monitoring
 
 ```python
 import time
@@ -157,7 +157,7 @@ eload.background_interval = 0.5  # Poll every 500ms
 
 eload.open()
 
-# Start background worker
+# Start background daemon
 eload.start()
 
 # Configure constant power mode
@@ -169,11 +169,11 @@ eload.output_enable(True, channel=1)
 # Data flows automatically to publishers
 while True:
     try:
-        # Optionally grab data being produced by the background worker.
+        # Optionally grab data being produced by the background daemon.
         ch1_voltage = eload.get_channel(
             channel_name = "myELoad.ch1.voltage",
             length = 1,
-            wait_for_latest = True)  # This will block for the next sample from the background worker
+            wait_for_latest = True)  # This will block for the next sample from the background daemon
         ch1_current = eload.get_channel(
             channel_name = "myELoad.ch1.current",
             length = 5,
@@ -185,17 +185,17 @@ while True:
 
 eload.output_enable(False, channel=1)
 
-# Stop background worker
+# Stop background daemon
 eload.stop()
 eload.close()
 ```
 
 In this mode:
-- `start()` begins a background worker, executing a function or list of functions periodically.
-- `stop()` ends the background worker.
+- `start()` begins a background daemon, executing a function or list of functions periodically.
+- `stop()` ends the background daemon.
 
 <Note>
-**Default ELoad Background Worker**
+**Default ELoad Background Daemon**
 
 For each <Tooltip tip="A named signal for a series of measurements or computed values (example: voltage, pressure, system state).">channel</Tooltip>:
 - Output voltage (via `get_voltage()`)
@@ -204,9 +204,9 @@ For each <Tooltip tip="A named signal for a series of measurements or computed v
 The default polling interval is 1 second, configurable via the `background_interval` property.
 </Note>
 
-**Custom Background Worker**
-* To define your own background worker, call `define_background_daemon()`.
-* To add a method to the background worker stack, call `add_background_daemon_function()`.
+**Custom Background Daemon**
+* To define your own background daemon, call `define_background_daemon()`.
+* To add a method to the background daemon stack, call `add_background_daemon_function()`.
 
 See [Two ways to get data](/instrumentation/overview#two-ways-to-get-data) for more information regarding background fetching of measurements.
 
@@ -217,7 +217,7 @@ Data is published as a direct result of an instrument method being called.
 
 For example, when you call `get_voltage()`, this not only queries the instrument for the voltage but also causes all attached Publishers to publish the measurement response automatically.
 
-Therefore the background worker, when calling these instrument methods, is publishing data in the background as well!
+Therefore the background daemon, when calling these instrument methods, is publishing data in the background as well!
 </Note>
 
 ## Published channels
@@ -250,8 +250,8 @@ Every measurement/command call produces a channel keyed under `{name}.{descripto
 | `short_output(enable, channel=1)` | Short the load channel (occurs immediately) |
 | `get_voltage(channel=1)` | Read measured input voltage |
 | `get_current(channel=1)` | Read measured input current |
-| `start()` | Begin background telemetry thread |
-| `stop()` | End background telemetry thread |
+| `start()` | Begin background telemetry daemon |
+| `stop()` | End background telemetry daemon |
 
 ---
 

--- a/docs/guides/instrumentation/examples.mdx
+++ b/docs/guides/instrumentation/examples.mdx
@@ -17,7 +17,7 @@ This section hosts **full, runnable examples** organized by instrument type and 
     Configure a DMM and trigger measurements.
   </Card>
   <Card title="PSU" icon="bolt" href="/instrumentation/examples/psu/psu">
-    Programmable power supply usage with and without a background worker.
+    Programmable power supply usage with and without a background daemon.
   </Card>
   <Card title="Electronic Load" icon="plug" href="/instrumentation/examples/eload/eload">
     Programmable electronic load usage.

--- a/docs/guides/instrumentation/examples/psu/psu.mdx
+++ b/docs/guides/instrumentation/examples/psu/psu.mdx
@@ -1,9 +1,9 @@
 ---
-title: "PSU without background worker"
+title: "PSU without background daemon"
 ---
 
 ```python psu.py
-"""Example: PSU without background worker.
+"""Example: PSU without background daemon.
 
 Demonstrates publishing measurements/commands to a dataset (Nominal Core publisher).
 

--- a/docs/guides/instrumentation/examples/psu/psu_background_daemon.mdx
+++ b/docs/guides/instrumentation/examples/psu/psu_background_daemon.mdx
@@ -1,4 +1,9 @@
-"""Example: PSU with background worker.
+---
+title: "PSU with background daemon"
+---
+
+```python psu_background_daemon.py
+"""Example: PSU with background daemon.
 
 Demonstrates publishing measurements/commands to a dataset (Nominal Core publisher).
 
@@ -50,3 +55,4 @@ try:
 
 finally:
     psu.close()
+```

--- a/docs/guides/instrumentation/protocols/i2c/overview.mdx
+++ b/docs/guides/instrumentation/protocols/i2c/overview.mdx
@@ -55,14 +55,14 @@ The typical I2CInterface workflow follows this pattern:
 1. **Create a `SystemDefinition`** - Define all I2C devices, registers, and commands (see [System Definition](/instrumentation/protocols/i2c/system-definition))
 2. **Construct `I2CInterface(name, driver=..., system_definition=...)`** - Compose a vendor driver (e.g. `Aardvark`) and pass it directly
 3. **`open()`** - Establish connection to the I2C adapter hardware
-5. **`start()`** - Begins a periodic worker in the background. (Optional)
+5. **`start()`** - Begins a periodic daemon in the background. (Optional)
 4. **Configure and communicate** - Access registers, fields, or send commands to devices
-6. **`stop()`** - End background worker (if started)
+6. **`stop()`** - End background daemon (if started)
 7. **`close()`** - Disconnect from hardware
 
-**Custom Background Worker**
-* To define your own background worker, call `define_background_daemon()`.
-* To add a method to the background worker stack, call `add_background_daemon_function()`.
+**Custom Background Daemon**
+* To define your own background daemon, call `define_background_daemon()`.
+* To add a method to the background daemon stack, call `add_background_daemon_function()`.
 
 See [Two ways to get data](/instrumentation/overview#two-ways-to-get-data) for more information regarding background fetching of measurements.
 
@@ -74,7 +74,7 @@ Data is published as a direct result of an instrument method being called.
 
 For example, when you call `read()`, this not only returns a register value but also causes all attached Publishers to publish the response automatically.
 
-Therefore the background worker, when calling these instrument methods, is publishing data in the background as well!
+Therefore the background daemon, when calling these instrument methods, is publishing data in the background as well!
 </Note>
 
 ### Device Types
@@ -409,8 +409,8 @@ Every read/write produces a channel keyed under `{name}.{descriptor}`, where `{n
 | `write_raw(address, data)` | Perform raw I2C write operation |
 | `write_read_raw(address, payload, length, endianness)` | Write then read without stop condition |
 | `write_then_read_raw(address, payload, length, endianness)` | Write then read with stop condition between operations |
-| `start()` | Begin background telemetry thread |
-| `stop()` | End background telemetry thread |
+| `start()` | Begin background telemetry daemon |
+| `stop()` | End background telemetry daemon |
 | `add_publisher(publisher)` | Attach a publisher for data routing |
 
 ---

--- a/docs/guides/instrumentation/protocols/modbus.mdx
+++ b/docs/guides/instrumentation/protocols/modbus.mdx
@@ -581,7 +581,7 @@ Each register in the `registers` array defines a named access point for a specif
 | `poll_interval` | Yes | | Polling interval in seconds (0.01 to 10.0) |
 | `write_delay_ms` | No | `0` | Delay in milliseconds applied after every write operation |
 
-When the `timing` section is present, all registers with `poll: true` are read at the specified interval in a background thread. Polled measurements are automatically published and buffered for retrieval.
+When the `timing` section is present, all registers with `poll: true` are read at the specified interval by the background daemon. Polled measurements are automatically published and buffered for retrieval.
 
 The `write_delay_ms` field is useful for devices that need a short delay between consecutive writes (e.g., controllers that process commands sequentially).
 
@@ -602,7 +602,7 @@ The configuration is validated at load time. Invalid configs produce clear error
 
 Modbus TCP connections drop for all the usual reasons, such as network blips, device reboots, and power cycles on a PLC. ModbusDevice handles this transparently. When a read or write hits a transport error, the driver closes the dead socket and pymodbus opens a fresh one on the next operation. No custom retry loop, no explicit `open()` after a disconnect.
 
-Your code just needs to tolerate the occasional `OSError` or `ConnectionError` being raised from `read()` / `write()`. If you're running with `autostart=True` and background polling, transient errors from a single poll are logged without tearing down the worker. The next tick will succeed as soon as the device comes back.
+Your code just needs to tolerate the occasional `OSError` or `ConnectionError` being raised from `read()` / `write()`. If you're running with `autostart=True` and background polling, transient errors from a single poll are logged without tearing down the daemon. The next tick will succeed as soon as the device comes back.
 
 ## Prototyping Without a Device
 

--- a/docs/guides/instrumentation/protocols/overview.mdx
+++ b/docs/guides/instrumentation/protocols/overview.mdx
@@ -19,7 +19,7 @@ This is valuable for several reasons:
 
 - **Access to non-SCPI/VISA devices.** Many industrial devices don't speak SCPI or use VISA transports. Protocols like Modbus, OPC-UA, and EtherNet/IP are ubiquitous in manufacturing, process control, and test infrastructure. The Protocols module brings these devices into the same publisher and data pipeline as your bench instruments.
 
-- **Consistent data pipeline.** Protocol instruments integrate with the same [publisher system](/instrumentation/publishers) and background worker infrastructure as the rest of the library. Regardless of which protocol your device speaks, data flows through the same path to Nominal.
+- **Consistent data pipeline.** Protocol instruments integrate with the same [publisher system](/instrumentation/publishers) and background daemon infrastructure as the rest of the library. Regardless of which protocol your device speaks, data flows through the same path to Nominal.
 
 ## Supported Protocols
 

--- a/docs/guides/instrumentation/psu.mdx
+++ b/docs/guides/instrumentation/psu.mdx
@@ -38,8 +38,8 @@ The typical InstroPSU workflow:
 1. **Construct**: instantiate the vendor driver and pass it to `InstroPSU`.
 2. **`open()`**: establishes the VISA connection.
 3. **Configure and measure**: set voltage/current limits, enable outputs, read measurements.
-4. **`start()`**: begins a periodic background worker. (Optional)
-5. **`stop()`**: ends the background worker (if started).
+4. **`start()`**: begins a periodic background daemon. (Optional)
+5. **`stop()`**: ends the background daemon (if started).
 6. **`close()`**: disconnects from hardware.
 
 ## Creating a InstroPSU Instance
@@ -122,7 +122,7 @@ psu.output_enable(False, channel=1)
 psu.close()
 ```
 
-### Background Worker for Continuous Monitoring
+### Background Daemon for Continuous Monitoring
 
 ```python
 import time
@@ -146,7 +146,7 @@ psu.background_interval = 0.5  # Poll every 500ms
 
 psu.open()
 
-# Start background worker
+# Start background daemon
 psu.start()
 
 # Configure channel 1
@@ -157,11 +157,11 @@ psu.output_enable(True, channel=1)
 # Data flows automatically to publishers
 while True:
     try:
-        # Optionally grab data being produced by the background worker.
+        # Optionally grab data being produced by the background daemon.
         ch1_voltage = psu.get_channel(
             channel_name = "myPSU.ch1.voltage",
             length = 1,
-            wait_for_latest = True)  # This will block for the next sample from the background worker
+            wait_for_latest = True)  # This will block for the next sample from the background daemon
         ch1_current = psu.get_channel(
             channel_name = "myPSU.ch1.current",
             length = 5,
@@ -174,17 +174,17 @@ while True:
 
 psu.output_enable(False, channel=1)
 
-# Stop background worker
+# Stop background daemon
 psu.stop()
 psu.close()
 ```
 
 In this mode:
-- `start()` begins a background worker, executing a function or list of functions periodically.
-- `stop()` ends the background worker.
+- `start()` begins a background daemon, executing a function or list of functions periodically.
+- `stop()` ends the background daemon.
 
 <Note>
-**Default PSU Background Worker**
+**Default PSU Background Daemon**
 
 For each <Tooltip tip="A named signal for a series of measurements or computed values (example: voltage, pressure, system state).">channel</Tooltip>:
 - Output voltage (via `get_voltage()`)
@@ -194,9 +194,9 @@ For each <Tooltip tip="A named signal for a series of measurements or computed v
 The default polling interval is 1 second, configurable via the `background_interval` property.
 </Note>
 
-**Custom Background Worker**
-* To define your own background worker, call `define_background_daemon()`.
-* To add a method to the background worker stack, call `add_background_daemon_function()`.
+**Custom Background Daemon**
+* To define your own background daemon, call `define_background_daemon()`.
+* To add a method to the background daemon stack, call `add_background_daemon_function()`.
 
 See [Two ways to get data](/instrumentation/overview#two-ways-to-get-data) for more information regarding background fetching of measurements.
 
@@ -207,7 +207,7 @@ Data is published as a direct result of an instrument method being called.
 
 For example, when you call `get_voltage()`, this not only queries the instrument for the voltage but also causes all attached Publishers to publish the measurement response automatically.
 
-Therefore the background worker, when calling these instrument methods, is publishing data in the background as well!
+Therefore the background daemon, when calling these instrument methods, is publishing data in the background as well!
 </Note>
 
 ## Published channels
@@ -260,8 +260,8 @@ Every measurement/command call produces a channel keyed under `{name}.{descripto
 | `get_overcurrent_protection_enabled(channel=1)` | Query whether overcurrent protection is enabled |
 | `set_remote_sense_enabled(enabled, channel=1)` | Enable or disable remote sense |
 | `get_remote_sense_enabled(channel=1)` | Query whether remote sense is enabled |
-| `start()` | Begin background telemetry thread |
-| `stop()` | End background telemetry thread |
+| `start()` | Begin background telemetry daemon |
+| `stop()` | End background telemetry daemon |
 
 # Simulated Power Supply
 

--- a/docs/guides/instrumentation/quickstart.mdx
+++ b/docs/guides/instrumentation/quickstart.mdx
@@ -138,7 +138,7 @@ with InstroPSU(
     How instruments, drivers, publishers, and the background daemon fit together.
   </Card>
   <Card title="Power supplies in depth" icon="bolt" href="/instrumentation/psu">
-    Multi-channel use, supported vendors, custom driver development, and the background telemetry worker.
+    Multi-channel use, supported vendors, custom driver development, and the background telemetry daemon.
   </Card>
   <Card title="Stream to Nominal Core" icon="rocket" href="/instrumentation/publishers">
     Attach a publisher in one line to ship measurements live to Nominal Core, Connect, or a file.

--- a/examples/psu/psu.py
+++ b/examples/psu/psu.py
@@ -1,4 +1,4 @@
-"""Example: PSU without background worker.
+"""Example: PSU without background daemon.
 
 Demonstrates publishing measurements/commands to a dataset (Nominal Core publisher).
 

--- a/examples/psu/psu_background_daemon.py
+++ b/examples/psu/psu_background_daemon.py
@@ -1,9 +1,4 @@
----
-title: "PSU with background worker"
----
-
-```python psu_background_worker.py
-"""Example: PSU with background worker.
+"""Example: PSU with background daemon.
 
 Demonstrates publishing measurements/commands to a dataset (Nominal Core publisher).
 
@@ -55,4 +50,3 @@ try:
 
 finally:
     psu.close()
-```

--- a/instro/daq/daq.py
+++ b/instro/daq/daq.py
@@ -403,7 +403,7 @@ class InstroDAQ(Instrument):
             # Never wait. Let fetch block
             self._background_config.interval = 0
         else:
-            # Give background thread a big wait so as not to eat cycles
+            # Give the background daemon a big wait so as not to eat cycles
             self._background_config.interval = 1
 
         self._background_config.enabled = enable
@@ -503,7 +503,7 @@ class InstroDAQ(Instrument):
         channel_type = kwargs.get("channel_type", None)
 
         # TODO
-        # Need to evaluate spinning up a different worker per channel type, but this
+        # Need to evaluate spinning up a different daemon per channel type, but this
         # gets weird with different devices. DAQmx's channel types are their own things
         # whereas labjack is all one timing engine. Tricky architecture.
         # Baselining ai sample rate as the rate right now, which will break as soon as

--- a/instro/dmm/dmm.py
+++ b/instro/dmm/dmm.py
@@ -192,7 +192,7 @@ class InstroDMM(Instrument):
         self._define_background_daemon()
 
     def start(self) -> None:
-        """Start the background worker thread.
+        """Start the background daemon thread.
 
         Raises:
             ValueError: ``set_measurement_function`` has not been called.

--- a/instro/lib/instrument.py
+++ b/instro/lib/instrument.py
@@ -1,7 +1,7 @@
 # This code is derived from concepts in the py-lab-hal codebase (Apache 2.0 licensed)
 # Original py-lab-hal repository: https://github.com/google/py-lab-hal
 
-"""Base instrument interface and background worker support."""
+"""Base instrument interface and background daemon support."""
 
 import functools
 import logging
@@ -65,7 +65,7 @@ logger = logging.getLogger(__name__)
 
 
 class Instrument:
-    """Base class for Nominal instrument interfaces. Owns publishing and the background-worker daemon."""
+    """Base class for Nominal instrument interfaces. Owns publishing and the background daemon."""
 
     def __init__(
         self,
@@ -188,7 +188,7 @@ class Instrument:
 
     @publish_measurement
     def _publish_daemon_timing(self, loop_time_s: float, work_time_s: float, timestamp: int) -> Measurement:
-        """Publish per-iteration diagnostic timing from the background worker loop."""
+        """Publish per-iteration diagnostic timing from the background daemon loop."""
         return Measurement(
             channel_data={
                 f"{self.name}.loop_time": [loop_time_s],
@@ -231,7 +231,7 @@ class Instrument:
 
     @property
     def background_interval(self):
-        """Seconds between background-worker iterations (0 = no wait)."""
+        """Seconds between background daemon iterations (0 = no wait)."""
         return self._background_config.interval
 
     @background_interval.setter
@@ -240,7 +240,7 @@ class Instrument:
 
     @property
     def background_enable(self):
-        """Whether the background worker daemon is enabled (must still be ``start()``-ed)."""
+        """Whether the background daemon is enabled (must still be ``start()``-ed)."""
         return self._background_config.enabled
 
     @background_enable.setter
@@ -260,21 +260,21 @@ class Instrument:
         self.add_publisher(self._channel_buffer)
 
     def start(self):
-        """Start the background-worker daemon thread. No-op if already running."""
+        """Start the background daemon thread. No-op if already running."""
         # Check if a thread is already running
         if self._background_thread and self._background_thread.is_alive():
-            logger.info("Background worker already running for instrument '%s'", self.name)
+            logger.info("Background daemon already running for instrument '%s'", self.name)
             return
 
         self._setup_channel_buffer(self._channel_buffer_length)
 
         self._background_stop_event.clear()
         self._background_thread = threading.Thread(
-            target=self._background_worker, daemon=True, name=f"{self.name}_background"
+            target=self._background_daemon_loop, daemon=True, name=f"{self.name}_background"
         )
         self._background_thread.start()
         logger.info(
-            "Started background worker for instrument '%s' (thread=%s, enabled=%s, interval_s=%s)",
+            "Started background daemon for instrument '%s' (thread=%s, enabled=%s, interval_s=%s)",
             self.name,
             self._background_thread.name,
             self._background_config.enabled,
@@ -282,18 +282,18 @@ class Instrument:
         )
 
     def stop(self):
-        """Signal the background-worker daemon to stop and join it. No-op if not running."""
+        """Signal the background daemon to stop and join it. No-op if not running."""
         if self._background_thread and self._background_thread.is_alive():
-            logger.info("Stopping background worker for instrument '%s'", self.name)
+            logger.info("Stopping background daemon for instrument '%s'", self.name)
             self._background_stop_event.set()
             self._background_thread.join()
 
             # Clear out the channel_buffer
             assert self._channel_buffer
             self._channel_buffer.close()
-            logger.info("Stopped background worker for instrument '%s'", self.name)
+            logger.info("Stopped background daemon for instrument '%s'", self.name)
         else:
-            logger.info("Background worker not running for instrument '%s'; stop() is a no-op", self.name)
+            logger.info("Background daemon not running for instrument '%s'; stop() is a no-op", self.name)
 
     def get_channel(
         self, channel_name: str, length: int = 1, wait_for_latest: bool = False, timeout: float = 10.0
@@ -317,7 +317,7 @@ class Instrument:
 
         raise RuntimeError("No channel buffer exists. Ensure start() was called on this instrument.")
 
-    def _background_worker(self):
+    def _background_daemon_loop(self):
         """Daemon loop: run registered functions every ``background_interval``, publish loop timing."""
         while not self._background_stop_event.is_set():
             daemon_loop_start = time.time_ns()
@@ -346,7 +346,7 @@ class Instrument:
                 if self._background_stop_event.is_set():
                     return
                 logger.exception(
-                    "Background worker error in instrument '%s' while calling %s: %s",
+                    "Background daemon error in instrument '%s' while calling %s: %s",
                     self.name,
                     method.__name__,
                     e,


### PR DESCRIPTION
Closes [INSTRO-46](https://linear.app/nominal-io/issue/INSTRO-46/consolidate-daemon-polling-background-thread-language).

## What

The instrument background mechanism (the thread that runs registered functions on an interval) was referred to several ways across the codebase: `daemon`, `worker`, and `background thread`. This standardizes on **"background daemon"** in docs, docstrings, comments, and log messages.

`polling` (Modbus/EtherNet-IP) and `acquisition` (DAQ) are unchanged: those name *what* the daemon does for a given protocol, not the mechanism itself.

## No breaking changes

This was deliberately chosen as the non-breaking direction. The public API and the published wire channel already used "daemon", so they are untouched:

- `add_background_daemon_function()`, `define_background_daemon()` — unchanged
- `BackgroundDaemonConfig` — unchanged
- published channel `{name}.daemon_work_time` — unchanged

No migration guide entry or codemod change is needed.

## Scope (16 files)

- **Code:** `instro/lib/instrument.py` log strings, docstrings, and one private rename (`_background_worker` → `_background_daemon_loop`); `dmm.py` / `daq.py` docstrings and comments.
- **Docs:** psu / eload / dmm / daq / i2c / modbus / overview / quickstart / examples guides standardized on "background daemon"; `polling`/`acquisition` verbs preserved.
- **Example rename:** `examples/psu/psu_background_worker.py` → `psu_background_daemon.py` (regenerated via `just gen-examples`). This changes that example's generated doc page path from `.../psu_background_worker` to `.../psu_background_daemon`.

## Left untouched

- `QueuedPublisher`'s own background thread (a separate thread, not the instrument daemon).
- The stdlib `threading.Thread(daemon=True)` flag, the Rust `Tokio worker pool`, and a test's sim-server thread.

## Verification

- `just check` (ruff format, mypy, lint) and `just test` (427 passed) both green.
- Repo-wide grep confirms "background daemon" is the consistent mechanism term, with no stray "worker"/"background thread" mechanism mentions.