### PR TITLE
refactor(daq)!: decouple acquisition start from the daemon thread

### DIFF
--- a/docs/guides/instrumentation/daq.mdx
+++ b/docs/guides/instrumentation/daq.mdx
@@ -383,12 +383,9 @@ Therefore the background daemon, which is calling instrument methods, is publish
 
 ### Hardware-Timed Acquisition with Manual Fetching
 
-For hardware-timed acquisition where you control when to fetch buffered data. Disable the Background Daemon and manually call `read_analog()`.
+For hardware-timed acquisition where you control when to fetch buffered data, start without the background daemon and manually call `read_analog()`.
 
 ```python
-
-# Disable automatic background publishing
-daq.background_enable = False
 
 daq.open()
 
@@ -396,8 +393,8 @@ daq.open()
 daq.configure_analog_channel(...)
 daq.configure_ai_sample_rate(sample_rate=100, samples_per_channel=10)
 
-# Start hardware acquisition (fills buffer)
-daq.start()
+# Start hardware acquisition (fills buffer) without spinning the background daemon
+daq.start(background=False)
 
 # Manually fetch from buffer when ready
 for i in range(10):
@@ -411,7 +408,7 @@ daq.close()
 <Warning>
 Failing to fetch samples from the hardware buffer at a reasonable rate will cause the DAQ data buffer to fill up and data will be either lost or an exception will be raised.
 </Warning>
-When `background_enable = False`, calling `read_analog()` during hardware-timed acquisition fetches from the hardware buffer rather than triggering a new conversion.
+With `start(background=False)`, calling `read_analog()` during hardware-timed acquisition fetches from the hardware buffer rather than triggering a new conversion.
 
 ## Analog Output
 

--- a/docs/guides/instrumentation/examples/daq/daq_read_analog_hw_timed_no_background.mdx
+++ b/docs/guides/instrumentation/examples/daq/daq_read_analog_hw_timed_no_background.mdx
@@ -56,10 +56,6 @@ daq.add_publisher(NominalCorePublisher(dataset_rid=DATASET_RID))
 
 daq.open()
 
-# Do not allow a background daemon to manage fetching data from the DAQ.
-# We will do that ourselves in the main app loop
-daq.background_enable = False
-
 try:
     daq.configure_analog_channel(
         direction=Direction.INPUT, physical_channel=CHANNEL_0, alias=f"ch_0", range_min=0, range_max=5
@@ -71,8 +67,9 @@ try:
     # Set the sample rate but also the number of samples we will fetch each time daq.read_analog() is called.
     daq.configure_ai_sample_rate(sample_rate=100, samples_per_channel=50)
 
-    # Start the acquisition
-    daq.start()
+    # Start hardware acquisition without a background daemon. We fetch the buffer
+    # ourselves in the main app loop via read_analog().
+    daq.start(background=False)
 
     while True:
         try:

--- a/examples/daq/daq_read_analog_hw_timed_no_background.py
+++ b/examples/daq/daq_read_analog_hw_timed_no_background.py
@@ -51,10 +51,6 @@ daq.add_publisher(NominalCorePublisher(dataset_rid=DATASET_RID))
 
 daq.open()
 
-# Do not allow a background daemon to manage fetching data from the DAQ.
-# We will do that ourselves in the main app loop
-daq.background_enable = False
-
 try:
     daq.configure_analog_channel(
         direction=Direction.INPUT, physical_channel=CHANNEL_0, alias=f"ch_0", range_min=0, range_max=5
@@ -66,8 +62,9 @@ try:
     # Set the sample rate but also the number of samples we will fetch each time daq.read_analog() is called.
     daq.configure_ai_sample_rate(sample_rate=100, samples_per_channel=50)
 
-    # Start the acquisition
-    daq.start()
+    # Start hardware acquisition without a background daemon. We fetch the buffer
+    # ourselves in the main app loop via read_analog().
+    daq.start(background=False)
 
     while True:
         try:

--- a/instro/daq/daq.py
+++ b/instro/daq/daq.py
@@ -436,30 +436,8 @@ class InstroDAQ(Instrument):
 
     @background_interval.setter
     def background_interval(self, seconds: float):
-        """No-op for DAQ — the interval is fixed at 0 while the daemon is enabled."""
+        """No-op for DAQ — the interval is fixed at 0 so the blocking fetch implicitly times the loop."""
         return
-
-    @property
-    def background_enable(self) -> bool:
-        """Whether the background daemon is enabled."""
-        return self._background_config.enabled
-
-    @background_enable.setter
-    def background_enable(self, enable: bool):
-        """Enable/disable the background daemon.
-
-        When enabled, the daemon continuously fetches the DAQ buffer; the interval
-        is set to 0 so the blocking fetch implicitly times the loop. When
-        disabled, the interval is bumped to 1 s so the loop doesn't burn cycles.
-        """
-        if enable:
-            # Never wait. Let fetch block
-            self._background_config.interval = 0
-        else:
-            # Give the background daemon a big wait so as not to eat cycles
-            self._background_config.interval = 1
-
-        self._background_config.enabled = enable
 
     def open(self):
         """Open the underlying driver."""
@@ -546,10 +524,13 @@ class InstroDAQ(Instrument):
         self._channel_buffer_length = max(int(sample_rate * 10), self._channel_buffer_length)
         logger.info("Configured AI hardware timing on DAQ '%s'", self.name)
 
-    def start(self, **kwargs):
+    def start(self, background: bool = True, **kwargs):
         """Start hardware-timed acquisition.
 
         Args:
+            background: When True (default), spin the daemon thread to continuously
+                fetch the buffer. When False, begin hardware acquisition only and
+                fetch the buffer yourself by calling ``read_analog()``.
             **kwargs: ``channel_type`` (NI only) selects which DAQmx task to start.
         """
         # DAQmx allows starting different channel_types independently.
@@ -563,9 +544,10 @@ class InstroDAQ(Instrument):
         # we add other channel type capabilities that are hardware timed.
 
         self._driver.start(channel_type=channel_type)
-        self._define_background_daemon()
 
-        super().start()
+        if background:
+            self._define_background_daemon()
+            super().start()
 
     def stop(self, **kwargs):
         """Stop the DAQ device."""
@@ -584,7 +566,7 @@ class InstroDAQ(Instrument):
         Returns a single Measurement when channels share a timebase, otherwise one Measurement per timebase cluster.
         """
         if self.ai_hw_timing_config:
-            if not self._background_config.enabled:
+            if not (self._background_thread and self._background_thread.is_alive()):
                 return self._fetch_analog(**kwargs)
             # Background daemon running. The user can't pull from the buffer mid-flight.
             # TODO revisit with INSTRO-149 issue ticket.

--- a/instro/lib/instrument.py
+++ b/instro/lib/instrument.py
@@ -238,15 +238,6 @@ class Instrument:
     def background_interval(self, seconds: float):
         self._background_config.interval = seconds
 
-    @property
-    def background_enable(self):
-        """Whether the background daemon is enabled (must still be ``start()``-ed)."""
-        return self._background_config.enabled
-
-    @background_enable.setter
-    def background_enable(self, enable: bool):
-        self._background_config.enabled = enable
-
     def add_background_daemon_function(self, method: Callable, *args, **kwargs):
         """Append ``method`` to the daemon's call list. Use ``define_background_daemon`` to replace instead."""
         self._background_methods.append((method, args, kwargs))
@@ -274,10 +265,9 @@ class Instrument:
         )
         self._background_thread.start()
         logger.info(
-            "Started background daemon for instrument '%s' (thread=%s, enabled=%s, interval_s=%s)",
+            "Started background daemon for instrument '%s' (thread=%s, interval_s=%s)",
             self.name,
             self._background_thread.name,
-            self._background_config.enabled,
             self._background_config.interval,
         )
 
@@ -321,18 +311,15 @@ class Instrument:
         """Daemon loop: run registered functions every ``background_interval``, publish loop timing."""
         while not self._background_stop_event.is_set():
             daemon_loop_start = time.time_ns()
-            if self._background_config.enabled:
-                self._background_daemon()
+            self._background_daemon()
             daemon_work_stop = time.time_ns()
 
             daemon_work_time_s = (daemon_work_stop - daemon_loop_start) * 1e-9
             self._background_stop_event.wait(max(0, self._background_config.interval - daemon_work_time_s))
 
             daemon_loop_stop = time.time_ns()
-            # Only publish if the background loop is running
-            if self._background_config.enabled:
-                daemon_loop_time_s = (daemon_loop_stop - daemon_loop_start) * 1e-9
-                self._publish_daemon_timing(daemon_loop_time_s, daemon_work_time_s, daemon_loop_stop)
+            daemon_loop_time_s = (daemon_loop_stop - daemon_loop_start) * 1e-9
+            self._publish_daemon_timing(daemon_loop_time_s, daemon_work_time_s, daemon_loop_stop)
 
     def _background_daemon(self):
         """Invoke each registered daemon function once.

--- a/instro/lib/types.py
+++ b/instro/lib/types.py
@@ -18,7 +18,6 @@ from pydantic import BaseModel, Field
 @dataclass
 class BackgroundDaemonConfig:
     interval: float = 1.0
-    enabled: bool = True
 
 
 @dataclass

--- a/tests/daq/mcc/test_mccdaq_hardware.py
+++ b/tests/daq/mcc/test_mccdaq_hardware.py
@@ -423,7 +423,6 @@ class TestMCCDAQHardware(unittest.TestCase):
                     sample_rate=SAMPLE_RATE_HZ,
                     samples_per_channel=SAMPLES_PER_CHANNEL,
                 )
-                daq.background_enable = True
                 daq.start()
 
                 try:
@@ -466,12 +465,11 @@ class TestMCCDAQHardware(unittest.TestCase):
                 self._configure_ai(daq)
                 self._configure_ao(daq)
 
-                daq.background_enable = False
                 daq.configure_ai_sample_rate(
                     sample_rate=SAMPLE_RATE_HZ,
                     samples_per_channel=SAMPLES_PER_CHANNEL,
                 )
-                daq.start()
+                daq.start(background=False)
 
                 try:
                     daq.write_analog_value("ao_0", 4.0)
@@ -508,7 +506,6 @@ class TestMCCDAQHardware(unittest.TestCase):
                     sample_rate=SAMPLE_RATE_HZ,
                     samples_per_channel=SAMPLES_PER_CHANNEL,
                 )
-                daq.background_enable = True
                 daq.start()
 
                 try:
@@ -557,7 +554,6 @@ class TestMCCDAQHardware(unittest.TestCase):
                     sample_rate=SAMPLE_RATE_HZ,
                     samples_per_channel=SAMPLES_PER_CHANNEL,
                 )
-                daq.background_enable = True
                 daq.start()
 
                 try:
@@ -596,7 +592,6 @@ class TestMCCDAQHardware(unittest.TestCase):
                     sample_rate=SAMPLE_RATE_HZ,
                     samples_per_channel=SAMPLES_PER_CHANNEL,
                 )
-                daq.background_enable = True
                 daq.start()
 
                 try:

--- a/tests/daq/test_daq_drivers.py
+++ b/tests/daq/test_daq_drivers.py
@@ -660,3 +660,50 @@ def test_channels_property_returns_immutable_tuple():
 
     assert isinstance(daq.channels, tuple)
     assert {ch.alias for ch in daq.channels} == {"do0"}
+
+
+# --- start(background=...) and read_analog dispatch ---
+
+
+def _hw_timed_daq() -> tuple[InstroDAQ, _RecordingDriver]:
+    """An InstroDAQ with one AI channel and a hardware sample rate configured."""
+    mock_driver = _make_mock_driver()
+    mock_driver._read_to_measurements.return_value = []
+    daq = InstroDAQ(name="ut", driver=mock_driver)
+    daq.configure_analog_channel(direction=Direction.INPUT, physical_channel="ai0", alias="ai0")
+    daq.configure_ai_sample_rate(sample_rate=100, samples_per_channel=10)
+    return daq, mock_driver
+
+
+def test_start_background_false_does_not_spin_daemon():
+    """start(background=False) begins hardware acquisition without spinning the daemon thread."""
+    daq, mock_driver = _hw_timed_daq()
+
+    daq.start(background=False)
+
+    mock_driver.start.assert_called_once()
+    assert daq._background_thread is None
+
+
+def test_start_background_false_read_analog_fetches_from_buffer():
+    """With no daemon running, read_analog() during HW-timed acquisition fetches the buffer."""
+    daq, mock_driver = _hw_timed_daq()
+    daq.start(background=False)
+
+    daq.read_analog()
+
+    mock_driver.fetch_analog.assert_called_once()
+
+
+def test_start_default_spins_daemon_and_read_analog_raises():
+    """Default start() spins the daemon, which owns the buffer; a manual read_analog() then raises."""
+    daq, _ = _hw_timed_daq()
+
+    daq.start()
+    try:
+        assert daq._background_thread is not None
+        assert daq._background_thread.is_alive()
+        with pytest.raises(RuntimeError, match="background acquisition daemon is running"):
+            daq.read_analog()
+    finally:
+        daq.stop()


### PR DESCRIPTION
## Problem

`InstroDAQ.start()` coupled two things: starting the device's hardware acquisition (`driver.start()`) and spinning the base daemon thread (`super().start()`). To run a hardware-timed acquisition but fetch the buffer manually, you set `background_enable = False` and called `start()` — which left the daemon thread running but idle. That "running but idle" state existed only because of the coupling, and the `enabled` flag was the sole thing distinguishing it.

## Change

- Add `background: bool = True` to `InstroDAQ.start()`. `start(background=False)` begins hardware acquisition without spinning the daemon thread.
- Retarget the `read_analog()` manual-fetch guard to key off whether the daemon thread is alive, instead of `_background_config.enabled`.
- Remove the `InstroDAQ.background_enable` override and its interval toggling.
- Remove the `enabled` flag from the base entirely: `BackgroundDaemonConfig.enabled`, `Instrument.background_enable`, the `if self._background_config.enabled:` guards in `_background_daemon_loop`, and the init-log reference.
- Update `examples/daq/daq_read_analog_hw_timed_no_background.py` to `start(background=False)`, regenerate its Mintlify mirror (`just gen-examples`), and update the DAQ guide.
- Update the MCC hardware integration test to the new API; add unit tests covering the no-daemon fetch path and the daemon-running raise.

## Outcome

The daemon runs iff its thread is alive — no third "running but idle" state. One less piece of state; the `read_analog()` manual-fetch path is preserved. Daemon timing (including `command_handling_time`) always reports while the loop runs, with no `enabled` gate to reason about.

## Notes

- **BREAKING:** `background_enable` is removed. Only one example used it, and the library is pre-1.0.
- Follow-up from the explicit daemon-command model, where this idle-thread state was the remaining rough edge.
- `AGENTS.md` and the mkdocs-generated reference docs carry no `background_enable`/daemon references, so neither needed manual edits.

## Verification

`just check` and `just test` both pass (435 unit tests + EtherNet/IP wheel smoke test, Rust suite, and bindings).

Closes #61
