### PR TITLE
docs: fix documentation drift from code

### DIFF
--- a/docs/guides/AGENTS.md
+++ b/docs/guides/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## About this project
 
-- Open-source documentation for [Nominal Instrumentation](https://nominal-io.github.io/instrumentation/), Nominal's Python library for test equipment automation.
+- Open-source documentation for [Nominal Instrumentation](https://instro.nominal.io), Nominal's Python library for test equipment automation.
 - Built on [Mintlify](https://mintlify.com). Pages are MDX files with YAML frontmatter.
 - Configuration lives in `docs.json`.
 - Run `mint dev` to preview locally. Run `mint broken-links` before opening a PR.

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -1,6 +1,6 @@
 # Nominal Instrumentation: User Documentation
 
-Prose / conceptual documentation for [Nominal Instrumentation](https://nominal-io.github.io/instrumentation/), Nominal's Python library for scripting and automating test equipment.
+Prose / conceptual documentation for [Nominal Instrumentation](https://instro.nominal.io), Nominal's Python library for scripting and automating test equipment.
 
 This site is built on [Mintlify](https://mintlify.com). It sits alongside `docs/reference/` (mkdocs), which auto-generates the API reference from docstrings. This Mintlify site holds the prose, examples, and getting-started content.
 
@@ -33,6 +33,6 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md). For questions or feedback about the li
 
 ## Resources
 
-- [Nominal Instrumentation SDK reference](https://nominal-io.github.io/instrumentation/)
-- [Runnable examples](https://nominal-io.github.io/instrumentation-docs/examples/)
+- [Nominal Instrumentation SDK reference](https://nominal-io.github.io/instro/)
+- [Runnable examples](https://instro.nominal.io/instrumentation/examples)
 - [Nominal](https://nominal.io)

--- a/docs/guides/docs.json
+++ b/docs/guides/docs.json
@@ -164,17 +164,17 @@
       "anchors": [
         {
           "anchor": "SDK Reference",
-          "href": "https://nominal-io.github.io/instrumentation/",
+          "href": "https://nominal-io.github.io/instro/",
           "icon": "book-open-cover"
         },
         {
           "anchor": "GitHub",
-          "href": "https://github.com/nominal-io/instrumentation",
+          "href": "https://github.com/nominal-io/instro",
           "icon": "github"
         },
         {
           "anchor": "Changelog",
-          "href": "https://nominal-io.github.io/instrumentation/changelog/",
+          "href": "https://nominal-io.github.io/instro/changelog/",
           "icon": "book"
         }
       ]
@@ -212,7 +212,7 @@
   "footer": {
     "socials": {
       "x": "https://x.com/nominal_io",
-      "github": "https://github.com/nominal-io/instrumentation",
+      "github": "https://github.com/nominal-io/instro",
       "linkedin": "https://linkedin.com/company/nominal-io"
     }
   },

--- a/docs/guides/instrumentation/contrib.mdx
+++ b/docs/guides/instrumentation/contrib.mdx
@@ -41,7 +41,7 @@ The category-level class (`InstroPSU`, `InstroDMM`, etc.) is always imported fro
 
 ## Available drivers
 
-The list starts empty. Drivers will appear here as they're contributed. To check what's currently available, browse [`packages/instro-contrib/instro/contrib/`](https://github.com/nominal-io/instrumentation/tree/main/packages/instro-contrib/instro/contrib) in the repo.
+The list starts empty. Drivers will appear here as they're contributed. To check what's currently available, browse [`packages/instro-contrib/instro/contrib/`](https://github.com/nominal-io/instro/tree/main/packages/instro-contrib/instro/contrib) in the repo.
 
 ## Graduation to core
 
@@ -59,4 +59,4 @@ Graduations are noted in `CHANGELOG.md`. The old `instro.contrib` import path is
 
 ## Contributing a driver
 
-See the **Contrib Package** section of [`CONTRIBUTING.md`](https://github.com/nominal-io/instrumentation/blob/main/CONTRIBUTING.md) for the contribution bar and review process.
+See the **Contrib Package** section of [`CONTRIBUTING.md`](https://github.com/nominal-io/instro/blob/main/CONTRIBUTING.md) for the contribution bar and review process.

--- a/docs/guides/instrumentation/custom-instruments.mdx
+++ b/docs/guides/instrumentation/custom-instruments.mdx
@@ -23,7 +23,7 @@ This is different than custom driver development within an existing instrument t
 
 ## Walkthrough: building a `SimpleTempController` instrument
 
-This section builds a custom instrument end to end. It's a simulated temperature controller (like a benchtop PID controller or thermal chamber) whose reading lags the commanded setpoint as it warms up or cools down. Standard library only, no hardware, no extra dependencies. The full file lives at [`examples/custom/simple_temp_controller.py`](https://github.com/nominal-io/instrumentation/blob/main/examples/custom/simple_temp_controller.py).
+This section builds a custom instrument end to end. It's a simulated temperature controller (like a benchtop PID controller or thermal chamber) whose reading lags the commanded setpoint as it warms up or cools down. Standard library only, no hardware, no extra dependencies. The full file lives at [`examples/custom/simple_temp_controller.py`](https://github.com/nominal-io/instro/blob/main/examples/custom/simple_temp_controller.py).
 
 The example covers everything a custom instrument needs:
 

--- a/docs/guides/instrumentation/daq.mdx
+++ b/docs/guides/instrumentation/daq.mdx
@@ -733,16 +733,21 @@ Each of the methods below must (a) program the device and (b) record the resulti
 - **`read_analog() -> Any`**: Perform software-timed analog read
   - Trigger immediate conversion and return data
 
-- **`fetch_analog(hw_timing_config) -> Any`**: Fetch samples from hardware-timed acquisition buffer
-  - Used during hardware-timed acquisition to retrieve buffered samples
+- **`fetch_analog() -> Any`**: Fetch samples from hardware-timed acquisition buffer
+  - Used during hardware-timed acquisition to retrieve buffered samples; reads timing from `self.ai_hw_timing_config`
 
-- **`read_digital_line(channel) -> int`**: Read digital input line
+- **`read_digital_line(channel) -> int`**: Read a digital input line
 
-- **`write_digital_line(channel, data)` Write to digital output line
+- **`write_digital_line(channel, data)`**: Write to a digital output line
+
+- **`read_digital_port(channel) -> int`**: Read a digital input port
+
+- **`write_digital_port(channel, data)`**: Write to a digital output port
+  - Port read/write are required of every driver; LabJack T-Series raises `NotImplementedError`
 
 ### Data Conversion
 
-- **`_read_to_measurements(response, channel_list, daq_name, **kwargs) -> list[Measurement]`**: Convert vendor data format to InstroDAQ `Measurement` objects
+- **`_read_to_measurements(response, channel_list, daq_name, default_tags, **kwargs) -> list[Measurement]`**: Convert vendor data format to InstroDAQ `Measurement` objects
   - Maps vendor data to channel names
   - Creates `Measurement` objects for publishing
 

--- a/docs/guides/instrumentation/dmm.mdx
+++ b/docs/guides/instrumentation/dmm.mdx
@@ -188,7 +188,7 @@ A DMM driver must:
 3. **Own lifecycle**: implement `open()` and `close()` by opening and closing the underlying transport.
 4. **Map commands**: translate each abstract method into vendor-specific commands.
 5. **Parse responses**: convert instrument responses to the expected Python types (`float`).
-6. **Report errors**: override `check_errors()` if the instrument exposes an error queue or status register.
+6. **Check errors (optional)**: if the instrument exposes an error queue (`SYST:ERR?`), add a private `_check_errors()` helper and call it from your write/query paths. This is a per-driver convention; the base class has no `check_errors`.
 
 ## DMMDriverBase Interface
 
@@ -214,11 +214,10 @@ def measure_resistance(self) -> float: ...
 Optional overrides (raise `NotImplementedError` if not supported):
 
 - **`set_digits(n)`**: Set resolution in digits.
-- **`set_aperture_seconds(seconds)`**: Set integration time in seconds.
+- **`set_aperture_seconds(seconds)`**: Set integration time in seconds. (Not implemented by the bundled Agilent 34401A or Keithley 2400 drivers.)
 - **Per-function range setters**: `set_dc_voltage_range`, `set_ac_voltage_range`, `set_dc_current_range`, `set_ac_current_range`, `set_two_wire_resistance_range`, `set_four_wire_resistance_range`. Each takes `value: float | None` (None = auto). `InstroDMM` dispatches to the right one based on the active measurement function, so the driver never needs to know which function is active.
 - **Per-function NPLC setters**: `set_dc_voltage_nplc`, `set_ac_voltage_nplc`, `set_dc_current_nplc`, `set_ac_current_nplc`, `set_two_wire_resistance_nplc`, `set_four_wire_resistance_nplc`. Same dispatch shape as the range setters.
 - **`measure_four_wire_resistance()`**: Measure 4-wire resistance.
-- **`check_errors()`**: Defaults to a no-op. Override to query the vendor error queue.
 
 The per-function range/NPLC split keeps `InstroDMM`'s `_measurement_config.function` as the single source of truth. The driver never receives or tracks the active function, so the wrong-function-passed-by-mistake class of bug doesn't exist.
 
@@ -280,7 +279,7 @@ class Agilent34401A(DMMDriverBase):
     set_two_wire_resistance_range = _store_range
     set_four_wire_resistance_range = _store_range
 
-    # ...other measure_* methods, set_digits, check_errors...
+    # ...other measure_* methods, set_digits, _check_errors...
 ```
 
 <Tip>
@@ -323,7 +322,7 @@ class MyCustomDMMDriver(DMMDriverBase):
 
     # ... implement other required methods ...
 
-    def check_errors(self) -> None:
+    def _check_errors(self) -> None:
         err = self._visa.query("ERR?")
         if err != "OK":
             raise RuntimeError(f"DMM error: {err}")
@@ -350,5 +349,5 @@ Driver development requires careful mapping of vendor-specific behavior to the u
 - Implementing all abstract methods on `DMMDriverBase` (and optional overrides where supported)
 - Using the correct vendor protocol or command syntax
 - Converting instrument responses to the expected Python types
-- Overriding `check_errors()` if your vendor exposes an error queue
+- Adding a private `_check_errors()` helper if your vendor exposes an error queue
 - Testing with actual hardware to ensure commands work as expected

--- a/docs/guides/instrumentation/dmm.mdx
+++ b/docs/guides/instrumentation/dmm.mdx
@@ -188,7 +188,6 @@ A DMM driver must:
 3. **Own lifecycle**: implement `open()` and `close()` by opening and closing the underlying transport.
 4. **Map commands**: translate each abstract method into vendor-specific commands.
 5. **Parse responses**: convert instrument responses to the expected Python types (`float`).
-6. **Check errors (optional)**: if the instrument exposes an error queue (`SYST:ERR?`), add a private `_check_errors()` helper and call it from your write/query paths. This is a per-driver convention; the base class has no `check_errors`.
 
 ## DMMDriverBase Interface
 

--- a/docs/guides/instrumentation/driver-dependencies.mdx
+++ b/docs/guides/instrumentation/driver-dependencies.mdx
@@ -20,7 +20,7 @@ Before using `instro` with specific instrument types, you must install the corre
 |--------------|--------------|------------------------|
 | **VISA** | SCPI/VISA-based instruments (PSUs, ELoads, Keysight DAQ) | All VISA-based driver implementations |
 | **NI-DAQmx** | National Instruments DAQ devices | `NIDAQDriver` |
-| **LJM (LabJack Module)** | LabJack T-Series devices | `LabJackDAQDriver` |
+| **LJM (LabJack Module)** | LabJack T-Series devices | `LabJackTSeriesDriver` |
 | **MCC Universal Library (`mcculw`)** | Measurement Computing DAQ devices | `MCCDriver` |
 | **Total Phase USB Drivers** | Total Phase Aardvark I2C/SPI Host Adapter | `Aardvark` |
 
@@ -68,7 +68,7 @@ LJM is the LabJack Module library required to communicate with LabJack T-Series 
 
 ### Used By
 
-- **`InstroDAQ`**: LabJack T-Series devices (via `LabJackDAQDriver`)
+- **`InstroDAQ`**: LabJack T-Series devices (via `LabJackTSeriesDriver`)
 
 ### Installation
 

--- a/docs/guides/instrumentation/eload.mdx
+++ b/docs/guides/instrumentation/eload.mdx
@@ -281,7 +281,6 @@ An electronic load driver must:
 3. **Own lifecycle**: implement `open()` and `close()` by opening and closing the underlying transport.
 4. **Map commands**: translate each abstract method into vendor-specific commands.
 5. **Parse responses**: convert instrument responses to the expected Python types (`float`, `bool`, etc.).
-6. **Check errors (optional)**: if the instrument exposes an error queue (`SYST:ERR?`), add a private `_check_errors()` helper and call it from your write/query paths. This is a per-driver convention; the base class has no `check_errors`.
 
 ## ELoadDriverBase Interface
 

--- a/docs/guides/instrumentation/eload.mdx
+++ b/docs/guides/instrumentation/eload.mdx
@@ -205,7 +205,7 @@ The default polling interval is 1 second, configurable via the `background_inter
 </Note>
 
 **Custom Background Daemon**
-* To define your own background daemon, call `define_background_daemon()`.
+* To define your own background daemon, call `define_background_daemon(method, *args, **kwargs)`, which replaces the registered daemon functions.
 * To add a method to the background daemon stack, call `add_background_daemon_function()`.
 
 See [Two ways to get data](/instrumentation/overview#two-ways-to-get-data) for more information regarding background fetching of measurements.
@@ -281,7 +281,7 @@ An electronic load driver must:
 3. **Own lifecycle**: implement `open()` and `close()` by opening and closing the underlying transport.
 4. **Map commands**: translate each abstract method into vendor-specific commands.
 5. **Parse responses**: convert instrument responses to the expected Python types (`float`, `bool`, etc.).
-6. **Report errors**: override `check_errors()` if the instrument exposes an error queue or status register.
+6. **Check errors (optional)**: if the instrument exposes an error queue (`SYST:ERR?`), add a private `_check_errors()` helper and call it from your write/query paths. This is a per-driver convention; the base class has no `check_errors`.
 
 ## ELoadDriverBase Interface
 
@@ -326,7 +326,7 @@ def get_current(self, channel: int) -> float:
     """Query and return the measured input current in amperes."""
 ```
 
-`check_errors()` is also part of the contract but defaults to a no-op on the base class. Override it if your vendor exposes an error queue.
+Error checking is not part of the base contract: if your vendor exposes an error queue, add a private `_check_errors()` helper and call it from your write/query paths (see the representative driver below).
 
 ### Talking to the Instrument
 
@@ -414,7 +414,7 @@ class BK85XXB(ELoadDriverBase):
     def get_voltage(self, channel: int) -> float:
         return float(self._visa.query("MEASure:VOLTage?"))
 
-    def check_errors(self) -> None:
+    def _check_errors(self) -> None:
         err = self._visa.query("SYST:ERR?")
         if not err.startswith("0"):
             raise RuntimeError(f"BK85XXB reported error: {err}")
@@ -456,7 +456,7 @@ class MyCustomELoadDriver(ELoadDriverBase):
 
     # ... implement other required methods ...
 
-    def check_errors(self) -> None:
+    def _check_errors(self) -> None:
         err = self._visa.query("ERR?")
         if err != "OK":
             raise RuntimeError(f"Electronic load error: {err}")
@@ -483,5 +483,5 @@ Driver development requires careful mapping of vendor-specific behavior to the u
 - Implementing all abstract methods on `ELoadDriverBase`
 - Using the correct vendor protocol or command syntax
 - Converting instrument responses to the expected Python types
-- Overriding `check_errors()` if your vendor exposes an error queue or status register
+- Adding a private `_check_errors()` helper if your vendor exposes an error queue or status register
 - Testing with actual hardware to ensure commands work as expected

--- a/docs/guides/instrumentation/examples.mdx
+++ b/docs/guides/instrumentation/examples.mdx
@@ -5,7 +5,7 @@ description: Full functional examples for Nominal Instrumentation
 
 Throughout the Nominal Instrumentation documentation you will find example code snippets inline with the topics being described. Those snippets are meant to highlight specific concepts and usage patterns in context.
 
-This section hosts **full, runnable examples** organized by instrument type and use case. Each page is a single Python file you can copy and adapt for your own projects. The source for these examples lives alongside the library at [`nominal-io/instrumentation`](https://github.com/nominal-io/instrumentation/tree/main/examples).
+This section hosts **full, runnable examples** organized by instrument type and use case. Each page is a single Python file you can copy and adapt for your own projects. The source for these examples lives alongside the library at [`nominal-io/instro`](https://github.com/nominal-io/instro/tree/main/examples).
 
 ## Browse by category
 

--- a/docs/guides/instrumentation/overview.mdx
+++ b/docs/guides/instrumentation/overview.mdx
@@ -204,7 +204,9 @@ These are the current instrument types that have been developed by Nominal and a
 - `InstroPSU`: programmable Power Supplies
 - `InstroDAQ`: data Acquisition devices
 - `InstroELoad`: electronic Loads
+- `InstroDMM`: digital Multimeters
 - `I2CInterface`: I2C master for communicating to peripherals on an I2C bus
+- `ModbusDevice`: Modbus register/coil device (TCP or RTU)
 
 ### Drivers
 
@@ -218,6 +220,7 @@ These are the current vendor/model specific drivers that have been developed by 
 - `InstroDAQ`
   - National Instruments (NI)
   - LabJack T-Series
+  - Measurement Computing (MCC)
   - Keysight 34980
 - `InstroELoad`
   - B&K Precision 85xx Series
@@ -232,4 +235,4 @@ These are the current vendor/model specific drivers that have been developed by 
 These are the current Publishers that have been developed by Nominal and available out of the box.
 
 - `NominalCorePublisher`: sends data to a Nominal Core dataset
-- `ConnectPublisher`: sends data to Nominal Connect client
+- `NominalConnectPublisher`: sends data to Nominal Connect client

--- a/docs/guides/instrumentation/protocols/i2c/overview.mdx
+++ b/docs/guides/instrumentation/protocols/i2c/overview.mdx
@@ -474,10 +474,10 @@ def write_read(self, address: int, data: bytes, read_len: int) -> bytes:
     """
 
 def set_bitrate(self, bitrate: int) -> None:
-    """Set the I2C bus bitrate.
+    """Set the I2C master clock rate in kHz.
 
     Args:
-        bitrate: Desired bitrate in Hz (e.g., 100000 for 100 kHz)
+        bitrate: Desired bus clock rate in kHz (e.g., 100 for 100 kHz)
     """
 
 def set_pullups(self, enable: bool) -> None:

--- a/docs/guides/instrumentation/protocols/i2c/system-definition.mdx
+++ b/docs/guides/instrumentation/protocols/i2c/system-definition.mdx
@@ -309,8 +309,8 @@ from instro.i2c.types import CustomScaling
 
 # ADC with voltage divider: V = (ADC_value / 4095) * 5.0 * 7.2
 scaling = CustomScaling(
-    to_physical=lambda x: x / 4095 * 5.0 * 7.2,
-    to_raw=lambda v: int(v / 7.2 / 5.0 * 4095)
+    to_physical_fn=lambda x: x / 4095 * 5.0 * 7.2,
+    to_raw_fn=lambda v: int(v / 7.2 / 5.0 * 4095)
 )
 ```
 

--- a/docs/guides/instrumentation/psu.mdx
+++ b/docs/guides/instrumentation/psu.mdx
@@ -195,7 +195,7 @@ The default polling interval is 1 second, configurable via the `background_inter
 </Note>
 
 **Custom Background Daemon**
-* To define your own background daemon, call `define_background_daemon()`.
+* To define your own background daemon, call `define_background_daemon(method, *args, **kwargs)`, which replaces the registered daemon functions.
 * To add a method to the background daemon stack, call `add_background_daemon_function()`.
 
 See [Two ways to get data](/instrumentation/overview#two-ways-to-get-data) for more information regarding background fetching of measurements.

--- a/docs/guides/instrumentation/psu.mdx
+++ b/docs/guides/instrumentation/psu.mdx
@@ -351,7 +351,6 @@ A PSU driver must:
 3. **Own lifecycle**: implement `open()` and `close()` by opening and closing the underlying transport.
 4. **Map commands**: translate each abstract method into vendor-specific commands.
 5. **Parse responses**: convert instrument responses to the expected Python types (`float`, `bool`, etc.).
-6. **Report errors**: query the instrument's error queue (where one exists) and raise on non-zero status.
 
 ## PSUDriverBase Interface
 

--- a/docs/guides/instrumentation/publishers.mdx
+++ b/docs/guides/instrumentation/publishers.mdx
@@ -277,7 +277,7 @@ class PrintChannelPublisher:
         try:
             if isinstance(data, Measurement):
                 if data.channel_data.get(self.channel_name, None):
-                    print(f"{self.channel_name}: {data.value}")
+                    print(f"{self.channel_name}: {data.latest}")
         except Exception as e:
             print(f"Error publishing data: {e}")
 
@@ -324,7 +324,7 @@ class PrintChannelPublisher:
     def publish(self, data: Measurement | Command, **kwargs):
         if isinstance(data, Measurement):
             if data.channel_data.get(self.channel_name, None):
-                print(f"{self.channel_name}: {data.value}")
+                print(f"{self.channel_name}: {data.latest}")
 
     def close(self):
         print("Publisher closed")

--- a/docs/guides/migration/v1.mdx
+++ b/docs/guides/migration/v1.mdx
@@ -109,11 +109,11 @@ These facade classes were removed entirely as part of the INSTRO-231 driver-shap
 
 <CodeGroup>
 ```bash curl
-curl -O https://raw.githubusercontent.com/nominal-io/instrumentation/main/docs/guides/migration/migrate_to_instro.py
+curl -O https://raw.githubusercontent.com/nominal-io/instro/main/docs/guides/migration/migrate_to_instro.py
 ```
 
 ```bash wget
-wget https://raw.githubusercontent.com/nominal-io/instrumentation/main/docs/guides/migration/migrate_to_instro.py
+wget https://raw.githubusercontent.com/nominal-io/instro/main/docs/guides/migration/migrate_to_instro.py
 ```
 </CodeGroup>
 
@@ -362,5 +362,5 @@ Or, if you committed before noticing, `git revert <commit>`.
 ## Source
 
 The codemod script lives at
-[`docs/guides/migration/migrate_to_instro.py`](https://github.com/nominal-io/instrumentation/blob/main/docs/guides/migration/migrate_to_instro.py)
+[`docs/guides/migration/migrate_to_instro.py`](https://github.com/nominal-io/instro/blob/main/docs/guides/migration/migrate_to_instro.py)
 in the `instro` repository. File issues or improvements against that path.

--- a/docs/reference/mkdocs.yml
+++ b/docs/reference/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: "Nominal Instrumentation SDK"
-repo_url: "https://github.com/nominal-io/instrumentation"
-repo_name: "nominal-io/instrumentation"
+repo_url: "https://github.com/nominal-io/instro"
+repo_name: "nominal-io/instro"
 site_dir: site
 watch: [mkdocs.yml, ../../README.md, ../../CHANGELOG.md, ../../instro, ../../packages]
 copyright: Copyright &copy; Nominal, Inc.

--- a/docs/reference/src/index.md
+++ b/docs/reference/src/index.md
@@ -8,7 +8,7 @@ collecting measurements, and publishing data to [Nominal](https://nominal.io).
 The SDK is organized into several key components:
 
 - **Library**: Base classes and infrastructure for building instrument integrations,
-  including the [`Instrument`](reference/nominal_instrument.md) base class, communication interfaces,
+  including the [`Instrument`](reference/instrument.md) base class, communication interfaces,
   and data publishers.
 
 - **Instruments**: High-level, vendor-agnostic interfaces for common instrument types:
@@ -29,5 +29,5 @@ The SDK is organized into several key components:
 
 | Section | Description |
 |---------|-------------|
-| [Library](reference/nominal_instrument.md) | `Instrument`, `Measurement`, `Command`, and base types |
+| [Library](reference/instrument.md) | `Instrument`, `Measurement`, `Command`, and base types |
 | [Changelog](changelog.md) | Release history and version changes |


### PR DESCRIPTION
Static audit of the docs against the code (4 parallel reviewers over disjoint slices, every finding verified against source) surfaced **16 discrepancies**. All fixed here. The v1.0 version-naming framing was reviewed and intentionally kept as-is.

## Tier 1: copy-paste breaks (documented code raised if run)
- `CustomScaling(to_physical=…, to_raw=…)` → real kwargs `to_physical_fn`/`to_raw_fn` (`protocols/i2c/system-definition.mdx`)
- `Measurement.value` → `.latest` (`publishers.mdx`)
- reference index → dead link `reference/nominal_instrument.md` → `reference/instrument.md` (`reference/src/index.md`)

## Tier 2: wrong API contract
- `check_errors()` documented as a base-class no-op to override → it's a private, per-driver `_check_errors()` convention; the base has no such method (`dmm.mdx`, `eload.mdx`)
- `fetch_analog(hw_timing_config)` → base takes no args (`daq.mdx`)
- i2c `set_bitrate` documented in Hz → code uses kHz (`protocols/i2c/overview.mdx`)

## Tier 3: stale names / links
- `LabJackDAQDriver` → `LabJackTSeriesDriver` (`driver-dependencies.mdx`)
- `ConnectPublisher` → `NominalConnectPublisher` (`overview.mdx`)
- repo slug `nominal-io/instrumentation` → `nominal-io/instro` (`contrib.mdx`, `custom-instruments.mdx`, `examples.mdx`, `mkdocs.yml`, `docs.json`, `migration/v1.mdx`)

## Tier 4: incomplete (newly-shipped capability undocumented)
- `overview.mdx` now lists MCC, `InstroDMM`, `ModbusDevice`
- `daq.mdx` driver-dev section now documents `read_digital_port`/`write_digital_port` (#50)

## Tier 5: minor
- malformed `write_digital_line` markdown bullet (`daq.mdx`)
- `_read_to_measurements` signature missing `default_tags` (`daq.mdx`)
- `set_aperture_seconds` not implemented by bundled DMM drivers — noted (`dmm.mdx`)
- `define_background_daemon(method, …)` signature (`psu.mdx`, `eload.mdx`)

## Hosted-docs URL routing
- SDK reference / changelog → `nominal-io.github.io/instro/`
- user-facing prose + examples → `instro.nominal.io`

## Notes
- Docs-only: no `.py` changed (`check-and-test` unaffected) and no example-mirror files touched (`check-examples-drift` unaffected).

Closes #58