### PR TITLE
docs: populate PyPI project descriptions for published packages

### DIFF
--- a/packages/instro-daq-labjack/README.md
+++ b/packages/instro-daq-labjack/README.md
@@ -1,0 +1,30 @@
+# instro-daq-labjack
+
+LabJack DAQ drivers for [`instro`](https://github.com/nominal-io/instro).
+
+This package contributes `LabJackTSeriesDriver` under `instro.daq.drivers.labjack`, with model definitions for the T4, T7, and T8. The driver talks to LabJack T-series hardware through the [LabJack LJM](https://support.labjack.com/docs/ljm-software-installer-downloads-t4-t7-t8-digit) library via the `labjack-ljm` Python binding, and runs behind the `InstroDAQ` hardware abstraction alongside the other DAQ vendors.
+
+## Installation
+
+```bash
+pip install 'instro[labjack]'
+```
+
+The LJM library is a separate vendor install from LabJack and is required at runtime on Windows, macOS, and Linux.
+
+## Usage
+
+Construct the driver with the device serial number, then pass it to `InstroDAQ`:
+
+```python
+from instro.daq import InstroDAQ
+from instro.daq.drivers.labjack import LabJackTSeriesDriver
+
+daq = InstroDAQ(name="myDAQ", driver=LabJackTSeriesDriver(device_id="440020473"))
+```
+
+See the [DAQ guides](https://instro.nominal.io) for channel configuration, hardware timing, and publishing to Nominal Core.
+
+## License
+
+[Apache License 2.0](./LICENSE).

--- a/packages/instro-daq-labjack/pyproject.toml
+++ b/packages/instro-daq-labjack/pyproject.toml
@@ -1,7 +1,8 @@
 [project]
 name = "instro-daq-labjack"
 version = "0.6.0"
-description = "LabJack DAQ drivers for instro"
+description = "LabJack T-series DAQ drivers for instro"
+readme = "README.md"
 license = "Apache-2.0"
 license-files = ["LICENSE"]
 requires-python = ">=3.10,<4.0"

--- a/packages/instro-daq-mcc/README.md
+++ b/packages/instro-daq-mcc/README.md
@@ -1,0 +1,30 @@
+# instro-daq-mcc
+
+Measurement Computing (MCC) DAQ drivers for [`instro`](https://github.com/nominal-io/instro).
+
+This package contributes `MCCDriver` under `instro.daq.drivers.mcc`. The driver talks to MCC USB-series hardware through the [MCC Universal Library](https://www.mccdaq.com/Software-Downloads) via the `mcculw` Python binding, and runs behind the `InstroDAQ` hardware abstraction alongside the other DAQ vendors.
+
+## Installation
+
+```bash
+pip install 'instro[mccdaq]'
+```
+
+The MCC Universal Library (`mcculw`) is Windows-only, so this package runs on Windows.
+
+## Usage
+
+Construct the driver with the MCC device ID, optionally suffixed with `:<board_number>` (default 0), then pass it to `InstroDAQ`:
+
+```python
+from instro.daq import InstroDAQ
+from instro.daq.drivers.mcc import MCCDriver
+
+daq = InstroDAQ(name="myDAQ", driver=MCCDriver(device_id="344371:0"))
+```
+
+See the [DAQ guides](https://instro.nominal.io) for channel configuration, hardware timing, and publishing to Nominal Core.
+
+## License
+
+[Apache License 2.0](./LICENSE).

--- a/packages/instro-daq-mcc/pyproject.toml
+++ b/packages/instro-daq-mcc/pyproject.toml
@@ -1,7 +1,8 @@
 [project]
 name = "instro-daq-mcc"
 version = "0.4.0"
-description = "MCC DAQ drivers for instro"
+description = "Measurement Computing (MCC) DAQ drivers for instro"
+readme = "README.md"
 license = "Apache-2.0"
 license-files = ["LICENSE"]
 requires-python = ">=3.10,<4.0"

--- a/packages/instro-daq-ni/README.md
+++ b/packages/instro-daq-ni/README.md
@@ -1,0 +1,30 @@
+# instro-daq-ni
+
+National Instruments DAQ drivers for [`instro`](https://github.com/nominal-io/instro).
+
+This package contributes `NIDAQDriver` under `instro.daq.drivers.ni`. The driver talks to NI multifunction DAQ hardware through the [NI-DAQmx](https://www.ni.com/en/support/downloads/drivers/download.ni-daq-mx.html) runtime via the `nidaqmx` Python binding, and runs behind the `InstroDAQ` hardware abstraction alongside the other DAQ vendors.
+
+## Installation
+
+```bash
+pip install 'instro[nidaq]'
+```
+
+The NI-DAQmx runtime is a separate vendor install from National Instruments and is required at runtime on Linux and Windows.
+
+## Usage
+
+Construct the driver with the device name as it appears in NI MAX, then pass it to `InstroDAQ`:
+
+```python
+from instro.daq import InstroDAQ
+from instro.daq.drivers.ni import NIDAQDriver
+
+daq = InstroDAQ(name="myDAQ", driver=NIDAQDriver(device_id="Dev1"))
+```
+
+See the [DAQ guides](https://instro.nominal.io) for channel configuration, hardware timing, and publishing to Nominal Core.
+
+## License
+
+[Apache License 2.0](./LICENSE).

--- a/packages/instro-daq-ni/pyproject.toml
+++ b/packages/instro-daq-ni/pyproject.toml
@@ -1,7 +1,8 @@
 [project]
 name = "instro-daq-ni"
 version = "0.6.0"
-description = "National Instruments DAQ drivers for instro"
+description = "National Instruments (NI-DAQmx) DAQ drivers for instro"
+readme = "README.md"
 license = "Apache-2.0"
 license-files = ["LICENSE"]
 requires-python = ">=3.10,<4.0"

--- a/packages/instro-i2c-aardvark/README.md
+++ b/packages/instro-i2c-aardvark/README.md
@@ -1,0 +1,34 @@
+# instro-i2c-aardvark
+
+Total Phase Aardvark I2C driver for [`instro`](https://github.com/nominal-io/instro).
+
+This package contributes `Aardvark` under `instro.i2c.drivers.totalphase`. The driver talks to the [Total Phase Aardvark](https://www.totalphase.com/products/aardvark-i2cspi/) I2C/SPI host adapter through the `pyaardvark` binding, and runs behind the `I2CInterface` hardware abstraction.
+
+## Installation
+
+```bash
+pip install 'instro[aardvark]'   # alias: instro[i2c]
+```
+
+The Aardvark shared library is a separate vendor install from Total Phase and is required at runtime on Windows, macOS, and Linux.
+
+## Usage
+
+Construct the driver with the adapter serial number, then pass it to `I2CInterface` along with a system definition describing the peripherals on the bus:
+
+```python
+from instro.i2c import I2CInterface
+from instro.i2c.drivers.totalphase import Aardvark
+
+i2c = I2CInterface(
+    name="myI2C",
+    driver=Aardvark(serial_number="2239-764425"),
+    system_definition=my_system_definition(),
+)
+```
+
+See the [I2C guides](https://instro.nominal.io) for system definitions, register and field access, and publishing to Nominal Core.
+
+## License
+
+[Apache License 2.0](./LICENSE).

--- a/packages/instro-i2c-aardvark/pyproject.toml
+++ b/packages/instro-i2c-aardvark/pyproject.toml
@@ -1,7 +1,8 @@
 [project]
 name = "instro-i2c-aardvark"
 version = "0.2.0"
-description = "TotalPhase Aardvark driver for instro"
+description = "Total Phase Aardvark I2C driver for instro"
+readme = "README.md"
 license = "Apache-2.0"
 license-files = ["LICENSE"]
 requires-python = ">=3.10,<4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,8 @@
 [project]
 name = "instro"
 version = "0.8.0"
-description = "Nominal instrumentation framework (core library + SCPI/VISA drivers)"
+description = "Typed Python API for test-and-measurement instruments: power supplies, multimeters, electronic loads, DAQs, and more"
+readme = "README.md"
 license = "Apache-2.0"
 license-files = ["LICENSE"]
 requires-python = ">=3.10,<4.0"

--- a/uv.lock
+++ b/uv.lock
@@ -444,7 +444,7 @@ wheels = [
 
 [[package]]
 name = "instro"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastavro", extra = ["snappy"] },
@@ -551,7 +551,7 @@ requires-dist = [{ name = "instro", editable = "." }]
 
 [[package]]
 name = "instro-daq-labjack"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "packages/instro-daq-labjack" }
 dependencies = [
     { name = "instro" },
@@ -566,7 +566,7 @@ requires-dist = [
 
 [[package]]
 name = "instro-daq-mcc"
-version = "0.3.0"
+version = "0.4.0"
 source = { editable = "packages/instro-daq-mcc" }
 dependencies = [
     { name = "instro" },
@@ -581,7 +581,7 @@ requires-dist = [
 
 [[package]]
 name = "instro-daq-ni"
-version = "0.5.0"
+version = "0.6.0"
 source = { editable = "packages/instro-daq-ni" }
 dependencies = [
     { name = "instro" },


### PR DESCRIPTION
## What

PyPI reads each project page's long description from the uploaded distribution's metadata. None of the published packages declared a `readme`, so that body rendered empty: only the one-line `description` summary showed.

This populates it for the five auto-published packages (those in `.github/release-please-config.json`):

- Adds a per-package `README.md` to the four vendor packages (`instro-daq-ni`, `instro-daq-labjack`, `instro-daq-mcc`, `instro-i2c-aardvark`). Root already had one.
- Wires up `readme = "README.md"` on all five `pyproject.toml` files.
- Tidies the one-line `description` summaries for consistency (and fixes `TotalPhase` -> `Total Phase`).

## Lockfile resync (called out)

`uv.lock` is also resynced. release-please's `python` release-type bumps the `version` in `pyproject.toml` without running `uv lock`, so the lock had drifted behind (`0.7.0`/`0.5.0`/`0.3.0`/`0.5.0` vs the current pyproject versions). `uv lock --check` gates CI, so this branch could not go green without the sync. No dependency versions changed, only the workspace-member versions.

## Verification

- `uv build --package <name>` for all five, then `twine check` on every wheel and sdist: all PASS (confirms the long descriptions render on PyPI).
- Inspected built `METADATA`: `Description-Content-Type: text/markdown` with the README body embedded.
- `just check` clean (ruff format, mypy, ruff lint).
- `uv lock --check` passes.

## Note on publishing

This is metadata only and a `docs:` change, so release-please will not cut a release on its own. The new descriptions reach PyPI on the **next release of each package** (a `feat`/`fix` landing, or a forced `Release-As:` release).

Closes #70