### PR TITLE
fix(psu): expect "+0" from TDK Lambda SYST:ERR? response

### DIFF
--- a/instro/psu/drivers/tdk_lambda_genesys.py
+++ b/instro/psu/drivers/tdk_lambda_genesys.py
@@ -50,5 +50,5 @@ class TDKLambdaGenesys(PSUDriverBase):
 
     def _check_errors(self) -> None:
         err = self._visa.query("SYSTEM:ERROR?")
-        if not err.startswith("0"):
+        if not err.startswith("+0"):
             raise RuntimeError(f"TDK Lambda PSU reported error: {err}")

--- a/tests/psu/test_psu_drivers.py
+++ b/tests/psu/test_psu_drivers.py
@@ -363,7 +363,7 @@ def tdk_visa_cls() -> Iterator[MagicMock]:
 @pytest.fixture
 def tdk_visa(tdk_visa_cls: MagicMock) -> MagicMock:
     visa = tdk_visa_cls.return_value
-    visa.query.return_value = '0,"No error"'
+    visa.query.return_value = '+0,"No error"'
     return visa
 
 
@@ -379,15 +379,15 @@ def test_tdk_set_voltage_writes_checked(tdk: TDKLambdaGenesys, tdk_visa: MagicMo
 
 
 def test_tdk_get_current_parses_response(tdk: TDKLambdaGenesys, tdk_visa: MagicMock) -> None:
-    tdk_visa.query.side_effect = ["2.500", '0,"No error"']
+    tdk_visa.query.side_effect = ["2.500", '+0,"No error"']
     assert tdk.get_current() == pytest.approx(2.5)
     assert tdk_visa.query.call_args_list == [call("MEAS:CURR?"), call("SYSTEM:ERROR?")]
 
 
 def test_tdk_get_output_status_parses_on(tdk: TDKLambdaGenesys, tdk_visa: MagicMock) -> None:
-    tdk_visa.query.side_effect = ["ON", '0,"No error"']
+    tdk_visa.query.side_effect = ["ON", '+0,"No error"']
     assert tdk.get_output_status() is True
-    tdk_visa.query.side_effect = ["OFF", '0,"No error"']
+    tdk_visa.query.side_effect = ["OFF", '+0,"No error"']
     assert tdk.get_output_status() is False
 
 


### PR DESCRIPTION
Closes #53.

## What

The TDK Lambda Genesys `SYSTEM:ERROR?` query returns a signed status code (e.g. `+0,"No error"`), but `_check_errors` only accepted a bare `0` prefix. Every healthy response started with `+0`, so it failed the `startswith("0")` check and was misreported as an error.

## Change

- `tdk_lambda_genesys.py`: match the `+0` prefix, consistent with the Siglent driver.
- `tests/psu/test_psu_drivers.py`: update the TDK fixtures/cases to the real `+0,"No error"` device response (they previously encoded the buggy `0,...` form).

## Testing

- `just check` (format + mypy + lint) on the changed files
- `uv run pytest tests/psu/test_psu_drivers.py` — 77 passed