### PR TITLE
chore(labjack): drop internal Linear URL from shutdown-guard TODO

### DIFF
--- a/packages/instro-daq-labjack/instro/daq/drivers/labjack/t_series.py
+++ b/packages/instro-daq-labjack/instro/daq/drivers/labjack/t_series.py
@@ -20,7 +20,7 @@ from instro.daq.types import (
 from instro.lib import Measurement
 from labjack import ljm
 
-# TODO: Remove this for [INSTRO-89: Add Context Managers](https://linear.app/nominal-io/issue/INSTRO-89/add-context-managers)
+# TODO(INSTRO-89): Remove this once context managers are added.
 # We use a callback functionality of the LJM driver. This is for performance reasons vs. python threading.
 # Registering this python callback to the c library
 # can create python segmentation faults when the python interpreter is shutting down.


### PR DESCRIPTION
The TODO above the LabJack LJM `atexit` shutdown guard in `t_series.py` hyperlinked an internal Linear ticket:

> `# TODO: Remove this for [INSTRO-89: Add Context Managers](https://linear.app/nominal-io/issue/INSTRO-89/add-context-managers)`

`instro` is a public, standalone package, but `linear.app/nominal-io/...` requires Nominal workspace access, so external readers and contributors hit an inaccessible link in the shipped source. This was the only literal `linear.app` URL in the codebase; tickets are referenced as bare `INSTRO-XXX` IDs everywhere else.

Replaced with the bare ticket ID, preserving maintainer traceability without shipping a private URL:

> `# TODO(INSTRO-89): Remove this once context managers are added.`

Comment-only change; no behavior change.

## Testing
- `just check` (ruff format, mypy, ruff lint): pass

Closes #66