### PR TITLE
fix(daq): stop kwarg crash and samples_per_channel=0 below 10 Hz

### DIFF
--- a/instro/daq/daq.py
+++ b/instro/daq/daq.py
@@ -510,7 +510,7 @@ class InstroDAQ(Instrument):
                 defaults to 10 % of ``sample_rate`` (e.g. 100 at 1 kHz).
         """
         if not samples_per_channel:
-            samples_per_channel = int(sample_rate // 10)
+            samples_per_channel = max(1, int(sample_rate // 10))
 
         hw_timing_config = HWTimingConfig(
             sample_rate=sample_rate,
@@ -552,7 +552,7 @@ class InstroDAQ(Instrument):
     def stop(self, **kwargs):
         """Stop the DAQ device."""
         super().stop()
-        channel_type = kwargs.get("channel_type", None)
+        channel_type = kwargs.pop("channel_type", None)
         self._driver.stop(channel_type=channel_type, **kwargs)
 
     def read_analog(

--- a/tests/daq/test_daq_drivers.py
+++ b/tests/daq/test_daq_drivers.py
@@ -662,6 +662,26 @@ def test_channels_property_returns_immutable_tuple():
     assert {ch.alias for ch in daq.channels} == {"do0"}
 
 
+def test_stop_with_channel_type_forwards_kwarg_once():
+    """stop(channel_type=...) must not pass channel_type both explicitly and via **kwargs."""
+    mock_driver = _make_mock_driver()
+    daq = InstroDAQ(name="ut", driver=mock_driver)
+
+    daq.stop(channel_type="analog_input")
+
+    mock_driver.stop.assert_called_once_with(channel_type="analog_input")
+
+
+def test_configure_ai_sample_rate_below_10hz_floors_samples_per_channel():
+    """The samples_per_channel default must never be 0; sub-10 Hz rates floor at 1."""
+    daq = InstroDAQ(name="ut", driver=_make_mock_driver())
+
+    daq.configure_ai_sample_rate(sample_rate=1.0)
+
+    assert daq.ai_hw_timing_config is not None
+    assert daq.ai_hw_timing_config.samples_per_channel == 1
+
+
 # --- start(background=...) and read_analog dispatch ---
 
 


### PR DESCRIPTION
Fixes #82

## What

Two one-line DAQ HAL fixes, each with a regression test:

- `InstroDAQ.stop(channel_type=...)`: `kwargs.get` → `kwargs.pop`. Previously `channel_type` was forwarded to the driver both explicitly and via `**kwargs`, so the NI per-task stop always raised `TypeError: got multiple values for keyword argument 'channel_type'`.
- `configure_ai_sample_rate`: the `samples_per_channel` default is now `max(1, int(sample_rate // 10))`. Below 10 Hz the old default was 0, which the vendor drivers fail on in three different ways (LJM `eStreamStart` error, NI `IndexError`, Keysight spins). LabJack supports stream rates down to 0.016 Hz, so this is reachable config.

## Scope note

The issue originally included a third item (DMM/eload mode state ordering); it was dropped as by-design — the HAL intentionally records commanded intent before the driver call.

## Verification

- New tests: `test_stop_with_channel_type_forwards_kwarg_once` (fails with `TypeError` before the fix) and `test_configure_ai_sample_rate_below_10hz_floors_samples_per_channel` (asserts the recorded `HWTimingConfig.samples_per_channel == 1` at 1 Hz).
- `just check` and `just test` pass (557 tests, mypy and ruff clean).
