### PR TITLE
docs: reconcile cross-page inconsistencies in instrumentation guides

### DIFF
--- a/docs/guides/AGENTS.md
+++ b/docs/guides/AGENTS.md
@@ -1,8 +1,8 @@
-# Nominal Instrumentation docs: agent instructions
+# instro docs: agent instructions
 
 ## About this project
 
-- Open-source documentation for [Nominal Instrumentation](https://instro.nominal.io), Nominal's Python library for test equipment automation.
+- Open-source documentation for [`instro`](https://instro.nominal.io), a Python library for test equipment automation.
 - Built on [Mintlify](https://mintlify.com). Pages are MDX files with YAML frontmatter.
 - Configuration lives in `docs.json`.
 - Run `mint dev` to preview locally. Run `mint broken-links` before opening a PR.
@@ -10,7 +10,7 @@
 
 ## Terminology
 
-- Refer to the library as **Nominal Instrumentation** (or `instro`, the package name).
+- Refer to the library as **`instro`** (the package name). Reserve *Nominal* for the platform it integrates with (Nominal Core, Nominal Connect, the Nominal publishers).
 - The instrument HALs are **`InstroPSU`**, **`InstroELoad`**, **`InstroDMM`**, **`InstroDAQ`**, **`I2CInterface`**: keep the casing.
 - A *channel* is a named signal for a series of measurements or computed values. The inline glossary tooltip is in `snippets/glossary/channel.mdx`.
 
@@ -30,4 +30,4 @@ Follow Nominal's writing style guide. The rules that bite most often here:
 
 ## Content boundaries
 
-- This repo documents Nominal Instrumentation only. Nominal Core, Nominal Connect, and the dashboard are documented elsewhere: link out, don't re-document.
+- This repo documents `instro` only. Nominal Core, Nominal Connect, and the dashboard are documented elsewhere: link out, don't re-document.

--- a/docs/guides/CONTRIBUTING.md
+++ b/docs/guides/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contribute to the Nominal Instrumentation documentation
+# Contribute to the instro documentation
 
 Thank you for your interest in contributing! This guide will help you get started.
 

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -1,6 +1,6 @@
-# Nominal Instrumentation: User Documentation
+# instro: User Documentation
 
-Prose / conceptual documentation for [Nominal Instrumentation](https://instro.nominal.io), Nominal's Python library for scripting and automating test equipment.
+Prose / conceptual documentation for [`instro`](https://instro.nominal.io), a Python library for scripting and automating test equipment.
 
 This site is built on [Mintlify](https://mintlify.com). It sits alongside `docs/reference/` (mkdocs), which auto-generates the API reference from docstrings. This Mintlify site holds the prose, examples, and getting-started content.
 
@@ -33,6 +33,6 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md). For questions or feedback about the li
 
 ## Resources
 
-- [Nominal Instrumentation SDK reference](https://nominal-io.github.io/instro/)
+- [instro SDK reference](https://nominal-io.github.io/instro/)
 - [Runnable examples](https://instro.nominal.io/instrumentation/examples)
 - [Nominal](https://nominal.io)

--- a/docs/guides/docs.json
+++ b/docs/guides/docs.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://mintlify.com/docs.json",
   "theme": "mint",
-  "name": "Nominal Instrumentation",
+  "name": "instro",
   "colors": {
     "primary": "#0B0B0B",
     "light": "#FFFFFF",

--- a/docs/guides/index.mdx
+++ b/docs/guides/index.mdx
@@ -1,9 +1,9 @@
 ---
-title: "Nominal Instrumentation"
+title: "instro"
 description: "A Python library for interfacing with hardware test equipment"
 ---
 
-Nominal Instrumentation is a Python library for scripting and automating test equipment, with first-class integration into [Nominal Core](https://nominal.io) and [Nominal Connect](https://nominal.io). Write your test once, swap vendors with a single configuration change, and stream data to Nominal automatically.
+`instro` is a Python library for scripting and automating test equipment, with first-class integration into [Nominal Core](https://nominal.io) and [Nominal Connect](https://nominal.io). Write your test once, swap vendors with a single configuration change, and stream data to Nominal automatically.
 
 ## Start here
 
@@ -34,7 +34,7 @@ Nominal Instrumentation is a Python library for scripting and automating test eq
     icon="file-code"
     href="/instrumentation/examples"
   >
-    Browse runnable examples on the Nominal Instrumentation SDK Examples site.
+    Browse runnable examples for every instrument category.
   </Card>
 </Columns>
 

--- a/docs/guides/instrumentation/custom-instruments.mdx
+++ b/docs/guides/instrumentation/custom-instruments.mdx
@@ -17,9 +17,9 @@ This page covers building an entirely new instrument type using `Instrument`. If
 
 # Custom Instrumentation
 
-Nominal Instrumentation provides a framework for developing instruments that do not ship with the library. This lets an engineer with domain knowledge of an instrument type develop new functionality within a paradigm that grants the features of other instruments within Nominal Instrumentation.
+`instro` provides a framework for developing instruments that do not ship with the library. This lets an engineer with domain knowledge of an instrument type develop new functionality within a paradigm that grants the features of other instruments within `instro`.
 
-This is different than custom driver development within an existing instrument type. For example, if Nominal does not provide an RF Power Meter instrument type but you want the `instro` experience, creating a custom instrument type using `Instrument` is the path forward.
+This is different than custom driver development within an existing instrument type. For example, if there is no built-in RF Power Meter instrument type but you want the `instro` experience, creating a custom instrument type using `Instrument` is the path forward.
 
 ## Walkthrough: building a `SimpleTempController` instrument
 

--- a/docs/guides/instrumentation/custom-instruments.mdx
+++ b/docs/guides/instrumentation/custom-instruments.mdx
@@ -67,7 +67,7 @@ class SimpleTempController(Instrument):
         super().close()
 ```
 
-The base constructor takes a `name` (used as the channel-name prefix), and any extra `**kwargs` become default tags. `self.background_interval` sets the daemon's polling cadence in seconds, and `add_background_daemon_function` registers a method to be called every tick.
+The base constructor takes a `name` (used as the channel-name prefix), and any extra `**kwargs` become default tags. `self.background_interval` sets the daemon's polling cadence in seconds. Two methods register what the daemon runs each tick: `add_background_daemon_function(method, *args, **kwargs)` appends one call to the daemon's list (call it once per method you want polled), and `define_background_daemon(method, *args, **kwargs)` is the replace-all variant that clears the list and registers a single method.
 
 Override `open()` and `close()` to manage the connection to your device. The simulated controller has nothing to open, so both overrides just call `super()`. This is the seam where a real instrument would call `socket.create_connection`, open a VISA session, claim a USB interface, etc. The base `close()` already stops the background daemon and closes attached publishers, so user-side overrides only need to add their own teardown.
 

--- a/docs/guides/instrumentation/daq.mdx
+++ b/docs/guides/instrumentation/daq.mdx
@@ -18,7 +18,7 @@ InstroDAQ is a hardware abstraction layer (HAL) that provides a unified interfac
 
 ### Lifecycle Pattern
 
-The typical InstroDAQ workflow follow this pattern:
+The typical InstroDAQ workflow follows this pattern:
 
 1. **`InstroDAQ(name, driver, ...)`** - Instantiate the DAQ with a vendor driver
 2. **`open()`** - Establish connection to the hardware
@@ -56,7 +56,7 @@ InstroDAQ supports two acquisition modes:
 - Data automatically published via the background daemon, OR manually fetch with `read_analog()`
 - Use case: Mid to high frequency continuous monitoring with deterministic sample timing.
 
-## Creating a InstroDAQ Instance
+## Creating an InstroDAQ Instance
 
 Construct a vendor driver and pass it to `InstroDAQ`:
 

--- a/docs/guides/instrumentation/dmm.mdx
+++ b/docs/guides/instrumentation/dmm.mdx
@@ -18,7 +18,7 @@ If your vendor or model is not listed, see [Custom Driver Development](#custom-d
 
 ### Driver Composition
 
-A `InstroDMM` is built from a concrete driver:
+An `InstroDMM` is built from a concrete driver:
 
 ```
 InstroDMM("name", driver=Agilent34401A("ASRL3::INSTR"))
@@ -52,7 +52,7 @@ Optionally, you can use background fetching via `start()` / `stop()`, but it is 
 
 You must call `set_measurement_function()` before configuring resolution, aperture, range, or calling `read()`.
 
-## Creating a InstroDMM Instance
+## Creating an InstroDMM Instance
 
 ```python
 from instro.dmm.drivers import Agilent34401A
@@ -150,15 +150,19 @@ Every measurement/command call produces a channel keyed under `{name}.{descripto
 
 | Method | Purpose |
 |--------|---------|
-| `InstroDMM(name, driver, publishers=None, **kwargs)` | Construct a InstroDMM with a vendor driver |
+| `InstroDMM(name, driver, publishers=None, **kwargs)` | Construct an InstroDMM with a vendor driver |
 | `open()` | Establish VISA connection to the DMM |
 | `close()` | Disconnect from DMM and close all publishers |
 | `set_measurement_function(function)` | Set measurement function (DC_VOLTAGE, AC_VOLTAGE, DC_CURRENT, AC_CURRENT, TWO_WIRE_RESISTANCE, FOUR_WIRE_RESISTANCE) |
 | `set_digits(n)` | Set resolution in digits (driver-dependent) |
-| `set_aperture_seconds(seconds)` | Set integration time in seconds |
+| `set_aperture_seconds(seconds)` | Set integration time in seconds (not implemented by the bundled drivers; see note) |
 | `set_aperture_nplc(nplc)` | Set integration time in power-line cycles |
 | `set_range(value)` | Set manual range in current function's units; `None` = auto range |
 | `read()` | Trigger a measurement and return a Measurement |
+
+<Note>
+`set_aperture_seconds` is part of the DMM contract but is not implemented by either bundled driver (Agilent 34401A, Keithley 2400). Calling it on those drivers raises `NotImplementedError`. Use `set_aperture_nplc` to set integration time on the shipped drivers. See [Exceptions](/instrumentation/exceptions) for the distinction between `NotImplementedError` and `FeatureNotSupportedError`.
+</Note>
 
 ---
 

--- a/docs/guides/instrumentation/driver-dependencies.mdx
+++ b/docs/guides/instrumentation/driver-dependencies.mdx
@@ -1,22 +1,22 @@
 ---
 title: Driver Dependencies
-description: External vendor drivers and libraries required to use Nominal Instrumentation
+description: External vendor drivers and libraries required to use instro
 ---
 
-`instro` depends on external software to be installed for various hardware interactions to be successful. These must be installed on your system before you can use the corresponding Nominal Instrumentation drivers.
+`instro` depends on external software to be installed for various hardware interactions to be successful. These must be installed on your system before you can use the corresponding `instro` drivers.
 
 <Note>
-**Understanding the distinction**: These vendor-installable drivers are **different from** the driver classes that a `Instrument` is composed with:
+**Understanding the distinction**: These vendor-installable drivers are **different from** the driver classes that an `Instrument` is composed with:
 
 - **Vendor-installable drivers**: External libraries/drivers developed by instrument vendors that must be installed to your system operating system. These are necessary to install, regardless of using `instro`, to interact with the vendor hardware on the system in any way/environment.
-- **Nominal driver classes**: The vendor/model-specific Python code that `Instrument` uses to interact with the external software drivers.
+- **`instro` driver classes**: The vendor/model-specific Python code that `Instrument` uses to interact with the external software drivers.
 </Note>
 
 ## Overview
 
-Before using `instro` with specific instrument types, you must install the corresponding vendor driver or library. The table below shows which vendor drivers are required for which Nominal instrument types:
+Before using `instro` with specific instrument types, you must install the corresponding vendor driver or library. The table below shows which vendor drivers are required for which `instro` instrument types:
 
-| Vendor Driver | Required For | Used By Nominal Drivers |
+| Vendor Driver | Required For | Used By instro Drivers |
 |--------------|--------------|------------------------|
 | **VISA** | SCPI/VISA-based instruments (PSUs, ELoads, Keysight DAQ) | All VISA-based driver implementations |
 | **NI-DAQmx** | National Instruments DAQ devices | `NIDAQDriver` |

--- a/docs/guides/instrumentation/eload.mdx
+++ b/docs/guides/instrumentation/eload.mdx
@@ -17,7 +17,7 @@ If your vendor or model is not listed, see [Custom Driver Development](#custom-d
 
 ### Driver Composition
 
-A `InstroELoad` is built from a concrete driver:
+An `InstroELoad` is built from a concrete driver:
 
 ```
 InstroELoad("name", driver=BK85XXB(visa_resource="USB0::..."))
@@ -52,7 +52,7 @@ Electronic loads can operate in four modes:
 The operating mode must be set using `set_mode()` before you can configure the level or range. Not all electronic loads support all four modes. Consult your instrument's manual.
 </Note>
 
-## Creating a InstroELoad Instance
+## Creating an InstroELoad Instance
 
 ```python
 from instro.eload.drivers.bk_85xxb import BK85XXB
@@ -177,7 +177,7 @@ while True:
         ch1_current = eload.get_channel(
             channel_name = "myELoad.ch1.current",
             length = 5,
-            wait_for_latest = False)  # This will immedietly return with the last 5 measurements for this channel (if available).
+            wait_for_latest = False)  # This will immediately return with the last 5 measurements for this channel (if available).
 
     except KeyboardInterrupt:
         print("Stopping...")
@@ -239,7 +239,7 @@ Every measurement/command call produces a channel keyed under `{name}.{descripto
 
 | Method | Purpose |
 |--------|---------|
-| `InstroELoad(name, driver, publishers=None, legacy_naming=False, **kwargs)` | Construct a InstroELoad with a vendor driver |
+| `InstroELoad(name, driver, publishers=None, legacy_naming=False, **kwargs)` | Construct an InstroELoad with a vendor driver |
 | `open()` | Establish VISA connection to the electronic load |
 | `close()` | Disconnect from electronic load and close all publishers |
 | `set_mode(mode, channel=1)` | Set operating mode (CC, CV, CR, or CP) |

--- a/docs/guides/instrumentation/examples.mdx
+++ b/docs/guides/instrumentation/examples.mdx
@@ -1,9 +1,9 @@
 ---
 title: Examples
-description: Full functional examples for Nominal Instrumentation
+description: Full functional examples for instro
 ---
 
-Throughout the Nominal Instrumentation documentation you will find example code snippets inline with the topics being described. Those snippets are meant to highlight specific concepts and usage patterns in context.
+Throughout the `instro` documentation you will find example code snippets inline with the topics being described. Those snippets are meant to highlight specific concepts and usage patterns in context.
 
 This section hosts **full, runnable examples** organized by instrument type and use case. Each page is a single Python file you can copy and adapt for your own projects. The source for these examples lives alongside the library at [`nominal-io/instro`](https://github.com/nominal-io/instro/tree/main/examples).
 

--- a/docs/guides/instrumentation/examples/daq/daq_read_analog_hw_timed.mdx
+++ b/docs/guides/instrumentation/examples/daq/daq_read_analog_hw_timed.mdx
@@ -75,7 +75,7 @@ try:
     while True:
         try:
             ch_1 = daq.get_channel("myDAQ.ch_0", 1, True)  # This will block for the latest sample
-            ch_2 = daq.get_channel("myDAQ.ch_1", 10, False)  # This will immedietly return with 10 samples.
+            ch_2 = daq.get_channel("myDAQ.ch_1", 10, False)  # This will immediately return with 10 samples.
             print(f"Channel 1 latest: {ch_1.latest}")
             print(f"Channel 1 samples: {ch_1.values}")
             print(f"Channel 2 latest: {ch_2.latest}")

--- a/docs/guides/instrumentation/exceptions.mdx
+++ b/docs/guides/instrumentation/exceptions.mdx
@@ -16,9 +16,11 @@ except InstroError:
     ...
 ```
 
+When a capability is unavailable, the library raises one of two distinct exceptions. They differ in *why* the capability is missing and, just as importantly, in what they inherit from.
+
 ## FeatureNotSupportedError
 
-`FeatureNotSupportedError` is raised when a driver cannot provide a requested feature.
+`FeatureNotSupportedError` (a subclass of `InstroError`) is raised by a concrete driver to declare that the connected instrument genuinely lacks a capability. For example, the `BK9115` power supply has no overcurrent protection or remote sense, so its driver raises `FeatureNotSupportedError` for those methods.
 
 ```python
 from instro.lib.exceptions import FeatureNotSupportedError
@@ -29,4 +31,30 @@ except FeatureNotSupportedError:
     ...
 ```
 
-Use `FeatureNotSupportedError` when the connected instrument or driver interface does not expose the feature. Use `NotImplementedError` when the feature exists but the driver has not implemented it yet.
+Because it inherits from `InstroError`, `except InstroError` catches it.
+
+## NotImplementedError
+
+`NotImplementedError` is the Python builtin, not an `InstroError`. Each `<Category>DriverBase` declares its optional methods to raise `NotImplementedError` by default, and a driver overrides only the ones its instrument supports. Calling an optional method on a driver that has not overridden it therefore raises `NotImplementedError`: the capability is part of the category contract, but this driver does not implement it.
+
+Because `NotImplementedError` is a builtin, `except InstroError` does **not** catch it.
+
+## Which one will I catch?
+
+It depends on the driver behind the HAL:
+
+- A driver that explicitly declares a feature absent raises `FeatureNotSupportedError`.
+- A driver that has simply not overridden an optional base method raises `NotImplementedError`.
+
+To handle both in one place, catch them together:
+
+```python
+from instro.lib.exceptions import FeatureNotSupportedError
+
+try:
+    psu.set_overcurrent_protection_level(5.0, channel=1)
+except (FeatureNotSupportedError, NotImplementedError):
+    ...
+```
+
+When writing a driver, raise `FeatureNotSupportedError` when the hardware lacks the feature, and leave the inherited `NotImplementedError` in place for optional methods that are not implemented yet.

--- a/docs/guides/instrumentation/installation.mdx
+++ b/docs/guides/instrumentation/installation.mdx
@@ -1,6 +1,6 @@
 ---
 title: Installation
-description: Installing the Nominal Instrumentation library
+description: Installing instro
 ---
 
 `instro` is published on [PyPI](https://pypi.org/project/instro/). Install it into your project using either `uv` (recommended) or `pip`.
@@ -25,7 +25,7 @@ Or, if you're working in an activated virtual environment:
 
 ## Additional Packages
 
-Nominal Instrumentation has additional packages for utilizing vendor instruments that require their own dependencies. This allows you to install only the vendor Python dependencies you need.
+`instro` has additional packages for utilizing vendor instruments that require their own dependencies. This allows you to install only the vendor Python dependencies you need.
 <Info>This is in reference to Python dependencies. See [Driver Dependencies](/instrumentation/driver-dependencies) as external installers are required for some instruments.</Info>
 
 To install additional packages, add the names of the groups (extras) to your install command. For example:

--- a/docs/guides/instrumentation/library.mdx
+++ b/docs/guides/instrumentation/library.mdx
@@ -10,7 +10,7 @@ description: The `Instrument`, `Measurement`, and `Command` building blocks
 # Library
 
 ## Instrument
-`Instrument` is the base class for all instrument types. It's responsibilities include.
+`Instrument` is the base class for all instrument types. Its responsibilities include:
 * Handling background daemons for synchronous instrument communication.
 * Holds the `publisher`s an instrument will use.
 * Creates and holds the communication interface for the instrument.
@@ -18,14 +18,14 @@ description: The `Instrument`, `Measurement`, and `Command` building blocks
 When creating a custom instrument type, you must subclass `Instrument`.
 
 ## Measurements and Commands
-Within a `Instrument`, data is packaged into `Measurement` and `Command` objects when data is read from or sent to an instrument, respectively.
+Within an `Instrument`, data is packaged into `Measurement` and `Command` objects when data is read from or sent to an instrument, respectively.
 
 The rationale for this is:
 1. Consistency regardless of instrument type or vendor.
 2. Interoperability of publishers across instrument types.
-3. Better integration with Nominal ecosystem by enforcing certain data is always be present, like timestamps.
+3. Better integration with the Nominal ecosystem by enforcing that certain data, like timestamps, is always present.
 
-Both of these classes are imported via `instro.lib`
+`Measurement` and `Command` are defined in `instro.lib.types` and re-exported from `instro.lib`, so either import path works: `from instro.lib import Measurement, Command` or `from instro.lib.types import Measurement, Command`.
 
 ### Measurement
 A `Measurement` object should be created when reading data from an instrument.
@@ -52,6 +52,8 @@ class Command:
     tags: dict[str, str] | None = None
 ```
 
+Unlike `Measurement`, a `Command` carries a single datapoint per channel (`float | str`, not `list[float]`) and a single `timestamp`. The `str` option covers categorical commands whose value is not numeric: mode names and relay states such as `OPEN` / `CLOSED`.
+
 ### Parameters
 
 - **`channel_data: dict[str, list[float]]`**
@@ -63,7 +65,7 @@ class Command:
   }
   ```
 - **`timestamps: list[int]`**
-  A list of POSIX timestamps (in integer milliseconds) for each measurement sample, aligned with the values in `channel_data`. The length of `timestamps` should match the length of each list in `channel_data`.
+  A list of timestamps in integer nanoseconds since the Unix epoch, one per measurement sample, aligned with the values in `channel_data`. The length of `timestamps` should match the length of each list in `channel_data`.
 
 - **`tags: dict[str, str] | None`**
   Optional metadata associated with this measurement acquisition. Common tags include test IDs, operator name, or environmental qualifiers. Useful for search, provenance, and analysis.
@@ -84,7 +86,7 @@ psu_legacy = InstroPSU(name="main", driver=BK9115(...), num_channels=1, legacy_n
 - **Backwards compatibility.** If your dashboards or recorded datasets were keyed on the pre-v1.0 channel names, flip the flag on each instrument as a single-line stopgap while you update downstream consumers.
 
 **Scope:**
-- Categories with a v1.0 rename (PSU, ELoad, I2C, DAQ digital channels, Scope) honor the flag.
+- Categories with a v1.0 rename (PSU, ELoad, I2C, DAQ digital channels, and the experimental `InstroScope` in `instro-unstable`) honor the flag.
 - Categories with no v1.0 rename (DMM, Modbus, DAQ analog/relay) ignore the flag (the published names are unchanged either way).
 
 **Limitations:**

--- a/docs/guides/instrumentation/overview.mdx
+++ b/docs/guides/instrumentation/overview.mdx
@@ -162,15 +162,15 @@ daq.close()
 
 You can get measurements into your script in two ways. **Both options publish data** whenever a measurement is produced. The difference is who triggers the reads and how often.
 
-|              | Background acquisition                                                                                                                                                                        | On-demand acquisition                                                                                                                                                             |
-| ------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **How**      | Call `start()`. A background daemon fetches from the instrument at a fixed, configurable rate. Use method `get_channel()` to pull the latest N values into your script if/when you need them. | Skip `start()`. Call the instrument's methods (e.g. `read_analog()`, `get_voltage()`) only when you want a measurement. Each call reads from the device and publishes the result. |
-| **Best for** | Simpler top-level apps where data should always be available and publishing.                                                                                                                  | Applications that only need measurements at specific times; lower system and bus usage. DMMs are a great example.                                                                 |
+|              | Background acquisition | On-demand acquisition |
+| ------------ | ---------------------- | --------------------- |
+| **How**      | Call `start()`. A background daemon reads from the instrument at a fixed, configurable rate. Pull the latest N values with `get_channel()` when you need them. | Skip `start()`. Call read methods (`read_analog()`, `get_voltage()`, …) only when you want a measurement. Each call reads the device and publishes the result. |
+| **Best for** | Apps where data should always be available and publishing. | Apps that need measurements only at specific times; lower system and bus load. DMMs are a good example. |
 
 <Note>
 **Recommendation**
 
-Nominal recommends the **background daemon pattern** for most workflows. Data is always available and publishing, and it often simplifies application code, especially for bufferred acquisitions from a DAQ where you'd need to manage servicing a buffer yourself.
+Nominal recommends the **background daemon pattern** for most workflows. Data is always available and publishing, and it often simplifies application code, especially for buffered acquisitions from a DAQ where you'd need to manage servicing a buffer yourself.
 
 Depending on your application, you may never need to call `get_channel()`, but the background daemon will always publish measurements for later analysis in tools like Nominal Core.
 
@@ -207,6 +207,11 @@ These are the current instrument types that have been developed by Nominal and a
 - `InstroDMM`: digital Multimeters
 - `I2CInterface`: I2C master for communicating to peripherals on an I2C bus
 - `ModbusDevice`: Modbus register/coil device (TCP or RTU)
+
+Additional instrument types are in development in the separate `instro-unstable` package, where APIs may change between releases:
+
+- `InstroScope`: oscilloscopes (Keysight 1200x, Tektronix 2-series), via `instro.unstable.scope`
+- `EtherNetIPDevice`: EtherNet/IP and CIP devices, via `instro.unstable.ethernetip`
 
 ### Drivers
 

--- a/docs/guides/instrumentation/overview.mdx
+++ b/docs/guides/instrumentation/overview.mdx
@@ -3,7 +3,7 @@ title: Overview
 description: A Python library/framework for interfacing with hardware
 ---
 
-Nominal Instrumentation is a Python library with the following objectives:
+`instro` is a Python library with the following objectives:
 
 1. Accelerate the authoring of tests which rely on hardware instruments.
 2. Provide low-code integration with Nominal tools like Connect and Core.
@@ -115,7 +115,7 @@ Here's what is required to read data from various DAQ devices and stream data to
 
 ## After: InstroDAQ
 
-Here's the same workflow using the Nominal Instrumentation library's `InstroDAQ`.
+Here's the same workflow using `instro`'s `InstroDAQ`.
 
 ```python
 from instro.daq.drivers.labjack import LabJackTSeriesDriver
@@ -152,7 +152,7 @@ daq.stop()
 daq.close()
 ```
 
-# Key Concepts of Nominal Instrumentation
+# Key Concepts of instro
 
 - **Code to an interface**, not the specific instrument in use.
 - **Automatic data publishing** to Nominal Core and Nominal Connect out of the box by way of a customizable `Publisher` interface.
@@ -170,7 +170,7 @@ You can get measurements into your script in two ways. **Both options publish da
 <Note>
 **Recommendation**
 
-Nominal recommends the **background daemon pattern** for most workflows. Data is always available and publishing, and it often simplifies application code, especially for buffered acquisitions from a DAQ where you'd need to manage servicing a buffer yourself.
+Use the **background daemon pattern** for most workflows. Data is always available and publishing, and it often simplifies application code, especially for buffered acquisitions from a DAQ where you'd need to manage servicing a buffer yourself.
 
 Depending on your application, you may never need to call `get_channel()`, but the background daemon will always publish measurements for later analysis in tools like Nominal Core.
 
@@ -199,7 +199,7 @@ This makes it easy to ensure measurements and state changes are consistently rec
 
 ### Instrument Types
 
-These are the current instrument types that have been developed by Nominal and available out of the box.
+These are the instrument types available out of the box.
 
 - `InstroPSU`: programmable Power Supplies
 - `InstroDAQ`: data Acquisition devices
@@ -215,7 +215,7 @@ Additional instrument types are in development in the separate `instro-unstable`
 
 ### Drivers
 
-These are the current vendor/model specific drivers that have been developed by Nominal and are available out of the box.
+These are the vendor/model-specific drivers available out of the box.
 
 - `InstroPSU`
   - B&K Precision
@@ -237,7 +237,7 @@ These are the current vendor/model specific drivers that have been developed by 
 
 ### Publishers
 
-These are the current Publishers that have been developed by Nominal and available out of the box.
+These are the publishers available out of the box.
 
 - `NominalCorePublisher`: sends data to a Nominal Core dataset
 - `NominalConnectPublisher`: sends data to Nominal Connect client

--- a/docs/guides/instrumentation/overview.mdx
+++ b/docs/guides/instrumentation/overview.mdx
@@ -240,4 +240,7 @@ These are the vendor/model-specific drivers available out of the box.
 These are the publishers available out of the box.
 
 - `NominalCorePublisher`: sends data to a Nominal Core dataset
-- `NominalConnectPublisher`: sends data to Nominal Connect client
+- `NominalConnectPublisher`: sends data to a Nominal Connect client
+- `FilePublisher`: writes data to a local file in Avro, CSV, or JSON
+
+`BasicBufferedPublisher` and `QueuedPublisher` wrap any of the above to add in-memory batching or non-blocking background delivery. See [Publishers](/instrumentation/publishers) for configuration and examples.

--- a/docs/guides/instrumentation/protocols/i2c/overview.mdx
+++ b/docs/guides/instrumentation/protocols/i2c/overview.mdx
@@ -44,7 +44,7 @@ mode = i2c.read("gpio_expander", "CONFIG", field="mode")
 See the [System Definition](/instrumentation/protocols/i2c/system-definition) page for detailed information on creating and configuring your `SystemDefinition`.
 
 <Tip>
-Nominal recommends creating your SystemDefinition in a separate file and importing it into your test code. This cleanly separates hardware configuration (typically done by a hardware/firmware engineer) from the test and automation logic (usually the test engineer's domain), leading to more maintainable and collaborative code.
+Create your SystemDefinition in a separate file and import it into your test code. This cleanly separates hardware configuration (typically done by a hardware/firmware engineer) from the test and automation logic (usually the test engineer's domain), leading to more maintainable and collaborative code.
 </Tip>
 
 

--- a/docs/guides/instrumentation/protocols/modbus.mdx
+++ b/docs/guides/instrumentation/protocols/modbus.mdx
@@ -5,7 +5,7 @@ description: Using ModbusDevice for Modbus TCP and RTU device communication
 
 # ModbusDevice
 
-ModbusDevice is a config-driven Modbus TCP/RTU client that provides **alias-based register access**, automatic background polling, and full integration with the Nominal publisher system. Instead of writing raw Modbus function calls, you define your device's register map in a JSON configuration file (or build it programmatically in Python) and access registers by semantic names.
+ModbusDevice is a config-driven Modbus TCP/RTU client that provides **alias-based register access**, automatic background polling, and full integration with the `instro` publisher system. Instead of writing raw Modbus function calls, you define your device's register map in a JSON configuration file (or build it programmatically in Python) and access registers by semantic names.
 
 <Note>
 [Modbus Application Protocol Specification](https://www.modbus.org/modbus-specifications)
@@ -13,7 +13,7 @@ ModbusDevice is a config-driven Modbus TCP/RTU client that provides **alias-base
 
 ## Quickstart
 
-Publishing Modbus data to Nominal Core with the Nominal Instrumentation Library
+Publishing Modbus data to Nominal Core with instro
 
 <Tabs>
 
@@ -50,7 +50,7 @@ modbus_device.close()
   "protocol": "modbus",
   "device": {
     "name": "example_device",
-    "description": "Example device for Nominal docs",
+    "description": "Example device for instro docs",
     "manufacturer": "Nominal",
     "model": "Sim Device 3000"
   },

--- a/docs/guides/instrumentation/protocols/modbus.mdx
+++ b/docs/guides/instrumentation/protocols/modbus.mdx
@@ -27,7 +27,8 @@ from instro.modbus import ModbusDevice
 
 RID = "<dataset_rid>" # Replace with your dataset RID.
 
-# Instantiate device with JSON config. The autostart flag opens and begins polling
+# Instantiate from a JSON config. autostart opens the connection and begins polling.
+# It requires a `timing` section in the config (present in my_device.json below).
 modbus_device = ModbusDevice(config="my_device.json", autostart=True)
 
 # Add publisher to flow data to Nominal Core
@@ -95,13 +96,13 @@ Most devices can be brought online with just a connection, a few registers, and 
 
 | If you're trying to... | Reach for... |
 | --- | --- |
-| Stream live data to Nominal Core with the shortest possible setup | [`autostart=True`](#lifecycle-pattern) + [`add_publisher()`](#creating-a-nominalmodbus-instance) |
+| Stream live data to Nominal Core with the shortest possible setup | [`autostart=True`](#lifecycle-pattern) + [`add_publisher()`](#creating-a-modbusdevice-instance) |
 | Read raw ADC counts or tick values as physical/engineering units | [`scale`](#linear-scaling) |
 | Protect equipment from out-of-range or wrong-type writes | [`write_min` / `write_max`](#write-limits) |
 | Replace magic numbers with human-readable labels for mode/state writes | [`write_value_map`](#write-value-maps) |
 | Unpack a packed status word into individual boolean channels | [`bitmap`](#bitmap-extraction) |
 | Minimize round-trips when polling many adjacent registers | [`read_group`](#read-groups) |
-| Share one device config across test benches with different networking | Pass [`connection` separately](#creating-a-nominalmodbus-instance) to the constructor |
+| Share one device config across test benches with different networking | Pass [`connection` separately](#creating-a-modbusdevice-instance) to the constructor |
 | Work with a device that uses little-endian or "Modbus-style" word ordering | [`byte_swap` / `word_swap` / `long_swap`](#byte-ordering) |
 | Throttle commands to a device that processes writes sequentially | [`write_delay_ms`](#timing-section) |
 | Prototype a config without real hardware | The built-in [simulator](#prototyping-without-a-device) |
@@ -860,7 +861,7 @@ import time
 from instro.modbus import ModbusDevice
 
 connection = {"transport": "tcp", "host": "192.168.5.222", "port": 502}
-f4t = ModbusDevice("watlow_f4t.json", connection=connection, autostart=True)
+f4t = ModbusDevice(config="watlow_f4t.json", connection=connection, autostart=True)
 
 try:
     # Set zone 1 to auto mode using write_value_map (no magic numbers)

--- a/docs/guides/instrumentation/protocols/overview.mdx
+++ b/docs/guides/instrumentation/protocols/overview.mdx
@@ -17,10 +17,20 @@ This is valuable for several reasons:
 
 - **Config-driven workflows.** The configuration file becomes a portable, shareable description of how to talk to a device. Teams can version control their device configs, reuse them across test setups, and onboard new hardware without writing any Python. Changing which registers to poll or adjusting scaling factors is a config edit, not a code change.
 
-- **Access to non-SCPI/VISA devices.** Many industrial devices don't speak SCPI or use VISA transports. Protocols like Modbus, OPC-UA, and EtherNet/IP are ubiquitous in manufacturing, process control, and test infrastructure. The Protocols module brings these devices into the same publisher and data pipeline as your bench instruments.
+- **Access to non-SCPI/VISA devices.** Many industrial devices don't speak SCPI or use VISA transports. Protocols like Modbus, OPC-UA, and EtherNet/IP are ubiquitous in manufacturing, process control, and test infrastructure. The Protocols module brings these devices into the same publisher and data pipeline as your bench instruments. Modbus ships today in the core package; see [Supported protocols](#supported-protocols) for what is available now and what is in development.
 
 - **Consistent data pipeline.** Protocol instruments integrate with the same [publisher system](/instrumentation/publishers) and background daemon infrastructure as the rest of the library. Regardless of which protocol your device speaks, data flows through the same path to Nominal.
 
 ## Supported Protocols
 
+Stable, in the core `instro` package:
+
 - **[Modbus](/instrumentation/protocols/modbus)**: Modbus TCP and RTU client with config-driven register access, automatic polling, and full publisher support.
+
+In development in the separate `instro-unstable` package, where APIs may change between releases:
+
+- **EtherNet/IP**: EtherNet/IP and CIP support for CompactLogix-class PLCs, via `instro.unstable.ethernetip` (`EtherNetIPDevice`).
+
+Planned, not yet available:
+
+- **OPC-UA**

--- a/docs/guides/instrumentation/protocols/overview.mdx
+++ b/docs/guides/instrumentation/protocols/overview.mdx
@@ -5,7 +5,7 @@ description: Protocol-based instrument communication for industrial protocols
 
 # Summary
 
-The Protocols module extends the Nominal Instrumentation Library to support commonly used industrial communication protocols. Protocol-based instruments use **configuration files** that define how to interface with a device.
+The Protocols module extends `instro` to support commonly used industrial communication protocols. Protocol-based instruments use **configuration files** that define how to interface with a device.
 
 ## Why Protocols?
 

--- a/docs/guides/instrumentation/psu.mdx
+++ b/docs/guides/instrumentation/psu.mdx
@@ -265,7 +265,7 @@ Every measurement/command call produces a channel keyed under `{name}.{descripto
 
 # Simulated Power Supply
 
-For development and testing without physical hardware, Nominal Instrumentation includes a simulated SCPI power supply server and a matching `SimulatedPSU`. This allows you to test your code and workflows before connecting to real instruments.
+For development and testing without physical hardware, `instro` includes a simulated SCPI power supply server and a matching `SimulatedPSU`. This allows you to test your code and workflows before connecting to real instruments.
 
 ## Starting the Simulation Server
 

--- a/docs/guides/instrumentation/psu.mdx
+++ b/docs/guides/instrumentation/psu.mdx
@@ -22,7 +22,7 @@ If your vendor or model is not listed, see [Custom Driver Development](#custom-d
 
 ### Driver Composition
 
-A `InstroPSU` is built from a concrete driver:
+An `InstroPSU` is built from a concrete driver:
 
 ```
 InstroPSU("name", driver=BK9115(visa_resource="USB0::..."), num_channels=1)
@@ -42,7 +42,7 @@ The typical InstroPSU workflow:
 5. **`stop()`**: ends the background daemon (if started).
 6. **`close()`**: disconnects from hardware.
 
-## Creating a InstroPSU Instance
+## Creating an InstroPSU Instance
 
 ```python
 from instro.psu.drivers import SiglentSPD3303
@@ -165,7 +165,7 @@ while True:
         ch1_current = psu.get_channel(
             channel_name = "myPSU.ch1.current",
             length = 5,
-            wait_for_latest = False)  # This will immedietly return with the last 5 measurements for this channel (if available).
+            wait_for_latest = False)  # This will immediately return with the last 5 measurements for this channel (if available).
         print(f"Voltage, Channel 1: {ch1_voltage}")
         print(f"Current, Channel 1: {ch1_current}")
     except KeyboardInterrupt:
@@ -239,7 +239,7 @@ Every measurement/command call produces a channel keyed under `{name}.{descripto
 
 | Method | Purpose |
 |--------|---------|
-| `InstroPSU(name, driver, num_channels, publishers=None, legacy_naming=False, **kwargs)` | Construct a InstroPSU with a vendor driver |
+| `InstroPSU(name, driver, num_channels, publishers=None, legacy_naming=False, **kwargs)` | Construct an InstroPSU with a vendor driver |
 | `open()` | Establish the connection to the PSU |
 | `close()` | Disconnect from PSU and close all publishers |
 | `set_voltage(voltage, channel=1)` | Set voltage setpoint in volts |

--- a/docs/guides/instrumentation/publishers.mdx
+++ b/docs/guides/instrumentation/publishers.mdx
@@ -172,7 +172,7 @@ If `custom_file_name` is not provided, the output file is named `measurements-YY
 
 - **`avro`** (default): Compact binary format with snappy compression. Uses the same schema as Nominal Core ingest, so captured files can be uploaded after the fact without transformation. Recommended for production captures.
 - **`csv`**: One row per `(timestamp, channel, value, tags)` tuple. Good for quick inspection in spreadsheet tools.
-- **`json`**: Appends each publish to a JSON array. Convenient for debugging small runs, but not recommended for high-rate data, as the file is re-read and rewritten on every publish call.
+- **`json`**: Appends each publish to a JSON array. Convenient for debugging small runs, but not recommended for high-rate data: the entire file is re-read and rewritten on every publish call, so the cost of a capture grows quadratically (O(n^2)) with the number of records.
 
 **Example:**
 
@@ -264,7 +264,7 @@ class Publisher(Protocol):
 ```
 
 ### Example
-This publisher prints to the console every time a `Measurement` is published corresponding to a predefied <Tooltip tip="A named signal for a series of measurements or computed values (example: voltage, pressure, system state).">channel</Tooltip> name.
+This publisher prints to the console every time a `Measurement` is published corresponding to a predefined <Tooltip tip="A named signal for a series of measurements or computed values (example: voltage, pressure, system state).">channel</Tooltip> name.
 ```python
 from instro.lib.types import Measurement, Command
 
@@ -289,9 +289,9 @@ class PrintChannelPublisher:
 
 Publisher wrappers modify the behavior of other publishers by adding buffering or asynchronous processing. They're composable - wrap any publisher to add new capabilities.
 
-### BufferedPublisher
+### BasicBufferedPublisher
 
-Collects data in memory and publishes in batches, reducing the overhead of frequent publish calls.
+`BasicBufferedPublisher` collects data in memory and publishes in batches, reducing the overhead of frequent publish calls. It is the concrete implementation of the abstract `BufferedPublisher` base, so instantiate `BasicBufferedPublisher`.
 
 **When to use:**
 - You're making many small publish calls and want to reduce overhead
@@ -335,7 +335,7 @@ buffered_publisher = BasicBufferedPublisher(print_publisher, buffer_size=5)
 
 psu = InstroPSU(
     name="myPSU",
-    driver=SimulatedPSU("TCPIP0::192.168.1.100::5025::SOCKET"),
+    driver=SimulatedPSU("TCPIP0::127.0.0.1::5025::SOCKET"),
     num_channels=2,
 )
 psu.add_publisher(buffered_publisher)
@@ -403,7 +403,7 @@ queued_publisher = QueuedPublisher(
 
 psu = InstroPSU(
     name="myPSU",
-    driver=SimulatedPSU("TCPIP0::192.168.1.100::5025::SOCKET"),
+    driver=SimulatedPSU("TCPIP0::127.0.0.1::5025::SOCKET"),
     num_channels=2,
 )
 psu.add_publisher(queued_publisher)

--- a/docs/guides/instrumentation/publishers.mdx
+++ b/docs/guides/instrumentation/publishers.mdx
@@ -1,9 +1,9 @@
 ---
 title: Publishers
-description: How Nominal Instrumentation gets data to places
+description: How instro gets data to places
 ---
 
-Publishers are the mechanism by which Nominal Instrumentation handles data from instruments. They define what happens to measurements and commands - whether that's sending data to Nominal Core, streaming to Nominal Connect, writing to files, or implementing custom behavior.
+Publishers are the mechanism by which `instro` handles data from instruments. They define what happens to measurements and commands - whether that's sending data to Nominal Core, streaming to Nominal Connect, writing to files, or implementing custom behavior.
 
 Every instrument can have multiple publishers attached, and data flows automatically: **Instrument → Publishers → Destinations**.
 
@@ -73,7 +73,7 @@ class Publisher(Protocol):
 
 ## Built-in Publishers
 
-Nominal Instrumentation provides built-in publishers for sending data to Nominal's platform and for writing to local files.
+`instro` provides built-in publishers for sending data to Nominal's platform and for writing to local files.
 
 ### NominalCorePublisher
 

--- a/docs/guides/instrumentation/scope.mdx
+++ b/docs/guides/instrumentation/scope.mdx
@@ -1,13 +1,13 @@
 ---
 title: Scope and Applicability
-description: Understanding what Nominal Instrumentation is for, where it's applicable, and where it's not
+description: Understanding what instro is for, where it's applicable, and where it's not
 ---
 
-Nominal Instrumentation is designed to accelerate test equipment automation and simplify integration with Nominal's platform. This page helps you understand when this library is the right tool for your needs and what responsibilities remain with you as the engineer.
+`instro` is designed to accelerate test equipment automation and simplify integration with Nominal's platform. This page helps you understand when this library is the right tool for your needs and what responsibilities remain with you as the engineer.
 
 ## What This Library Is For
 
-Nominal Instrumentation is primarily used for **scripting and automating test equipment**. It provides:
+`instro` is primarily used for **scripting and automating test equipment**. It provides:
 
 - **Unified interfaces and code reusability** across different vendors and models of the same equipment type
 - **Built-in publishers** that stream measurements to Nominal Core and Nominal Connect
@@ -22,7 +22,7 @@ This library is designed for scripting and automation workflows, not for tight c
 
 ### What It Does
 
-Nominal Instrumentation strives to provide the same behavior and user experience across devices within the same type that share the same features. For example, if you have a data acquisition system from National Instruments or LabJack, the library provides a consistent API so your code can work with either vendor by changing a configuration parameter.
+`instro` strives to provide the same behavior and user experience across devices within the same type that share the same features. For example, if you have a data acquisition system from National Instruments or LabJack, the library provides a consistent API so your code can work with either vendor by changing a configuration parameter.
 
 ### What It Doesn't Do
 
@@ -42,7 +42,7 @@ The library has intentional boundaries that preserve your engineering judgment a
 
 ### This Library Is Optional
 
-Nominal Instrumentation is **not a requirement** for using hardware with Nominal Core or Nominal Connect. You can always interface with your instruments using manufacturer-provided SDKs and send data to Nominal products through their APIs.
+`instro` is **not a requirement** for using hardware with Nominal Core or Nominal Connect. You can always interface with your instruments using manufacturer-provided SDKs and send data to Nominal products through their APIs.
 
 ### Why You Might Choose to Use It
 
@@ -56,9 +56,9 @@ The library offers significant convenience by:
 
 ### When to Use Native Interfaces
 
-Nominal wants you to use all the features of your instruments. If this library doesn't expose a feature you need:
+You should be able to use all the features of your instruments. If this library doesn't expose a feature you need:
 
-- **Don't hesitate to reach out**: Contact Nominal to request the feature be added.
+- **Don't hesitate to reach out**: Open an issue to request the feature be added.
 - **Don't hesitate to go direct**: You are not beholden to this library. Use the instrument's native interfaces directly if that better serves your needs.
 
 A missing feature in this library should never block your work. Your success with your test equipment is more important than using any particular abstraction layer.
@@ -89,7 +89,7 @@ As with any test system, you should validate that your configuration produces th
 
 ## Implementation Approach
 
-Nominal Instrumentation prioritizes performance and reliability by leveraging compiled binaries where possible:
+`instro` prioritizes performance and reliability by leveraging compiled binaries where possible:
 
 - **Compiled drivers**: Where available, instrument drivers use compiled binaries provided by instrument manufacturers rather than pure Python implementations. This approach provides better performance and reliability for instrument communication.
 
@@ -101,4 +101,4 @@ This hybrid approach balances performance with developer accessibility. You prog
 
 ## Summary
 
-Nominal Instrumentation is a tool designed to make your work with test equipment easier and more integrated with Nominal's platform. It's built on the principle that you, the engineer, know your requirements best. The library provides convenience and consistency while leaving you free to work directly with hardware when needed. Use it where it helps, skip it where it doesn't, and tell Nominal how to make it better.
+`instro` is a tool designed to make your work with test equipment easier and more integrated with Nominal's platform. It's built on the principle that you, the engineer, know your requirements best. The library provides convenience and consistency while leaving you free to work directly with hardware when needed. Use it where it helps, skip it where it doesn't, and file an issue to help make it better.

--- a/docs/guides/instrumentation/scope.mdx
+++ b/docs/guides/instrumentation/scope.mdx
@@ -28,7 +28,7 @@ Nominal Instrumentation strives to provide the same behavior and user experience
 
 The library has intentional boundaries that preserve your engineering judgment and the capabilities of your chosen hardware:
 
-- **Does not replace equipment selection**: The library does not absolve the need for you to choose the right equipment for your specific application. You remain responsible for selecting hardware that meets your requirements.
+- **Does not replace equipment selection**: The library does not absolve you of the need to choose the right equipment for your specific application. You remain responsible for selecting hardware that meets your requirements.
 
 - **Does not add hardware capabilities**: If a piece of equipment doesn't inherently have a feature or capability, this library cannot add it. The library works within the bounds of what your hardware can do.
 

--- a/docs/guides/instrumentation/transports/visa.mdx
+++ b/docs/guides/instrumentation/transports/visa.mdx
@@ -5,7 +5,7 @@ description: VISA transport driver for building custom SCPI instrument drivers
 
 # VisaDriver
 
-`VisaDriver` is the VISA transport that Nominal's built-in SCPI instrument drivers (`BK9115`, `RigolDP800`, `SiglentSPD3303`, `Keithley2400`, `Agilent34401A`, `BK85xxB`, …) sit on top of. It is available as a public part of the library so customers can build their own drivers for VISA-attached instruments without having to wrap [pyvisa](https://pyvisa.readthedocs.io/) themselves.
+`VisaDriver` is the VISA transport that `instro`'s built-in SCPI instrument drivers (`BK9115`, `RigolDP800`, `SiglentSPD3303`, `Keithley2400`, `Agilent34401A`, `BK85xxB`, …) sit on top of. It is available as a public part of the library so customers can build their own drivers for VISA-attached instruments without having to wrap [pyvisa](https://pyvisa.readthedocs.io/) themselves.
 
 It is intentionally narrow: it opens, closes, and locks a VISA resource and exposes text and raw byte I/O. The caller chooses the command strings.
 
@@ -20,7 +20,7 @@ It is intentionally narrow: it opens, closes, and locks a VISA resource and expo
 | If you want to... | `VisaDriver` is the right fit because... |
 | --- | --- |
 | Talk to a **VISA-addressable** instrument | It wraps pyvisa and supports GPIB, USB-TMC, TCPIP (SOCKET, VXI-11, HiSLIP), and ASRL (serial) |
-| Build a **vendor- or model-specific driver** that plugs into an `Instro*` instrument type (`InstroPSU`, `InstroDMM`, `InstroELoad`, …) for a device Nominal doesn't ship | It's the same transport every built-in SCPI driver uses, so your driver composes the same way |
+| Build a **vendor- or model-specific driver** that plugs into an `Instro*` instrument type (`InstroPSU`, `InstroDMM`, `InstroELoad`, …) for a device `instro` doesn't ship | It's the same transport every built-in SCPI driver uses, so your driver composes the same way |
 | Use a **standalone client** for a SCPI instrument that doesn't fit any existing instrument type | It's usable on its own, without an `Instro*` wrapper |
 
 If you're working with a non-VISA protocol (Modbus, raw TCP without VISA framing, a vendor REST API), use the appropriate protocol module (e.g. [ModbusDevice](/instrumentation/protocols/modbus)) or a plain client library instead.
@@ -110,7 +110,7 @@ When the VISA resource is an ASRL (RS-232 / RS-485) interface, `VisaDriver` appl
 
 ## Building a Custom Driver
 
-The intended use of `VisaDriver` is as an internal transport inside a vendor-specific instrument driver. Nominal's shipped SCPI drivers all follow the same shape: take a `str | VisaConfig` in the constructor, store a `VisaDriver`, and delegate `open()` / `close()` and all I/O to it.
+The intended use of `VisaDriver` is as an internal transport inside a vendor-specific instrument driver. `instro`'s shipped SCPI drivers all follow the same shape: take a `str | VisaConfig` in the constructor, store a `VisaDriver`, and delegate `open()` / `close()` and all I/O to it.
 
 Here is a minimal `InstroPSU`-compatible driver for a hypothetical SCPI power supply. The same shape applies to any instrument type whose driver base class exposes `open()`, `close()`, and a small set of category methods.
 
@@ -189,7 +189,7 @@ print(psu.get_voltage())
 psu.close()
 ```
 
-Two patterns from this example are worth calling out because they recur in every Nominal SCPI driver:
+Two patterns from this example are worth calling out because they recur in every `instro` SCPI driver:
 
 | Pattern | Why it matters |
 | --- | --- |

--- a/docs/reference/mkdocs.yml
+++ b/docs/reference/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: "Nominal Instrumentation SDK"
+site_name: "instro SDK"
 repo_url: "https://github.com/nominal-io/instro"
 repo_name: "nominal-io/instro"
 site_dir: site

--- a/docs/reference/src/index.md
+++ b/docs/reference/src/index.md
@@ -1,6 +1,6 @@
-# Nominal Instrumentation SDK
+# instro SDK
 
-The Nominal Instrumentation SDK provides a unified Python interface for controlling lab instruments,
+The `instro` SDK provides a unified Python interface for controlling lab instruments,
 collecting measurements, and publishing data to [Nominal](https://nominal.io).
 
 ## Overview

--- a/docs/reference/src/instruments/index.md
+++ b/docs/reference/src/instruments/index.md
@@ -1,6 +1,6 @@
 # Instruments
 
-The Nominal Instrumentation SDK provides high-level, vendor-agnostic interfaces for common lab
+The `instro` SDK provides high-level, vendor-agnostic interfaces for common lab
 instruments. Each instrument type defines a standard API that works across multiple hardware vendors.
 
 | Class | Description |

--- a/docs/reference/src/reference/instrument.md
+++ b/docs/reference/src/reference/instrument.md
@@ -1,3 +1,3 @@
-# Nominal Instrument
+# Instrument
 
 ::: instro.lib.instrument

--- a/examples/daq/daq_read_analog_hw_timed.py
+++ b/examples/daq/daq_read_analog_hw_timed.py
@@ -70,7 +70,7 @@ try:
     while True:
         try:
             ch_1 = daq.get_channel("myDAQ.ch_0", 1, True)  # This will block for the latest sample
-            ch_2 = daq.get_channel("myDAQ.ch_1", 10, False)  # This will immedietly return with 10 samples.
+            ch_2 = daq.get_channel("myDAQ.ch_1", 10, False)  # This will immediately return with 10 samples.
             print(f"Channel 1 latest: {ch_1.latest}")
             print(f"Channel 1 samples: {ch_1.values}")
             print(f"Channel 2 latest: {ch_2.latest}")


### PR DESCRIPTION
Fixes the documentation inconsistencies, confusing definitions, and typos surfaced in review. Each item was validated against the code in this repo before fixing. Closes #64.

## High-impact contradictions
- **Timestamp units.** `library.mdx` claimed "POSIX timestamps (in integer milliseconds)". Code is unambiguously **nanoseconds since the Unix epoch** (`Measurement.timestamps: list[int]`, `time.time_ns()` throughout; the DAQ page and every example already say ns). Library page now matches.
- **`BasicBufferedPublisher` naming.** Both `BufferedPublisher` (abstract base) and `BasicBufferedPublisher` (concrete) exist; the heading/prose now name the instantiable `BasicBufferedPublisher` consistently with the parameter block and examples.
- **Modbus `autostart` + `timing`.** The Quickstart one-liner now states that `autostart=True` requires a `timing` section; the Watlow example uses the keyword `config=` form like the rest of the page.
- **Simulated PSU VISA resource.** Publisher examples pointed `SimulatedPSU` at `192.168.1.100`; fixed to the loopback `127.0.0.1:5025` the bundled simulator actually listens on.

## Confusing / incomplete
- **`FeatureNotSupportedError` vs `NotImplementedError`.** Reconciled and fleshed out: concrete drivers raise `FeatureNotSupportedError` (an `InstroError`) for genuinely-absent hardware; the category bases raise builtin `NotImplementedError` for un-overridden optional methods. Crucially, `except InstroError` catches the former but **not** the latter, with guidance on catching both.
- **`Command.channel_data` typing.** Added a note on why a `Command` is `dict[str, float | str]` with a single datapoint/channel (mode names, relay `OPEN`/`CLOSED`), vs `Measurement`'s `dict[str, list[float]]`.
- **`set_aperture_seconds` on DMM.** Surfaced in the user-facing reference that neither bundled driver (Agilent 34401A, Keithley 2400) implements it (raises `NotImplementedError`); use `set_aperture_nplc`.
- **"Two ways to get data" table.** Tightened so the columns read cleanly.

## Wording / cleanup
- "a" → "an" before Instro* (psu/eload/dmm/daq headings + method-ref rows, library).
- Typos: `immedietly`, `bufferred`, `predefied`, "It's responsibilities include.", "data is always be present", "follow this pattern", "absolve the need".
- Clarified the `Measurement`/`Command` import path (`instro.lib` re-export vs `instro.lib.types`).
- Single, consistent description of the `add_background_daemon_function` (append) vs `define_background_daemon` (replace-all) contract.
- FilePublisher JSON: noted the rewrite cost is O(n^2).

## Validation notes (where review assumptions differed from the code)
- **Scope / EtherNet/IP are not premature.** `InstroScope` and `EtherNetIPDevice` ship in the in-development `instro-unstable` package (confirmed by tests). They are now marked **in-development (instro-unstable)** rather than removed. **OPC-UA** genuinely does not exist yet, so it is labeled **planned**.
- Also fixed two pre-existing broken intra-page anchors in `modbus.mdx` (`#creating-a-nominalmodbus-instance` → `#creating-a-modbusdevice-instance`).
- Example `.mdx` pages are generated from `examples/*.py`, so the `immedietly` fix was made in the source and the page regenerated (keeps the examples-drift gate green).

## Testing
- `just check` (ruff format, mypy, ruff lint): pass
- `just test`: 435 passed
- example pages regenerated via `just gen-examples` (no drift); no em/en-dashes introduced

---

## Added: de-emphasize Nominal branding (2nd commit)

Per follow-up: minimize Nominal-specific branding so the library reads as standalone, keeping Nominal only where it genuinely applies.

- Product title "Nominal Instrumentation" → `instro` across guides, the SDK reference site, and site config (`docs.json` name, `mkdocs.yml` site name).
- Neutralized Nominal-as-author/recommendation voice (`developed by Nominal`, `Nominal recommends`, `Nominal wants you`, `Contact Nominal`, `tell Nominal how to make it better`, `Nominal's built-in SCPI drivers`).
- **Kept all integration references**: Nominal Core, Nominal Connect, the Nominal publishers, "Nominal's platform", the support-portal link, the copyright notice, and the migration guide's historical `Nominal*` class names.
- Left `contrib.mdx`'s maintainer-governance references intact (they're the substance of the core-vs-contrib distinction, not branding) — can neutralize to "the maintainers" if preferred.
