### PR TITLE
fix(lib,daq): make Instrument start/stop/start restartable

### DIFF
--- a/instro/daq/daq.py
+++ b/instro/daq/daq.py
@@ -853,7 +853,8 @@ class InstroDAQ(Instrument):
 
     def _define_background_daemon(self):
         """Register ``_fetch_analog`` as the daemon function when AI channels exist."""
-        if self.ai_channels:
+        already_registered = any(method == self._fetch_analog for method, _, _ in self._background_methods)
+        if self.ai_channels and not already_registered:
             self.add_background_daemon_function(self._fetch_analog)
 
     def get_actual_sample_rate(self) -> float | None:

--- a/instro/lib/instrument.py
+++ b/instro/lib/instrument.py
@@ -243,12 +243,12 @@ class Instrument:
         self._background_methods.append((method, args, kwargs))
 
     def _setup_channel_buffer(self, buffer_length: int):
-        # Create a channel buffer if one doesn't alredy exist. Add it to list of publishers.
-        self._channel_buffer = (
-            DequeInMemoryPublisher(self._channel_buffer_length) if not self._channel_buffer else self._channel_buffer
-        )
-        logger.info("Setting up channel buffer for instrument '%s' (length=%d)", self.name, buffer_length)
-        self.add_publisher(self._channel_buffer)
+        # Create a channel buffer if one doesn't already exist. Add it to list of publishers.
+        if self._channel_buffer is None:
+            self._channel_buffer = DequeInMemoryPublisher(buffer_length)
+        if self._channel_buffer not in self.publishers:
+            logger.info("Setting up channel buffer for instrument '%s' (length=%d)", self.name, buffer_length)
+            self.add_publisher(self._channel_buffer)
 
     def start(self):
         """Start the background daemon thread. No-op if already running."""
@@ -278,9 +278,13 @@ class Instrument:
             self._background_stop_event.set()
             self._background_thread.join()
 
-            # Clear out the channel_buffer
+            # close() wakes blocked get_channel() waiters but is one-way, so drop the
+            # buffer entirely; the next start() builds and registers a fresh one.
             assert self._channel_buffer
             self._channel_buffer.close()
+            if self._channel_buffer in self.publishers:
+                self.publishers.remove(self._channel_buffer)
+            self._channel_buffer = None
             logger.info("Stopped background daemon for instrument '%s'", self.name)
         else:
             logger.info("Background daemon not running for instrument '%s'; stop() is a no-op", self.name)

--- a/tests/daq/test_daq_drivers.py
+++ b/tests/daq/test_daq_drivers.py
@@ -695,6 +695,20 @@ def test_start_background_false_read_analog_fetches_from_buffer():
     mock_driver.fetch_analog.assert_called_once()
 
 
+def test_restart_registers_background_fetch_exactly_once():
+    """start() after stop() must not register a second _fetch_analog daemon function."""
+    daq, _ = _hw_timed_daq()
+    try:
+        daq.start()
+        daq.stop()
+        daq.start()
+
+        fetchers = [method for method, _, _ in daq._background_methods if method == daq._fetch_analog]
+        assert len(fetchers) == 1
+    finally:
+        daq.stop()
+
+
 def test_start_default_spins_daemon_and_read_analog_raises():
     """Default start() spins the daemon, which owns the buffer; a manual read_analog() then raises."""
     daq, _ = _hw_timed_daq()

--- a/tests/lib/test_instrumentation.py
+++ b/tests/lib/test_instrumentation.py
@@ -1,8 +1,19 @@
+import time
 from importlib.metadata import version
 
 from instro.lib import Instrument
+from instro.lib.publishers.channel_buffer import DequeInMemoryPublisher
+from instro.lib.types import BackgroundDaemonConfig, Measurement
 from instro.psu import InstroPSU
 from instro.psu.drivers import SimulatedPSU
+
+
+def _make_publishing_instrument() -> Instrument:
+    instrument = Instrument(name="ut", background_config=BackgroundDaemonConfig(interval=0.01))
+    instrument.add_background_daemon_function(
+        lambda: instrument.publish(Measurement(channel_data={"ut.v": [1.0]}, timestamps=[time.time_ns()]))
+    )
+    return instrument
 
 
 def test_default_tag_set_base_class():
@@ -40,6 +51,43 @@ def test_context_manager_calls_open_and_close():
         assert isinstance(probe, Probe)
         assert calls == ["open"]
     assert calls == ["open", "close"]
+
+
+def test_get_channel_works_after_restart():
+    instrument = _make_publishing_instrument()
+    try:
+        instrument.start()
+        assert instrument.get_channel("ut.v").channel_data == {"ut.v": [1.0]}
+        instrument.stop()
+
+        instrument.start()
+        assert instrument.get_channel("ut.v").channel_data == {"ut.v": [1.0]}
+    finally:
+        instrument.stop()
+
+
+def test_restart_registers_exactly_one_channel_buffer_publisher():
+    instrument = _make_publishing_instrument()
+    try:
+        instrument.start()
+        instrument.stop()
+        instrument.start()
+
+        buffers = [p for p in instrument.publishers if isinstance(p, DequeInMemoryPublisher)]
+        assert len(buffers) == 1
+        assert buffers[0] is instrument._channel_buffer
+    finally:
+        instrument.stop()
+
+
+def test_stop_removes_channel_buffer_publisher():
+    instrument = _make_publishing_instrument()
+    instrument.start()
+
+    instrument.stop()
+
+    assert instrument._channel_buffer is None
+    assert not any(isinstance(p, DequeInMemoryPublisher) for p in instrument.publishers)
 
 
 def test_context_manager_closes_on_exception():


### PR DESCRIPTION
Fixes #80

## What

Makes `start()` → `stop()` → `start()` work on `Instrument` and `InstroDAQ`:

- `Instrument.stop()` now removes the channel buffer from `self.publishers` and drops the reference after closing it. `close()` still runs first so any `get_channel(wait_for_latest=True)` waiters wake up, but since it is one-way (`_closed` can never be unset), the buffer is no longer reusable afterward — the next `start()` builds a fresh one.
- `Instrument._setup_channel_buffer()` only registers the buffer if it is not already a publisher, and uses its `buffer_length` parameter (it was previously ignored in favor of the attribute).
- `InstroDAQ._define_background_daemon()` registers `_fetch_analog` only if it is not already in `_background_methods`, so a restart does not double the fetch rate. User-added daemon functions are untouched.

## Why

Previously, after a single restart:

- `get_channel()` raised `ValueError: Publisher is closed` forever — `stop()` closed the buffer but kept it, and the next `start()` re-registered the dead buffer as an *additional* publisher (N restarts → N+1 copies in `self.publishers`).
- A restarted `InstroDAQ` fetched and published every buffered batch twice per daemon iteration, because `start()` appended `_fetch_analog` again each time.

Pausing acquisition and resuming (reconfigure, exclusive access, test phases) is a normal workflow, so this was a pre-1.0 blocker.

## Verification

- Live repro: an `Instrument` with a publishing daemon function. Before: second `start()` left `publishers == [DequeInMemoryPublisher, DequeInMemoryPublisher]` and `get_channel` raised `ValueError`. After: one buffer, one daemon method, `get_channel` returns data.
- New regression tests: `test_get_channel_works_after_restart`, `test_restart_registers_exactly_one_channel_buffer_publisher`, `test_stop_removes_channel_buffer_publisher` (tests/lib), `test_restart_registers_background_fetch_exactly_once` (tests/daq).
- `just check` and `just test` pass (554 tests, mypy and ruff clean).
