### PR TITLE
fix(dmm): accept the Keithley 2400 signed +0 no-error reply

### DIFF
--- a/instro/dmm/drivers/keithley_2400.py
+++ b/instro/dmm/drivers/keithley_2400.py
@@ -152,6 +152,7 @@ class Keithley2400(DMMDriverBase):
         err = self._visa.query(":SYST:ERR?")
         parts = err.strip().split(",", 1)
         code_str = parts[0] if parts else ""
-        code_val = int(code_str) if code_str.lstrip("-").isdigit() else -1
+        # The 2400 signs the no-error code: +0,"No error" (User's Manual Appendix B, Table B-1).
+        code_val = int(code_str) if code_str.lstrip("-+").isdigit() else -1
         if code_val != 0:
             raise RuntimeError(f"Keithley 2400 reported error: {err.strip()}")

--- a/tests/dmm/test_instro_dmm.py
+++ b/tests/dmm/test_instro_dmm.py
@@ -201,6 +201,11 @@ def test_keithley_measure_dc_voltage_parses_first_field(keithley: Keithley2400, 
     assert keithley.measure_dc_voltage() == pytest.approx(1.234)
 
 
+def test_keithley_check_errors_passes_on_signed_zero(keithley: Keithley2400, keithley_visa: MagicMock) -> None:
+    keithley_visa.query.return_value = '+0,"No error"'
+    keithley._check_errors()
+
+
 def test_keithley_check_errors_raises_on_nonzero(keithley: Keithley2400, keithley_visa: MagicMock) -> None:
     keithley_visa.query.return_value = '-100,"Command error"'
     with pytest.raises(RuntimeError, match="Keithley 2400 reported error"):


### PR DESCRIPTION
Fixes #84

## What

`Keithley2400._check_errors` now strips `-+` (was `-`) before the `isdigit()` validity check, so the instrument's signed no-error reply `+0,"No error"` parses as code 0 instead of falling back to `-1` and raising.

## Why

The 2400 signs its error codes: per the [2400 Series User's Manual](https://download.tek.com/manual/2400S-900-01_K-Sep2011_User.pdf) Appendix B, "positive (+) numbers are used for Keithley defined messages", and Table B-1 lists the no-error entry as `+000 No error`. With `lstrip("-")` the healthy reply failed `isdigit()`, so **every checked command raised** `RuntimeError: Keithley 2400 reported error: +0,"No error"` against real hardware. The mocked unit tests replied with an unsigned `0,"No error"` and never saw it.

`agilent_a34401a.py` already uses `lstrip("-+")` for the same convention. The change parses both `0` and `+0`, so firmware returning an unsigned code cannot regress.

## Verification

- New regression test `test_keithley_check_errors_passes_on_signed_zero` (fails before the fix).
- `just check` and `just test` pass (556 tests, mypy and ruff clean).
