### PR TITLE
feat(scope): add hardware-validated Siglent SDS1104X-E driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Don't see your vendor? Drivers the maintainers can't verify directly against the
 
 In-development categories whose APIs may break between releases live in the separate [`instro-unstable`](./packages/instro-unstable/) workspace package:
 
-- **`InstroScope`**: oscilloscope category, with drivers for Keysight 1200x and Tektronix 2-series. Import via `instro.unstable.scope`.
+- **`InstroScope`**: oscilloscope category, with drivers for Keysight 1200x, Tektronix 2-series, and Siglent SDS1000X-E. Import via `instro.unstable.scope`.
 - **`EtherNetIPDevice`**: EtherNet/IP / CIP support for CompactLogix-class PLCs. Import via `instro.unstable.ethernetip`.
 
 Opt in by depending on `instro-unstable` explicitly.

--- a/packages/instro-unstable/instro/unstable/scope/drivers/siglent/__init__.py
+++ b/packages/instro-unstable/instro/unstable/scope/drivers/siglent/__init__.py
@@ -1,0 +1,3 @@
+from instro.unstable.scope.drivers.siglent.siglent_sds1000x_e import SiglentSDS1000XE
+
+__all__ = ["SiglentSDS1000XE"]

--- a/packages/instro-unstable/instro/unstable/scope/drivers/siglent/siglent_sds1000x_e.py
+++ b/packages/instro-unstable/instro/unstable/scope/drivers/siglent/siglent_sds1000x_e.py
@@ -124,6 +124,17 @@ def _parse_trailing_float(resp: str) -> float:
     return float(token)
 
 
+def _parse_ieee_block(raw: bytes) -> bytes:
+    """Extract the payload from an IEEE-488.2 definite-length block (``#<ndigits><length><payload>``)."""
+    hash_idx = raw.find(b"#")
+    if hash_idx < 0:
+        raise ValueError("no IEEE-488.2 block header in reply")
+    ndigits = int(chr(raw[hash_idx + 1]))
+    length = int(raw[hash_idx + 2 : hash_idx + 2 + ndigits])
+    start = hash_idx + 2 + ndigits
+    return raw[start : start + length]
+
+
 def _parse_sample_rate(resp: str) -> float:
     """Parse a SARA? reply (e.g. ``1.00GSa/s``, ``500.0kSa``, or bare ``1.00E+09``) to samples/sec."""
     token = resp.strip().upper()
@@ -142,6 +153,7 @@ class SiglentSDS1000XE(ScopeDriverBase):
         self._visa = VisaDriver(visa_resource)
         self._trigger_source: int | None = None
         self._trigger_type: TriggerType = TriggerType.EDGE
+        self._average_count: int = 16
 
     def open(self) -> None:
         """Open the transport and disable comm headers so query replies are bare values."""
@@ -151,6 +163,32 @@ class SiglentSDS1000XE(ScopeDriverBase):
 
     def close(self) -> None:
         self._visa.close()
+
+    def _consume_trailing_terminator(self) -> None:
+        """Drain the lone LF the SDS appends after a binary block; it would otherwise desync the next query."""
+        try:
+            with self._visa.temporary_timeout(400):
+                self._visa.read_raw()
+        except Exception:  # noqa: BLE001 - nothing buffered is the normal case
+            pass
+
+    def _read_binary_message(self, command: str) -> bytes:
+        """Read a full binary reply with the read terminator disabled.
+
+        SDS binary blocks (``SCDP`` BMP, ``PNSU?`` setup) embed LF bytes, so the transport's
+        terminator-aware reads truncate them. Reach the pyvisa resource directly to read to EOM.
+        """
+        with self._visa.lock():
+            inst = self._visa._inst  # noqa: SLF001 - escape hatch for terminator-free binary reads
+            if inst is None:
+                raise RuntimeError("SiglentSDS1000XE transport is not open")
+            saved_termination = inst.read_termination
+            inst.read_termination = None
+            try:
+                self._visa.write(command)
+                return inst.read_raw()
+            finally:
+                inst.read_termination = saved_termination
 
     def check_errors(self) -> None:
         """Poll ``CMR?`` then ``EXR?`` and raise on the first non-zero code (no error queue on Siglent)."""
@@ -206,23 +244,29 @@ class SiglentSDS1000XE(ScopeDriverBase):
     # --- Acquisition ---
 
     def set_acquisition_mode(self, mode: AcquisitionMode) -> None:
+        # The scope only applies ACQW while acquiring; call run() first if it's stopped.
         if mode == AcquisitionMode.ENVELOPE:
             raise NotImplementedError("ENVELOPE acquisition mode is not supported on Siglent SDS1000X-E series")
-        self._visa.write(f"ACQW {_ACQ_MODE_TO_SCPI[mode]}")
+        if mode == AcquisitionMode.AVERAGE:
+            # AVERAGE is ignored without an inline count.
+            self._visa.write(f"ACQW AVERAGE,{self._average_count}")
+        else:
+            self._visa.write(f"ACQW {_ACQ_MODE_TO_SCPI[mode]}")
 
     def get_acquisition_mode(self) -> AcquisitionMode:
         resp = self._visa.query("ACQW?").strip().upper().split(",")[0]
         return _SCPI_TO_ACQ_MODE.get(resp, AcquisitionMode.NORMAL)
 
     def set_average_count(self, count: int) -> None:
+        self._average_count = count
         self._visa.write(f"AVGA {count}")
 
     def get_average_count(self) -> int:
         return int(float(self._visa.query("AVGA?")))
 
     def run(self) -> None:
+        # ARM would force single-shot mode; TRMD AUTO alone free-runs continuously.
         self._visa.write("TRMD AUTO")
-        self._visa.write("ARM")
 
     def stop(self) -> None:
         self._visa.write("STOP")
@@ -266,6 +310,7 @@ class SiglentSDS1000XE(ScopeDriverBase):
         sample_rate = _parse_sample_rate(self._visa.query("SARA?"))
 
         codes = self._visa.query_binary_values(f"C{channel}:WF? DAT2", datatype="b", container=list)
+        self._consume_trailing_terminator()
 
         x_origin_ns = int((trigger_delay - timebase * _HORIZONTAL_DIVISIONS / 2) * 1e9)
         x_incr_ns = int((1.0 / sample_rate) * 1e9)
@@ -323,11 +368,12 @@ class SiglentSDS1000XE(ScopeDriverBase):
     # --- File operations ---
 
     def save_screenshot(self, filepath: str, to_instrument: bool = False) -> bytes:
-        """Transfer a screen dump (``SCDP``) to the host and write it to ``filepath``."""
+        """Transfer a screen dump (``SCDP``, a raw BMP) to the host and write it to ``filepath``."""
         if to_instrument:
             raise NotImplementedError("SDS1000X-E SCDP is host-transfer only; saving to the instrument is unsupported")
-        self._visa.write("SCDP")
-        data = self._visa.read_raw()
+        raw = self._read_binary_message("SCDP")
+        size = int.from_bytes(raw[2:6], "little")  # BMP header: 'BM' then a little-endian file size
+        data = raw[:size]
         with open(filepath, "wb") as f:
             f.write(data)
         return data
@@ -337,17 +383,21 @@ class SiglentSDS1000XE(ScopeDriverBase):
         if to_instrument:
             self._visa.write(f"STPN DISK,UDSK,FILE,'{name}'")
             return b""
-        self._visa.write("PNSU?")
-        data = self._visa.read_raw()
+        data = _parse_ieee_block(self._read_binary_message("PNSU?"))
         with open(name, "wb") as f:
             f.write(data)
         return data
 
     def load_settings(self, name: str, from_instrument: bool = False) -> None:
-        """Recall a panel setup from a USB file (``RCPN``) or push host bytes back (``PNSU``)."""
+        """Recall a panel setup from a USB file (``RCPN``) or push host bytes back (``PNSU``).
+
+        The host-side ``PNSU`` write-back is known to wedge the USBTMC interface on some
+        SDS1000X-E firmware; prefer ``from_instrument=True`` (USB stick) over USB connections.
+        """
         if from_instrument:
             self._visa.write(f"RCPN DISK,UDSK,FILE,'{name}'")
             return
         with open(name, "rb") as f:
             data = f.read()
-        self._visa.write_raw(b"PNSU " + data)
+        header = f"#9{len(data):09d}".encode()
+        self._visa.write_raw(b"PNSU " + header + data + b"\n")

--- a/packages/instro-unstable/instro/unstable/scope/drivers/siglent/siglent_sds1000x_e.py
+++ b/packages/instro-unstable/instro/unstable/scope/drivers/siglent/siglent_sds1000x_e.py
@@ -1,0 +1,353 @@
+"""Siglent SDS1000X-E series oscilloscope driver (SDS1104X-E and family)."""
+
+from __future__ import annotations
+
+import math
+import time
+
+from instro.lib.transports.visa import VisaConfig, VisaDriver
+from instro.unstable.scope.driver import ScopeDriverBase
+from instro.unstable.scope.types import (
+    AcquisitionMode,
+    AcquisitionState,
+    Coupling,
+    ScopeMeasurementType,
+    TriggerMode,
+    TriggerSlope,
+    TriggerStatus,
+    TriggerType,
+    WaveformData,
+)
+
+_ACQ_MODE_TO_SCPI = {
+    AcquisitionMode.NORMAL: "SAMPLING",
+    AcquisitionMode.AVERAGE: "AVERAGE",
+    AcquisitionMode.HIGH_RESOLUTION: "HIGH_RES",
+    AcquisitionMode.PEAK_DETECT: "PEAK_DETECT",
+}
+
+_SCPI_TO_ACQ_MODE = {v.upper(): k for k, v in _ACQ_MODE_TO_SCPI.items()}
+
+# Siglent combines coupling and input impedance in one token; default to 1 MΩ.
+_COUPLING_TO_SCPI = {
+    Coupling.AC: "A1M",
+    Coupling.DC: "D1M",
+}
+
+_TRIGGER_TYPE_TO_SCPI = {
+    TriggerType.EDGE: "EDGE",
+    TriggerType.PULSE: "GLIT",
+}
+
+_TRIGGER_SLOPE_TO_SCPI = {
+    TriggerSlope.RISING: "POS",
+    TriggerSlope.FALLING: "NEG",
+    TriggerSlope.EITHER: "WINDOW",
+}
+
+_TRIGGER_MODE_TO_SCPI = {
+    TriggerMode.AUTO: "AUTO",
+    TriggerMode.NORMAL: "NORM",
+}
+
+_MEAS_TYPE_TO_SCPI = {
+    ScopeMeasurementType.VPP: "PKPK",
+    ScopeMeasurementType.VMAX: "MAX",
+    ScopeMeasurementType.VMIN: "MIN",
+    ScopeMeasurementType.VAVG: "MEAN",
+    ScopeMeasurementType.VRMS: "RMS",
+    ScopeMeasurementType.FREQUENCY: "FREQ",
+    ScopeMeasurementType.PERIOD: "PER",
+    ScopeMeasurementType.DUTY_CYCLE: "DUTY",
+}
+
+_TRIGGER_STATUS_MAP = {
+    "ARM": TriggerStatus.ARMED,
+    "READY": TriggerStatus.READY,
+    "TRIG'D": TriggerStatus.TRIGGERED,
+    "TRIGGERED": TriggerStatus.TRIGGERED,
+    "AUTO": TriggerStatus.AUTO,
+    "STOP": TriggerStatus.READY,
+    "ROLL": TriggerStatus.SCAN,
+}
+
+# Command-error (CMR?) and execution-error (EXR?) code tables; 0 means no error.
+_CMR_CODES = {
+    1: "Unrecognized command/query header",
+    2: "Invalid character",
+    3: "Invalid separator",
+    4: "Missing parameter",
+    5: "Unrecognized keyword",
+    6: "String error",
+    7: "Parameter not allowed",
+    8: "Command string too long",
+    9: "Query not allowed",
+    10: "Missing query mask",
+    11: "Invalid parameter",
+    12: "Parameter syntax error",
+    13: "Filename too long",
+}
+
+_EXR_CODES = {
+    21: "Permission error",
+    22: "Environment error",
+    23: "Option error",
+    25: "Parameter error",
+    26: "Non-implemented command",
+    32: "Waveform descriptor error",
+    36: "Panel setup error",
+}
+
+# SI multipliers used by SARA? (sample rate), which carries a unit suffix.
+_SI_MULTIPLIERS = {"K": 1e3, "M": 1e6, "G": 1e9}
+
+# Codes-per-division and horizontal divisions for the SDS1000X-E grid.
+_CODES_PER_DIV = 25.0
+_HORIZONTAL_DIVISIONS = 14
+
+# IEEE-488.2 "not a number" sentinel for an invalid/unavailable measurement.
+_VENDOR_INVALID_MEASUREMENT = 9.91e37
+
+
+def _convert_sentinel(value: float) -> float:
+    """Map the vendor invalid-measurement sentinel to NaN."""
+    if abs(value) >= _VENDOR_INVALID_MEASUREMENT:
+        return math.nan
+    return value
+
+
+def _parse_trailing_float(resp: str) -> float:
+    """Parse the value after the last comma, stripping any trailing unit (V, S, Hz, %)."""
+    token = resp.strip().split(",")[-1].strip()
+    while token and token[-1] not in "0123456789.eE+-":
+        token = token[:-1]
+    return float(token)
+
+
+def _parse_sample_rate(resp: str) -> float:
+    """Parse a SARA? reply (e.g. ``1.00GSa/s``, ``500.0kSa``, or bare ``1.00E+09``) to samples/sec."""
+    token = resp.strip().upper()
+    if token.startswith("SARA"):
+        token = token[4:].strip()
+    token = token.replace("SA/S", "").replace("SA", "").strip()
+    if token and token[-1] in _SI_MULTIPLIERS:
+        return float(token[:-1]) * _SI_MULTIPLIERS[token[-1]]
+    return float(token)
+
+
+class SiglentSDS1000XE(ScopeDriverBase):
+    """SCPI driver for Siglent SDS1000X-E series oscilloscopes (SDS1104X-E and family)."""
+
+    def __init__(self, visa_resource: str | VisaConfig) -> None:
+        self._visa = VisaDriver(visa_resource)
+        self._trigger_source: int | None = None
+        self._trigger_type: TriggerType = TriggerType.EDGE
+
+    def open(self) -> None:
+        """Open the transport and disable comm headers so query replies are bare values."""
+        self._visa.open()
+        self._visa.write("CHDR OFF")
+        self._visa.write("*CLS")
+
+    def close(self) -> None:
+        self._visa.close()
+
+    def check_errors(self) -> None:
+        """Poll ``CMR?`` then ``EXR?`` and raise on the first non-zero code (no error queue on Siglent)."""
+        cmr = int(self._visa.query("CMR?"))
+        if cmr != 0:
+            raise RuntimeError(f"Siglent command error {cmr}: {_CMR_CODES.get(cmr, 'Unknown command error')}")
+        exr = int(self._visa.query("EXR?"))
+        if exr != 0:
+            raise RuntimeError(f"Siglent execution error {exr}: {_EXR_CODES.get(exr, 'Unknown execution error')}")
+
+    # --- Channel vertical settings ---
+
+    def set_vertical_scale(self, volts_per_div: float, channel: int) -> None:
+        self._visa.write(f"C{channel}:VDIV {volts_per_div:.4E}")
+
+    def get_vertical_scale(self, channel: int) -> float:
+        return float(self._visa.query(f"C{channel}:VDIV?"))
+
+    def set_vertical_offset(self, offset: float, channel: int) -> None:
+        self._visa.write(f"C{channel}:OFST {offset:.4E}")
+
+    def get_vertical_offset(self, channel: int) -> float:
+        return float(self._visa.query(f"C{channel}:OFST?"))
+
+    def set_coupling(self, coupling: Coupling, channel: int) -> None:
+        self._visa.write(f"C{channel}:CPL {_COUPLING_TO_SCPI[coupling]}")
+
+    def get_coupling(self, channel: int) -> Coupling:
+        resp = self._visa.query(f"C{channel}:CPL?").strip().upper()
+        if resp.startswith("A"):
+            return Coupling.AC
+        return Coupling.DC
+
+    def set_probe_attenuation(self, factor: float, channel: int) -> None:
+        self._visa.write(f"C{channel}:ATTN {factor:g}")
+
+    def get_probe_attenuation(self, channel: int) -> float:
+        return float(self._visa.query(f"C{channel}:ATTN?"))
+
+    # --- Horizontal (timebase) settings ---
+
+    def set_horizontal_scale(self, seconds_per_div: float) -> None:
+        self._visa.write(f"TDIV {seconds_per_div:.4E}")
+
+    def get_horizontal_scale(self) -> float:
+        return float(self._visa.query("TDIV?"))
+
+    # --- Sample rate ---
+
+    def get_sample_rate(self) -> float:
+        return _parse_sample_rate(self._visa.query("SARA?"))
+
+    # --- Acquisition ---
+
+    def set_acquisition_mode(self, mode: AcquisitionMode) -> None:
+        if mode == AcquisitionMode.ENVELOPE:
+            raise NotImplementedError("ENVELOPE acquisition mode is not supported on Siglent SDS1000X-E series")
+        self._visa.write(f"ACQW {_ACQ_MODE_TO_SCPI[mode]}")
+
+    def get_acquisition_mode(self) -> AcquisitionMode:
+        resp = self._visa.query("ACQW?").strip().upper().split(",")[0]
+        return _SCPI_TO_ACQ_MODE.get(resp, AcquisitionMode.NORMAL)
+
+    def set_average_count(self, count: int) -> None:
+        self._visa.write(f"AVGA {count}")
+
+    def get_average_count(self) -> int:
+        return int(float(self._visa.query("AVGA?")))
+
+    def run(self) -> None:
+        self._visa.write("TRMD AUTO")
+        self._visa.write("ARM")
+
+    def stop(self) -> None:
+        self._visa.write("STOP")
+
+    def single(self) -> None:
+        self._visa.write("TRMD SINGLE")
+        self._visa.write("ARM")
+
+    def digitize(self, timeout: float) -> None:
+        """Arm a single acquisition then poll ``INR?`` bit 0 (new signal acquired) until set or ``timeout``."""
+        self._visa.write("TRMD SINGLE")
+        self._visa.write("ARM")
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            if int(self._visa.query("INR?")) & 0x1:
+                return
+            time.sleep(0.05)
+        self._visa.write("STOP")
+        raise TimeoutError(
+            f"Acquisition did not complete within {timeout}s. The trigger condition may not have been met."
+        )
+
+    def get_acquisition_state(self) -> AcquisitionState:
+        resp = self._visa.query("SAST?").strip().upper()
+        if resp.startswith("STOP"):
+            return AcquisitionState.STOPPED
+        return AcquisitionState.RUNNING
+
+    # --- Waveform data ---
+
+    def fetch_waveform(self, channel: int) -> WaveformData:
+        """Fetch the full waveform from ``channel`` over ``C{n}:WF? DAT2`` (signed 8-bit codes)."""
+        self._visa.write("WFSU SP,0,NP,0,FP,0")
+        # Check errors before the data query — a bad setup command would otherwise hang the read.
+        self.check_errors()
+
+        vdiv = float(self._visa.query(f"C{channel}:VDIV?"))
+        offset = float(self._visa.query(f"C{channel}:OFST?"))
+        timebase = float(self._visa.query("TDIV?"))
+        trigger_delay = float(self._visa.query("TRDL?"))
+        sample_rate = _parse_sample_rate(self._visa.query("SARA?"))
+
+        codes = self._visa.query_binary_values(f"C{channel}:WF? DAT2", datatype="b", container=list)
+
+        x_origin_ns = int((trigger_delay - timebase * _HORIZONTAL_DIVISIONS / 2) * 1e9)
+        x_incr_ns = int((1.0 / sample_rate) * 1e9)
+
+        times = [x_origin_ns + i * x_incr_ns for i in range(len(codes))]
+        voltages = [code * vdiv / _CODES_PER_DIV - offset for code in codes]
+
+        return WaveformData(times=times, voltages=voltages)
+
+    # --- Measurements ---
+
+    def measure(self, measurement_type: ScopeMeasurementType, channel: int) -> float:
+        """Query a built-in parameter via ``C{n}:PAVA?``; unavailable/sentinel results map to ``NaN``."""
+        param = _MEAS_TYPE_TO_SCPI[measurement_type]
+        resp = self._visa.query(f"C{channel}:PAVA? {param}")
+        try:
+            return _convert_sentinel(_parse_trailing_float(resp))
+        except ValueError:
+            return math.nan
+
+    # --- Trigger ---
+
+    def _write_trigger_select(self) -> None:
+        """Re-emit ``TRSE`` with the cached type+source (Siglent sets both in one command)."""
+        source = self._trigger_source if self._trigger_source is not None else 1
+        type_token = _TRIGGER_TYPE_TO_SCPI[self._trigger_type]
+        self._visa.write(f"TRSE {type_token},SR,C{source},HT,OFF")
+
+    def set_trigger_source(self, channel: int) -> None:
+        self._trigger_source = channel
+        self._write_trigger_select()
+
+    def set_trigger_type(self, trigger_type: TriggerType) -> None:
+        self._trigger_type = trigger_type
+        self._write_trigger_select()
+
+    def set_trigger_level(self, level: float) -> None:
+        source = self._trigger_source if self._trigger_source is not None else 1
+        self._visa.write(f"C{source}:TRLV {level:.4E}")
+
+    def set_trigger_slope(self, slope: TriggerSlope) -> None:
+        source = self._trigger_source if self._trigger_source is not None else 1
+        self._visa.write(f"C{source}:TRSL {_TRIGGER_SLOPE_TO_SCPI[slope]}")
+
+    def set_trigger_mode(self, mode: TriggerMode) -> None:
+        self._visa.write(f"TRMD {_TRIGGER_MODE_TO_SCPI[mode]}")
+
+    def force_trigger(self) -> None:
+        self._visa.write("FRTR")
+
+    def get_trigger_status(self) -> TriggerStatus:
+        resp = self._visa.query("SAST?").strip().upper()
+        return _TRIGGER_STATUS_MAP.get(resp, TriggerStatus.ARMED)
+
+    # --- File operations ---
+
+    def save_screenshot(self, filepath: str, to_instrument: bool = False) -> bytes:
+        """Transfer a screen dump (``SCDP``) to the host and write it to ``filepath``."""
+        if to_instrument:
+            raise NotImplementedError("SDS1000X-E SCDP is host-transfer only; saving to the instrument is unsupported")
+        self._visa.write("SCDP")
+        data = self._visa.read_raw()
+        with open(filepath, "wb") as f:
+            f.write(data)
+        return data
+
+    def save_settings(self, name: str, to_instrument: bool = False) -> bytes:
+        """Save the panel setup to a USB file (``STPN``) or transfer it to the host (``PNSU?``)."""
+        if to_instrument:
+            self._visa.write(f"STPN DISK,UDSK,FILE,'{name}'")
+            return b""
+        self._visa.write("PNSU?")
+        data = self._visa.read_raw()
+        with open(name, "wb") as f:
+            f.write(data)
+        return data
+
+    def load_settings(self, name: str, from_instrument: bool = False) -> None:
+        """Recall a panel setup from a USB file (``RCPN``) or push host bytes back (``PNSU``)."""
+        if from_instrument:
+            self._visa.write(f"RCPN DISK,UDSK,FILE,'{name}'")
+            return
+        with open(name, "rb") as f:
+            data = f.read()
+        self._visa.write_raw(b"PNSU " + data)

--- a/tests/scope/siglent/test_siglent_sds1000x_e_hardware.py
+++ b/tests/scope/siglent/test_siglent_sds1000x_e_hardware.py
@@ -1,0 +1,314 @@
+"""Hardware validation for Siglent SDS1104X-E via InstroScope. Self-contained; no publishers.
+
+Exercises every method SiglentSDS1000XE implements: setting roundtrips
+(vertical scale/offset, coupling, probe attenuation, timebase), sample-rate and
+status queries, acquisition control (run/stop/single/digitize),
+acquisition-mode and average-count config, waveform fetch, the eight built-in
+measurements, the full trigger surface, and host-side screenshot/settings I/O.
+
+Two check tiers: structural sanity (finite, positive, max > min, expected
+length) is always asserted; strict value checks (e.g. measured frequency ≈ the
+comp signal's 1 kHz) run only when the matching EXPECTED_* constant is set.
+
+Wiring / stimulus:
+    The scope's built-in probe-compensation square wave (~1 kHz, ~3 Vpp) is fed
+    into CH1. CH1 is the active/trigger channel. No external gear required.
+
+Run:
+    uv run python tests/scope/siglent/test_siglent_sds1000x_e_hardware.py
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import sys
+import tempfile
+import time
+from collections.abc import Callable
+
+import pytest
+
+from instro.lib.types import Command, Measurement
+from instro.unstable.scope import (
+    AcquisitionMode,
+    Coupling,
+    InstroScope,
+    ScopeMeasurementType,
+    TriggerMode,
+    TriggerSlope,
+    TriggerType,
+)
+from instro.unstable.scope.drivers.siglent import SiglentSDS1000XE
+
+# --- Configuration — edit before running -----------------------------------
+RESOURCE = "USB0::0xF4EC::0xEE38::SDSMMGKD804634::INSTR"
+NUM_CHANNELS = 4
+SIGNAL_CHANNEL = 1  # CH1 carries the ~1 kHz comp-signal square wave
+
+# Stimulus expectations (set to None to skip the corresponding strict check).
+EXPECTED_FREQUENCY_HZ: float | None = 1000.0  # comp signal default is 1 kHz
+EXPECTED_DUTY_PERCENT: float | None = 50.0  # square wave ≈ 50% duty
+
+# Tolerances
+REL_TOL = 0.05  # relative tolerance for snapped setting readbacks
+FREQ_REL_TOL = 0.10
+DUTY_ABS_TOL = 10.0  # percent
+MIN_VPP_V = 0.1  # the comp signal must show at least this much amplitude
+
+
+def _cmd_value(cmd: Command) -> float | str:
+    """Unwrap the single value a HAL command-getter packages."""
+    return next(iter(cmd.channel_data.values()))
+
+
+def _make_scope() -> InstroScope:
+    scope = InstroScope(
+        name="hw_validate",
+        driver=SiglentSDS1000XE(RESOURCE),
+        num_channels=NUM_CHANNELS,
+        publishers=None,
+    )
+    scope.open()
+    return scope
+
+
+def _run(name: str, fn: Callable[[], None], failures: list) -> None:
+    try:
+        fn()
+        print(f"  [OK]   {name}")
+    except Exception as exc:  # noqa: BLE001 - report, don't abort
+        print(f"  [FAIL] {name}: {exc}")
+        failures.append((name, exc))
+
+
+def _skip(name: str, reason: str) -> None:
+    print(f"  [SKIP] {name}: {reason}")
+
+
+def run_all() -> list:
+    scope = _make_scope()
+    failures: list = []
+    ch = SIGNAL_CHANNEL
+    try:
+        # --- Connection / bulk getters + error drain ---
+        def sync() -> None:
+            cfg = scope.sync_configuration()
+            assert cfg.channels, "sync_configuration returned no channel state"
+            vs = cfg.channels[ch].vertical_scale
+            assert vs is not None and math.isfinite(vs) and vs > 0, f"bad vertical scale: {vs}"
+
+        _run("sync_configuration (all getters + check_errors)", sync, failures)
+
+        # --- Vertical scale roundtrip ---
+        def vscale() -> None:
+            scope.set_vertical_scale(1.0, channel=ch)
+            got = scope.get_vertical_scale(channel=ch).latest
+            assert math.isclose(got, 1.0, rel_tol=REL_TOL), f"set 1.0 V/div, read {got}"
+
+        _run("vertical scale set/get roundtrip", vscale, failures)
+
+        # --- Vertical offset roundtrip ---
+        def voffset() -> None:
+            scope.set_vertical_offset(0.0, channel=ch)
+            got = scope.get_vertical_offset(channel=ch).latest
+            assert abs(got) < 0.05, f"set 0 V offset, read {got}"
+
+        _run("vertical offset set/get roundtrip", voffset, failures)
+
+        # --- Coupling roundtrip ---
+        def coupling() -> None:
+            scope.set_coupling(Coupling.DC, channel=ch)
+            assert _cmd_value(scope.get_coupling(channel=ch)) == Coupling.DC.value
+            scope.set_coupling(Coupling.AC, channel=ch)
+            assert _cmd_value(scope.get_coupling(channel=ch)) == Coupling.AC.value
+            scope.set_coupling(Coupling.DC, channel=ch)  # restore
+
+        _run("coupling set/get roundtrip (AC/DC)", coupling, failures)
+
+        # --- Probe attenuation roundtrip ---
+        def probe() -> None:
+            scope.set_probe_attenuation(10, channel=ch)
+            assert math.isclose(scope.get_probe_attenuation(channel=ch).latest, 10, rel_tol=REL_TOL)
+            scope.set_probe_attenuation(1, channel=ch)  # restore to match the direct BNC feed
+            assert math.isclose(scope.get_probe_attenuation(channel=ch).latest, 1, rel_tol=REL_TOL)
+
+        _run("probe attenuation set/get roundtrip", probe, failures)
+
+        # --- Timebase roundtrip ---
+        def timebase() -> None:
+            scope.set_horizontal_scale(2e-4)  # 200 us/div -> ~2.8 cycles of 1 kHz on screen
+            got = scope.get_horizontal_scale().latest
+            assert math.isclose(got, 2e-4, rel_tol=REL_TOL), f"set 200us/div, read {got}"
+
+        _run("horizontal scale set/get roundtrip", timebase, failures)
+
+        # --- Sample rate query ---
+        def sample_rate() -> None:
+            sr = scope.get_sample_rate().latest
+            assert math.isfinite(sr) and sr > 0, f"bad sample rate: {sr}"
+
+        _run("sample rate query (SARA?)", sample_rate, failures)
+
+        # --- Acquisition mode + average count ---
+        def acq_mode() -> None:
+            scope.run()  # the scope only applies ACQW/AVGA changes while acquiring
+            scope.set_acquisition_mode(AcquisitionMode.NORMAL)
+            assert _cmd_value(scope.get_acquisition_mode()) == AcquisitionMode.NORMAL.value
+            scope.set_acquisition_mode(AcquisitionMode.AVERAGE)
+            assert _cmd_value(scope.get_acquisition_mode()) == AcquisitionMode.AVERAGE.value
+            scope.set_average_count(16)
+            assert int(scope.get_average_count().latest) == 16
+            scope.set_acquisition_mode(AcquisitionMode.NORMAL)  # restore
+
+        _run("acquisition mode + average count", acq_mode, failures)
+
+        def acq_envelope_unsupported() -> None:
+            try:
+                scope.set_acquisition_mode(AcquisitionMode.ENVELOPE)
+            except NotImplementedError:
+                return
+            raise AssertionError("ENVELOPE mode should raise NotImplementedError on SDS1000X-E")
+
+        _run("acquisition mode ENVELOPE rejected", acq_envelope_unsupported, failures)
+
+        # --- Trigger configuration ---
+        def trigger_config() -> None:
+            scope.set_trigger_source(channel=ch)
+            scope.set_trigger_type(TriggerType.EDGE)
+            scope.set_trigger_slope(TriggerSlope.RISING)
+            scope.set_trigger_level(1.0)  # comp square wave crosses 1 V
+            scope.set_trigger_mode(TriggerMode.AUTO)
+
+        _run("trigger source/type/slope/level/mode", trigger_config, failures)
+
+        # --- run / state / stop ---
+        def run_stop() -> None:
+            scope.run()
+            time.sleep(0.3)
+            assert _cmd_value(scope.get_acquisition_state()) == "RUNNING"
+            scope.stop_acquisition()
+            time.sleep(0.2)
+            assert _cmd_value(scope.get_acquisition_state()) == "STOPPED"
+
+        _run("run -> RUNNING, stop -> STOPPED", run_stop, failures)
+
+        # --- single + digitize via fetch_waveform ---
+        def digitize_fetch() -> None:
+            # Single-shot waits for a real trigger, so the level must sit inside the signal.
+            # Learn the signal midpoint first (works regardless of probe attenuation).
+            scope.run()
+            time.sleep(0.5)
+            vmax = scope.measure(ScopeMeasurementType.VMAX, channel=ch).latest
+            vmin = scope.measure(ScopeMeasurementType.VMIN, channel=ch).latest
+            scope.set_trigger_level((vmax + vmin) / 2.0)
+            scope.set_trigger_slope(TriggerSlope.RISING)
+            scope.single()  # arms; fetch_waveform then drives driver.digitize()
+            wf: Measurement = scope.fetch_waveform(channel=ch, timeout=3.0)
+            volts = wf.values
+            assert len(volts) > 100, f"short waveform: {len(volts)} pts"
+            assert all(math.isfinite(v) for v in volts), "non-finite sample in waveform"
+            assert len(wf.timestamps) == len(volts), "timestamp/voltage length mismatch"
+            vpp = max(volts) - min(volts)
+            assert vpp > MIN_VPP_V, f"waveform Vpp {vpp:.3f} below {MIN_VPP_V} V — is CH1 driven?"
+
+        _run("single + digitize + fetch_waveform", digitize_fetch, failures)
+
+        # --- Built-in measurements ---
+        def measurements() -> None:
+            scope.run()  # free-run so PAVA? has a live acquisition
+            time.sleep(0.6)
+            results: dict[ScopeMeasurementType, float] = {}
+            for mtype in ScopeMeasurementType:
+                val = scope.measure(mtype, channel=ch).latest
+                results[mtype] = val
+                assert not math.isnan(val), f"{mtype.value} returned NaN"
+            assert results[ScopeMeasurementType.VPP] > MIN_VPP_V, f"VPP {results[ScopeMeasurementType.VPP]}"
+            if EXPECTED_FREQUENCY_HZ is not None:
+                freq = results[ScopeMeasurementType.FREQUENCY]
+                assert math.isclose(freq, EXPECTED_FREQUENCY_HZ, rel_tol=FREQ_REL_TOL), (
+                    f"frequency {freq:.1f} Hz vs expected {EXPECTED_FREQUENCY_HZ} Hz"
+                )
+            if EXPECTED_DUTY_PERCENT is not None:
+                duty = results[ScopeMeasurementType.DUTY_CYCLE]
+                assert abs(duty - EXPECTED_DUTY_PERCENT) < DUTY_ABS_TOL, (
+                    f"duty {duty:.1f}% vs expected {EXPECTED_DUTY_PERCENT}%"
+                )
+
+        _run("measure (VPP/VMAX/VMIN/VAVG/VRMS/FREQ/PERIOD/DUTY)", measurements, failures)
+
+        # --- force_trigger ---
+        def force() -> None:
+            scope.set_trigger_mode(TriggerMode.NORMAL)
+            scope.single()
+            scope.force_trigger()
+            scope.set_trigger_mode(TriggerMode.AUTO)  # restore
+
+        _run("force_trigger", force, failures)
+
+        # --- trigger status ---
+        def trigger_status() -> None:
+            scope.run()
+            time.sleep(0.2)
+            status = _cmd_value(scope.get_trigger_status())
+            assert isinstance(status, str) and status, f"bad trigger status: {status!r}"
+
+        _run("get_trigger_status", trigger_status, failures)
+
+        # --- Screenshot (host transfer) ---
+        def screenshot() -> None:
+            path = os.path.join(tempfile.gettempdir(), "sds1104xe_hw_screenshot.bin")
+            scope.save_screenshot(path)
+            assert os.path.exists(path) and os.path.getsize(path) > 0, "screenshot file empty/missing"
+            os.remove(path)
+
+        _run("save_screenshot (SCDP host transfer)", screenshot, failures)
+
+        def screenshot_to_instrument_unsupported() -> None:
+            try:
+                scope.save_screenshot("ignored.png", to_instrument=True)
+            except NotImplementedError:
+                return
+            raise AssertionError("save_screenshot(to_instrument=True) should raise NotImplementedError")
+
+        _run("save_screenshot to-instrument rejected", screenshot_to_instrument_unsupported, failures)
+
+        # --- Settings host save (PNSU? read) ---
+        def settings_save() -> None:
+            # InstroScope.save_settings returns a Command, not the bytes; verify via the written file.
+            path = os.path.join(tempfile.gettempdir(), "sds1104xe_hw_setup.bin")
+            scope.save_settings(path)
+            assert os.path.exists(path) and os.path.getsize(path) > 0, "settings file empty/missing"
+            os.remove(path)
+
+        _run("save_settings (PNSU? host read)", settings_save, failures)
+
+        # load_settings host-path issues a PNSU panel-setup write-back, which wedges this
+        # SDS1104X-E's USBTMC command interface (recovers only with a power-cycle). Do not
+        # exercise it over USB; use load_settings(from_instrument=True) with a USB stick instead.
+        _skip("load_settings (PNSU host write-back)", "PNSU write-back wedges the USBTMC interface on this unit")
+        _skip("save_settings to-instrument", "requires a USB stick mounted on the scope (UDSK)")
+
+    finally:
+        try:
+            scope.stop_acquisition()
+        except Exception:  # noqa: BLE001 - best-effort safe state
+            pass
+        scope.close()
+    return failures
+
+
+@pytest.mark.hardware
+def test_sds1104xe_hardware() -> None:
+    failures = run_all()
+    assert not failures, f"{len(failures)} hardware check(s) failed: {failures}"
+
+
+def main() -> int:
+    failures = run_all()
+    print(f"\n{'PASSED' if not failures else f'FAILED ({len(failures)} check(s))'}")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_instro_scope.py
+++ b/tests/test_instro_scope.py
@@ -492,6 +492,25 @@ def test_siglent_set_acquisition_mode_writes_scpi(siglent: SiglentSDS1000XE, sig
     siglent_visa.write.assert_called_once_with("ACQW HIGH_RES")
 
 
+def test_siglent_set_acquisition_mode_average_includes_count(
+    siglent: SiglentSDS1000XE, siglent_visa: MagicMock
+) -> None:
+    # AVERAGE is silently ignored by the scope without an inline count.
+    siglent.set_acquisition_mode(AcquisitionMode.AVERAGE)
+    siglent_visa.write.assert_called_once_with("ACQW AVERAGE,16")
+
+
+def test_siglent_set_average_count_writes_and_feeds_average_mode(
+    siglent: SiglentSDS1000XE, siglent_visa: MagicMock
+) -> None:
+    siglent.set_average_count(64)
+    siglent_visa.write.assert_called_once_with("AVGA 64")
+    siglent_visa.reset_mock()
+    # The cached count is reused as the inline AVERAGE count.
+    siglent.set_acquisition_mode(AcquisitionMode.AVERAGE)
+    siglent_visa.write.assert_called_once_with("ACQW AVERAGE,64")
+
+
 def test_siglent_acquisition_mode_envelope_rejected(siglent: SiglentSDS1000XE) -> None:
     with pytest.raises(NotImplementedError, match="ENVELOPE"):
         siglent.set_acquisition_mode(AcquisitionMode.ENVELOPE)
@@ -504,10 +523,11 @@ def test_siglent_get_acquisition_mode_parses_average_with_count(
     assert siglent.get_acquisition_mode() == AcquisitionMode.AVERAGE
 
 
-def test_siglent_run_sets_auto_and_arms(siglent: SiglentSDS1000XE, siglent_visa: MagicMock) -> None:
+def test_siglent_run_sets_auto_without_arm(siglent: SiglentSDS1000XE, siglent_visa: MagicMock) -> None:
+    # ARM would force single-shot mode, so run() must NOT send it.
     siglent.run()
     writes = [c.args[0] for c in siglent_visa.write.call_args_list]
-    assert writes == ["TRMD AUTO", "ARM"]
+    assert writes == ["TRMD AUTO"]
 
 
 def test_siglent_single_arms_single_shot(siglent: SiglentSDS1000XE, siglent_visa: MagicMock) -> None:
@@ -633,6 +653,54 @@ def test_siglent_save_settings_to_instrument_writes_stpn(siglent: SiglentSDS1000
 def test_siglent_load_settings_from_instrument_writes_rcpn(siglent: SiglentSDS1000XE, siglent_visa: MagicMock) -> None:
     siglent.load_settings("setup.set", from_instrument=True)
     siglent_visa.write.assert_called_once_with("RCPN DISK,UDSK,FILE,'setup.set'")
+
+
+def _setup_escape_hatch(visa_mock: MagicMock, raw_reply: bytes) -> MagicMock:
+    """Wire the pyvisa-resource escape hatch on the mocked transport for binary-read tests."""
+    inst = MagicMock()
+    inst.read_termination = "\n"
+    inst.read_raw.return_value = raw_reply
+    visa_mock._inst = inst
+    visa_mock.lock.return_value = _make_temp_timeout_cm()
+    return inst
+
+
+def test_siglent_save_screenshot_host_reads_full_bmp(
+    siglent: SiglentSDS1000XE, siglent_visa: MagicMock, tmp_path
+) -> None:
+    # 'BM' + 4-byte little-endian size (10) + 4 payload bytes, with a stray trailing LF to drop.
+    bmp = b"BM" + (10).to_bytes(4, "little") + b"WXYZ"
+    inst = _setup_escape_hatch(siglent_visa, bmp + b"\n")
+    path = tmp_path / "shot.bmp"
+    data = siglent.save_screenshot(str(path))
+    assert "SCDP" in [c.args[0] for c in siglent_visa.write.call_args_list]
+    inst.read_raw.assert_called_once()
+    assert data == bmp  # sliced to the declared BMP size, trailing LF dropped
+    assert path.read_bytes() == bmp
+
+
+def test_siglent_save_settings_host_reads_pnsu_block(
+    siglent: SiglentSDS1000XE, siglent_visa: MagicMock, tmp_path
+) -> None:
+    # Host path reads the full message via the escape hatch and parses the IEEE #9<len> block.
+    payload = b"hi"
+    block = b"#9" + b"%09d" % len(payload) + payload + b"\n"
+    inst = _setup_escape_hatch(siglent_visa, block)
+    path = tmp_path / "setup.bin"
+    result = siglent.save_settings(str(path), to_instrument=False)
+    assert "PNSU?" in [c.args[0] for c in siglent_visa.write.call_args_list]
+    inst.read_raw.assert_called_once()
+    assert result == payload
+    assert path.read_bytes() == payload
+
+
+def test_siglent_load_settings_host_reconstructs_block_header(
+    siglent: SiglentSDS1000XE, siglent_visa: MagicMock, tmp_path
+) -> None:
+    path = tmp_path / "setup.bin"
+    path.write_bytes(b"hello")
+    siglent.load_settings(str(path), from_instrument=False)
+    siglent_visa.write_raw.assert_called_once_with(b"PNSU #9000000005hello\n")
 
 
 # --- InstroScope composition tests ---

--- a/tests/test_instro_scope.py
+++ b/tests/test_instro_scope.py
@@ -1,7 +1,7 @@
 """Tests for the oscilloscope driver shape.
 
-Covers vendor drivers (Keysight1200X, Tektronix2SeriesMSO) owning a VisaDriver,
-and InstroScope delegating to its driver.
+Covers vendor drivers (Keysight1200X, Tektronix2SeriesMSO, SiglentSDS1000XE)
+owning a VisaDriver, and InstroScope delegating to its driver.
 """
 
 import math
@@ -13,14 +13,18 @@ import pytest
 from instro.lib.transports.visa import SerialConfig, VisaConfig
 from instro.unstable.scope import (
     AcquisitionMode,
+    AcquisitionState,
     Coupling,
     InstroScope,
     ScopeMeasurementType,
+    TriggerMode,
     TriggerSlope,
+    TriggerStatus,
     TriggerType,
 )
 from instro.unstable.scope.driver import ScopeDriverBase
 from instro.unstable.scope.drivers.keysight import Keysight1200X
+from instro.unstable.scope.drivers.siglent import SiglentSDS1000XE
 from instro.unstable.scope.drivers.tektronix import Tektronix2SeriesMSO
 
 
@@ -375,6 +379,260 @@ def test_tektronix_digitize_raises_timeout_and_clears(
         tektronix.digitize(timeout=0.1)
 
     tektronix_visa.clear.assert_called_once()
+
+
+# --- SiglentSDS1000XE unit tests ---
+
+
+@pytest.fixture
+def siglent_visa_cls() -> Iterator[MagicMock]:
+    with patch("instro.unstable.scope.drivers.siglent.siglent_sds1000x_e.VisaDriver", autospec=True) as driver_cls:
+        yield driver_cls
+
+
+@pytest.fixture
+def siglent_visa(siglent_visa_cls: MagicMock) -> MagicMock:
+    visa = siglent_visa_cls.return_value
+    visa.query.return_value = "0"  # default: CMR?/EXR? report no error
+    visa.temporary_timeout.return_value = _make_temp_timeout_cm()
+    return visa
+
+
+@pytest.fixture
+def siglent(siglent_visa_cls: MagicMock, siglent_visa: MagicMock) -> SiglentSDS1000XE:
+    return SiglentSDS1000XE("TCPIP0::192.168.1.10::INSTR")
+
+
+def test_siglent_init_passes_resource_to_visa(siglent_visa_cls: MagicMock) -> None:
+    SiglentSDS1000XE("TCPIP0::192.168.1.10::INSTR")
+    siglent_visa_cls.assert_called_once_with("TCPIP0::192.168.1.10::INSTR")
+
+
+def test_siglent_init_accepts_prebuilt_visa_config(siglent_visa_cls: MagicMock) -> None:
+    config = VisaConfig(visa_resource="ASRL3::INSTR", serial_config=SerialConfig(baud_rate=115_200))
+    SiglentSDS1000XE(config)
+    siglent_visa_cls.assert_called_once_with(config)
+
+
+def test_siglent_open_disables_headers_and_clears(siglent: SiglentSDS1000XE, siglent_visa: MagicMock) -> None:
+    siglent.open()
+    siglent_visa.open.assert_called_once()
+    writes = [c.args[0] for c in siglent_visa.write.call_args_list]
+    assert writes == ["CHDR OFF", "*CLS"]
+
+
+def test_siglent_close_delegates(siglent: SiglentSDS1000XE, siglent_visa: MagicMock) -> None:
+    siglent.close()
+    siglent_visa.close.assert_called_once()
+
+
+def test_siglent_check_errors_passes_on_zero(siglent: SiglentSDS1000XE, siglent_visa: MagicMock) -> None:
+    siglent_visa.query.return_value = "0"
+    siglent.check_errors()
+    queries = [c.args[0] for c in siglent_visa.query.call_args_list]
+    assert queries == ["CMR?", "EXR?"]
+
+
+def test_siglent_check_errors_raises_on_command_error(siglent: SiglentSDS1000XE, siglent_visa: MagicMock) -> None:
+    siglent_visa.query.return_value = "1"
+    with pytest.raises(RuntimeError, match="Siglent command error 1"):
+        siglent.check_errors()
+
+
+def test_siglent_check_errors_raises_on_execution_error(siglent: SiglentSDS1000XE, siglent_visa: MagicMock) -> None:
+    # CMR? clean, EXR? reports an execution fault.
+    siglent_visa.query.side_effect = ["0", "26"]
+    with pytest.raises(RuntimeError, match="Siglent execution error 26"):
+        siglent.check_errors()
+
+
+def test_siglent_set_vertical_scale_writes_scpi(siglent: SiglentSDS1000XE, siglent_visa: MagicMock) -> None:
+    siglent.set_vertical_scale(0.05, channel=2)
+    siglent_visa.write.assert_called_once_with("C2:VDIV 5.0000E-02")
+
+
+def test_siglent_get_vertical_scale_parses_float(siglent: SiglentSDS1000XE, siglent_visa: MagicMock) -> None:
+    siglent_visa.query.return_value = "2.00E-01"
+    assert siglent.get_vertical_scale(1) == pytest.approx(0.2)
+    siglent_visa.query.assert_called_once_with("C1:VDIV?")
+
+
+def test_siglent_set_coupling_maps_to_impedance_token(siglent: SiglentSDS1000XE, siglent_visa: MagicMock) -> None:
+    siglent.set_coupling(Coupling.AC, channel=1)
+    siglent_visa.write.assert_called_once_with("C1:CPL A1M")
+
+
+def test_siglent_get_coupling_parses_token(siglent: SiglentSDS1000XE, siglent_visa: MagicMock) -> None:
+    siglent_visa.query.return_value = "D1M"
+    assert siglent.get_coupling(3) == Coupling.DC
+
+
+def test_siglent_set_probe_attenuation_writes_scpi(siglent: SiglentSDS1000XE, siglent_visa: MagicMock) -> None:
+    siglent.set_probe_attenuation(10, channel=4)
+    siglent_visa.write.assert_called_once_with("C4:ATTN 10")
+
+
+def test_siglent_set_horizontal_scale_writes_scpi(siglent: SiglentSDS1000XE, siglent_visa: MagicMock) -> None:
+    siglent.set_horizontal_scale(5e-4)
+    siglent_visa.write.assert_called_once_with("TDIV 5.0000E-04")
+
+
+def test_siglent_get_sample_rate_parses_si_suffix(siglent: SiglentSDS1000XE, siglent_visa: MagicMock) -> None:
+    siglent_visa.query.return_value = "1.00GSa/s"
+    assert siglent.get_sample_rate() == pytest.approx(1e9)
+
+
+def test_siglent_get_sample_rate_parses_bare_float(siglent: SiglentSDS1000XE, siglent_visa: MagicMock) -> None:
+    siglent_visa.query.return_value = "5.00E+08"
+    assert siglent.get_sample_rate() == pytest.approx(5e8)
+
+
+def test_siglent_set_acquisition_mode_writes_scpi(siglent: SiglentSDS1000XE, siglent_visa: MagicMock) -> None:
+    siglent.set_acquisition_mode(AcquisitionMode.HIGH_RESOLUTION)
+    siglent_visa.write.assert_called_once_with("ACQW HIGH_RES")
+
+
+def test_siglent_acquisition_mode_envelope_rejected(siglent: SiglentSDS1000XE) -> None:
+    with pytest.raises(NotImplementedError, match="ENVELOPE"):
+        siglent.set_acquisition_mode(AcquisitionMode.ENVELOPE)
+
+
+def test_siglent_get_acquisition_mode_parses_average_with_count(
+    siglent: SiglentSDS1000XE, siglent_visa: MagicMock
+) -> None:
+    siglent_visa.query.return_value = "AVERAGE,16"
+    assert siglent.get_acquisition_mode() == AcquisitionMode.AVERAGE
+
+
+def test_siglent_run_sets_auto_and_arms(siglent: SiglentSDS1000XE, siglent_visa: MagicMock) -> None:
+    siglent.run()
+    writes = [c.args[0] for c in siglent_visa.write.call_args_list]
+    assert writes == ["TRMD AUTO", "ARM"]
+
+
+def test_siglent_single_arms_single_shot(siglent: SiglentSDS1000XE, siglent_visa: MagicMock) -> None:
+    siglent.single()
+    writes = [c.args[0] for c in siglent_visa.write.call_args_list]
+    assert writes == ["TRMD SINGLE", "ARM"]
+
+
+def test_siglent_digitize_returns_when_inr_bit_set(siglent: SiglentSDS1000XE, siglent_visa: MagicMock) -> None:
+    siglent_visa.query.return_value = "1"  # INR? bit 0 set immediately
+    siglent.digitize(timeout=1.0)
+    writes = [c.args[0] for c in siglent_visa.write.call_args_list]
+    assert writes == ["TRMD SINGLE", "ARM"]
+    siglent_visa.query.assert_called_with("INR?")
+
+
+def test_siglent_digitize_times_out_and_stops(siglent: SiglentSDS1000XE, siglent_visa: MagicMock) -> None:
+    with pytest.raises(TimeoutError, match="did not complete"):
+        siglent.digitize(timeout=0.0)
+    assert siglent_visa.write.call_args_list[-1].args[0] == "STOP"
+
+
+def test_siglent_get_acquisition_state_stopped(siglent: SiglentSDS1000XE, siglent_visa: MagicMock) -> None:
+    siglent_visa.query.return_value = "Stop"
+    assert siglent.get_acquisition_state() == AcquisitionState.STOPPED
+
+
+def test_siglent_get_acquisition_state_running(siglent: SiglentSDS1000XE, siglent_visa: MagicMock) -> None:
+    siglent_visa.query.return_value = "Trig'd"
+    assert siglent.get_acquisition_state() == AcquisitionState.RUNNING
+
+
+def test_siglent_fetch_waveform_converts_codes(siglent: SiglentSDS1000XE, siglent_visa: MagicMock) -> None:
+    # CMR?, EXR? (check_errors), then VDIV?, OFST?, TDIV?, TRDL?, SARA?.
+    siglent_visa.query.side_effect = ["0", "0", "0.5", "-0.5", "5.00E-09", "-5.00E-09", "1.00GSa/s"]
+    siglent_visa.query_binary_values.return_value = [2, 4, -3]
+
+    waveform = siglent.fetch_waveform(channel=1)
+
+    siglent_visa.query_binary_values.assert_called_once_with("C1:WF? DAT2", datatype="b", container=list)
+    # voltage = code * vdiv/25 - offset; code=2 -> 2*0.02 + 0.5 = 0.54
+    assert waveform.voltages[0] == pytest.approx(0.54)
+    assert len(waveform.times) == 3
+    # 1 GSa/s -> 1 ns interval
+    assert waveform.times[1] - waveform.times[0] == 1
+
+
+def test_siglent_measure_vpp_queries_pava(siglent: SiglentSDS1000XE, siglent_visa: MagicMock) -> None:
+    siglent_visa.query.return_value = "PKPK,1.23E+00V"
+    result = siglent.measure(ScopeMeasurementType.VPP, channel=1)
+    assert result == pytest.approx(1.23)
+    siglent_visa.query.assert_called_once_with("C1:PAVA? PKPK")
+
+
+def test_siglent_measure_returns_nan_on_non_numeric(siglent: SiglentSDS1000XE, siglent_visa: MagicMock) -> None:
+    siglent_visa.query.return_value = "PKPK,****"
+    assert math.isnan(siglent.measure(ScopeMeasurementType.VPP, channel=1))
+
+
+def test_siglent_measure_returns_nan_on_sentinel(siglent: SiglentSDS1000XE, siglent_visa: MagicMock) -> None:
+    siglent_visa.query.return_value = "FREQ,9.91E+37Hz"
+    assert math.isnan(siglent.measure(ScopeMeasurementType.FREQUENCY, channel=1))
+
+
+def test_siglent_set_trigger_source_emits_trse_and_caches(siglent: SiglentSDS1000XE, siglent_visa: MagicMock) -> None:
+    siglent.set_trigger_source(3)
+    assert siglent._trigger_source == 3
+    siglent_visa.write.assert_called_once_with("TRSE EDGE,SR,C3,HT,OFF")
+
+
+def test_siglent_set_trigger_type_pulse_maps_to_glit(siglent: SiglentSDS1000XE, siglent_visa: MagicMock) -> None:
+    siglent.set_trigger_source(2)
+    siglent_visa.reset_mock()
+    siglent.set_trigger_type(TriggerType.PULSE)
+    siglent_visa.write.assert_called_once_with("TRSE GLIT,SR,C2,HT,OFF")
+
+
+def test_siglent_set_trigger_level_uses_cached_source(siglent: SiglentSDS1000XE, siglent_visa: MagicMock) -> None:
+    siglent.set_trigger_source(2)
+    siglent_visa.reset_mock()
+    siglent.set_trigger_level(0.75)
+    siglent_visa.write.assert_called_once_with("C2:TRLV 7.5000E-01")
+
+
+def test_siglent_set_trigger_level_defaults_to_ch1(siglent: SiglentSDS1000XE, siglent_visa: MagicMock) -> None:
+    siglent.set_trigger_level(0.0)
+    siglent_visa.write.assert_called_once_with("C1:TRLV 0.0000E+00")
+
+
+def test_siglent_set_trigger_slope_uses_cached_source(siglent: SiglentSDS1000XE, siglent_visa: MagicMock) -> None:
+    siglent.set_trigger_source(4)
+    siglent_visa.reset_mock()
+    siglent.set_trigger_slope(TriggerSlope.FALLING)
+    siglent_visa.write.assert_called_once_with("C4:TRSL NEG")
+
+
+def test_siglent_set_trigger_mode_writes_scpi(siglent: SiglentSDS1000XE, siglent_visa: MagicMock) -> None:
+    siglent.set_trigger_mode(TriggerMode.NORMAL)
+    siglent_visa.write.assert_called_once_with("TRMD NORM")
+
+
+def test_siglent_force_trigger_writes_frtr(siglent: SiglentSDS1000XE, siglent_visa: MagicMock) -> None:
+    siglent.force_trigger()
+    siglent_visa.write.assert_called_once_with("FRTR")
+
+
+def test_siglent_get_trigger_status_maps_token(siglent: SiglentSDS1000XE, siglent_visa: MagicMock) -> None:
+    siglent_visa.query.return_value = "Trig'd"
+    assert siglent.get_trigger_status() == TriggerStatus.TRIGGERED
+
+
+def test_siglent_save_screenshot_to_instrument_unsupported(siglent: SiglentSDS1000XE) -> None:
+    with pytest.raises(NotImplementedError, match="host-transfer only"):
+        siglent.save_screenshot("scope.png", to_instrument=True)
+
+
+def test_siglent_save_settings_to_instrument_writes_stpn(siglent: SiglentSDS1000XE, siglent_visa: MagicMock) -> None:
+    result = siglent.save_settings("setup.set", to_instrument=True)
+    siglent_visa.write.assert_called_once_with("STPN DISK,UDSK,FILE,'setup.set'")
+    assert result == b""
+
+
+def test_siglent_load_settings_from_instrument_writes_rcpn(siglent: SiglentSDS1000XE, siglent_visa: MagicMock) -> None:
+    siglent.load_settings("setup.set", from_instrument=True)
+    siglent_visa.write.assert_called_once_with("RCPN DISK,UDSK,FILE,'setup.set'")
 
 
 # --- InstroScope composition tests ---


### PR DESCRIPTION
Adds a `ScopeDriverBase` driver for the **Siglent SDS 1104X-E** (SDS1000X-E series) under `instro-unstable`, scaffolded with the `add-instrument-driver` skill and confirmed against a real unit with the `validate-driver-hardware` skill.

Closes #72.

> **Stacked on #63** (the driver-scaffolding skill). Based on `issue-60-add-driver-skill` so this PR's diff is just the driver; GitHub will retarget it to `main` automatically once #63 merges. Review/merge #63 first.

## What's here
- `SiglentSDS1000XE` driver (`packages/instro-unstable/.../scope/drivers/siglent/`) + vendor-subpackage registration.
- Mocked-transport unit tests in `tests/test_instro_scope.py`.
- A standalone, no-publisher `@pytest.mark.hardware` validation script (`tests/scope/siglent/`).
- README "Experimental modules" entry.

Uses the legacy Siglent SCPI dialect (`C1:VDIV`, `PAVA?`, `TRSE`, `C1:WF? DAT2`); disables comm headers in `open()`; polls `CMR?`/`EXR?` for errors (no error queue).

## Hardware-confirmed
Validated against a physical SDS1104X-E (`*IDN?` → `Siglent Technologies,SDS1104X-E`), **18/18 active checks pass**. The hardware run surfaced and fixed 5 real bugs the mocked tests couldn't:

| Bug | Fix |
|---|---|
| `run()` sent `ARM` after `TRMD AUTO` → forced single-shot, never free-ran | `TRMD AUTO` only |
| `set_acquisition_mode(AVERAGE)` silently ignored | send `ACQW AVERAGE,<count>` inline + track count |
| `fetch_waveform` left the block's trailing LF → desynced next query | drain it |
| `save_screenshot` (raw BMP) + host `save_settings` (PNSU block) truncated at first LF by `read_raw` | read full message with terminator disabled (pyvisa escape hatch) + parse length header |

Also documented two hardware behaviors: ACQW/AVGA only apply while acquiring (validation runs them under `run()`), and host PNSU panel-setup **write-back wedges this unit's USBTMC interface**. `load_settings` host-path is documented with that caveat and skipped in hardware validation (use `from_instrument=True` with a USB stick).

No change to shared lib core (`visa.py`): length-aware binary reads use the documented VISA escape hatch (`self._visa._inst` under `self._visa.lock()`).

## CI
`just check` and `just test` pass (476 passed, hardware test deselected). The hardware test is `@pytest.mark.hardware` and **does not run in CI** by design — the driver was confirmed against a real unit locally.