### PR TITLE
docs(daq): document multi-task NI via multiple InstroDAQ instances

### DIFF
--- a/docs/guides/docs.json
+++ b/docs/guides/docs.json
@@ -43,7 +43,8 @@
               "instrumentation/psu",
               "instrumentation/eload",
               "instrumentation/dmm",
-              "instrumentation/daq"
+              "instrumentation/daq",
+              "instrumentation/daq-ni-multi-task"
             ]
           },
           {
@@ -98,7 +99,8 @@
               "instrumentation/examples/daq/daq_write_analog_sw_timed",
               "instrumentation/examples/daq/daq_write_digital_line",
               "instrumentation/examples/daq/daq_read_digital_port",
-              "instrumentation/examples/daq/daq_write_digital_port"
+              "instrumentation/examples/daq/daq_write_digital_port",
+              "instrumentation/examples/daq/daq_multi_rate_ni"
             ]
           },
           {

--- a/docs/guides/instrumentation/daq-ni-multi-task.mdx
+++ b/docs/guides/instrumentation/daq-ni-multi-task.mdx
@@ -1,0 +1,87 @@
+---
+title: Multiple InstroDAQ instances on NI
+description: Run multi-task, multi-rate NI DAQmx acquisitions with one InstroDAQ instance per task
+---
+
+One `InstroDAQ` instance drives one `NIDAQDriver`, and that driver owns one NI DAQmx task per subsystem (analog input, digital input, digital output). The analog input task carries a single hardware sample rate. To run more than one acquisition at a time (more than one task, or more than one hardware sample rate), create multiple `InstroDAQ` instances: one per task, each with its own `NIDAQDriver`.
+
+This is the supported pattern. `instro` has no task framework or task-level API; multiple tasks means multiple `InstroDAQ` instances.
+
+## When to use this pattern
+
+- **Multiple hardware sample rates.** A single analog input task samples every channel at one rate. To sample a vibration sensor at 10 kHz and a temperature sensor at 10 Hz, give each its own instance.
+- **Independent lifecycles.** Each instance starts, stops, and closes on its own. Stop a short acquisition while a long one keeps running.
+- **Separate publishing.** Each instance has its own `name` (the channel prefix) and its own publishers, so each acquisition can target a different dataset.
+
+## Constructing the instances
+
+Give each instance its own `NIDAQDriver` and a unique `name`. Each driver targets one DAQmx device by `device_id`; on a CompactDAQ chassis, each module is its own DAQmx device (`cDAQ1Mod1`, `cDAQ1Mod2`, ...), so two instances run two tasks on the same chassis:
+
+```python
+from instro.daq import InstroDAQ
+from instro.daq.drivers.ni import NIDAQDriver
+
+daq_fast = InstroDAQ(name="daqFast", driver=NIDAQDriver(device_id="cDAQ1Mod1"))
+daq_slow = InstroDAQ(name="daqSlow", driver=NIDAQDriver(device_id="cDAQ1Mod2"))
+```
+
+Do not share one `NIDAQDriver` between two `InstroDAQ` instances. The driver is the single source of truth for its channels and timing, and two HALs mutating one task set will conflict.
+
+## Allocating channels across instances
+
+- **A physical channel belongs to exactly one instance.** DAQmx reserves a physical channel for the task that configures it; configuring `cDAQ1Mod1/ai0` on two instances fails when the second task starts.
+- **Each hardware-timed analog input task needs its own DAQmx device.** Give each instance a `device_id` that no other instance uses for the same subsystem. On a cDAQ chassis that means one instance per module: the chassis timing engines run the modules' analog input tasks concurrently, each at its own rate. On a multifunction device (USB or PCIe X Series, for example), the whole device is one DAQmx device with one analog input timing engine, so a second hardware-timed analog input task on the same `device_id` fails with a DAQmx reserved-resource error (for example error -50103).
+- **One device can also be split across instances by subsystem.** Analog input, analog output, digital input, and digital output have independent timing engines, so one instance can own a device's analog input while another owns its digital lines. The driver names its DAQmx tasks `{device_id}_{subsystem}`, so two instances on the same `device_id` must not configure the same subsystem; the second task creation fails because DAQmx task names are unique per process.
+
+```python
+from instro.daq.types import Direction
+
+# Channels are allocated per instance, with no overlap.
+daq_fast.configure_analog_channel(
+    direction=Direction.INPUT, physical_channel="cDAQ1Mod1/ai0", alias="vibration", range_min=-5, range_max=5
+)
+daq_slow.configure_analog_channel(
+    direction=Direction.INPUT, physical_channel="cDAQ1Mod2/ai0", alias="temperature", range_min=0, range_max=5
+)
+
+# Each instance carries its own hardware sample rate.
+daq_fast.configure_ai_sample_rate(sample_rate=10000)
+daq_slow.configure_ai_sample_rate(sample_rate=10)
+```
+
+## Lifecycle per instance
+
+Each instance follows the normal [InstroDAQ lifecycle](/instrumentation/daq#lifecycle-pattern) on its own: `open()`, configure, `start()`, read, `stop()`, `close()`. `start()` launches that instance's own background daemon, so the two acquisitions fetch and publish concurrently without coordinating.
+
+```python
+daq_fast.open()
+daq_slow.open()
+
+try:
+    # ... configure channels and sample rates per instance ...
+
+    daq_fast.start()
+    daq_slow.start()
+
+    fast_data = daq_fast.get_channel("daqFast.vibration", 100, True)
+    slow_data = daq_slow.get_channel("daqSlow.temperature", 1, False)
+
+    # Stopping one acquisition does not affect the other.
+    daq_fast.stop()
+    daq_slow.stop()
+finally:
+    daq_fast.close()
+    daq_slow.close()
+```
+
+<Warning>
+**NI constraints to respect across instances**
+
+- One hardware-timed analog input task per DAQmx device: on cDAQ, one instance per module; on multifunction devices, one analog input instance per device.
+- cDAQ chassis have a fixed number of analog input timing engines (three on cDAQ-917x), which caps the number of concurrent hardware-timed analog input tasks per chassis.
+- A physical channel can be reserved by only one task at a time: never configure the same physical channel on two instances.
+- On one `device_id`, give each instance a different subsystem (analog input vs digital, for example). Two instances configuring the same subsystem on one `device_id` collide on the DAQmx task.
+- Per-device aggregate sample rate limits still apply: splitting channels across instances does not raise a multiplexed module's total throughput.
+</Warning>
+
+See the full runnable example: [NI multi-rate acquisition with two InstroDAQ instances](/instrumentation/examples/daq/daq_multi_rate_ni).

--- a/docs/guides/instrumentation/daq-ni-multi-task.mdx
+++ b/docs/guides/instrumentation/daq-ni-multi-task.mdx
@@ -15,23 +15,21 @@ This is the supported pattern. `instro` has no task framework or task-level API;
 
 ## Constructing the instances
 
-Give each instance its own `NIDAQDriver` and a unique `name`. Each driver targets one DAQmx device by `device_id`; on a CompactDAQ chassis, each module is its own DAQmx device (`cDAQ1Mod1`, `cDAQ1Mod2`, ...), so two instances run two tasks on the same chassis:
+Give each instance its own `NIDAQDriver` and a unique `name`. Both drivers can target the same device:
 
 ```python
 from instro.daq import InstroDAQ
 from instro.daq.drivers.ni import NIDAQDriver
 
-daq_fast = InstroDAQ(name="daqFast", driver=NIDAQDriver(device_id="cDAQ1Mod1"))
-daq_slow = InstroDAQ(name="daqSlow", driver=NIDAQDriver(device_id="cDAQ1Mod2"))
+daq_fast = InstroDAQ(name="daqFast", driver=NIDAQDriver(device_id="cDAQ1"))
+daq_slow = InstroDAQ(name="daqSlow", driver=NIDAQDriver(device_id="cDAQ1"))
 ```
 
 Do not share one `NIDAQDriver` between two `InstroDAQ` instances. The driver is the single source of truth for its channels and timing, and two HALs mutating one task set will conflict.
 
 ## Allocating channels across instances
 
-- **A physical channel belongs to exactly one instance.** DAQmx reserves a physical channel for the task that configures it; configuring `cDAQ1Mod1/ai0` on two instances fails when the second task starts.
-- **Each hardware-timed analog input task needs its own DAQmx device.** Give each instance a `device_id` that no other instance uses for the same subsystem. On a cDAQ chassis that means one instance per module: the chassis timing engines run the modules' analog input tasks concurrently, each at its own rate. On a multifunction device (USB or PCIe X Series, for example), the whole device is one DAQmx device with one analog input timing engine, so a second hardware-timed analog input task on the same `device_id` fails with a DAQmx reserved-resource error (for example error -50103).
-- **One device can also be split across instances by subsystem.** Analog input, analog output, digital input, and digital output have independent timing engines, so one instance can own a device's analog input while another owns its digital lines. The driver names its DAQmx tasks `{device_id}_{subsystem}`, so two instances on the same `device_id` must not configure the same subsystem; the second task creation fails because DAQmx task names are unique per process.
+A physical channel belongs to exactly one instance: DAQmx reserves a physical channel for the task that configures it, so never configure the same physical channel on two instances. Split the channels along hardware boundaries. On a CompactDAQ chassis, allocate per module: one instance owns `cDAQ1Mod1`'s channels, the other owns `cDAQ1Mod2`'s.
 
 ```python
 from instro.daq.types import Direction
@@ -75,13 +73,9 @@ finally:
 ```
 
 <Warning>
-**NI constraints to respect across instances**
+**Check your device's capabilities**
 
-- One hardware-timed analog input task per DAQmx device: on cDAQ, one instance per module; on multifunction devices, one analog input instance per device.
-- cDAQ chassis have a fixed number of analog input timing engines (three on cDAQ-917x), which caps the number of concurrent hardware-timed analog input tasks per chassis.
-- A physical channel can be reserved by only one task at a time: never configure the same physical channel on two instances.
-- On one `device_id`, give each instance a different subsystem (analog input vs digital, for example). Two instances configuring the same subsystem on one `device_id` collide on the DAQmx task.
-- Per-device aggregate sample rate limits still apply: splitting channels across instances does not raise a multiplexed module's total throughput.
+How many DAQmx tasks a device can run concurrently, and at which combinations of subsystems and sample rates, varies per device. Consult your device's documentation. When the hardware cannot run an additional task, DAQmx raises a reserved-resource error when that task starts. Per-device aggregate sample rate limits also still apply: splitting channels across instances does not raise a device's total throughput.
 </Warning>
 
 See the full runnable example: [NI multi-rate acquisition with two InstroDAQ instances](/instrumentation/examples/daq/daq_multi_rate_ni).

--- a/docs/guides/instrumentation/daq-ni-multi-task.mdx
+++ b/docs/guides/instrumentation/daq-ni-multi-task.mdx
@@ -29,7 +29,7 @@ Do not share one `NIDAQDriver` between two `InstroDAQ` instances. The driver is 
 
 ## Allocating channels across instances
 
-A physical channel belongs to exactly one instance: DAQmx reserves a physical channel for the task that configures it, so never configure the same physical channel on two instances. Split the channels along hardware boundaries. On a CompactDAQ chassis, allocate per module: one instance owns `cDAQ1Mod1`'s channels, the other owns `cDAQ1Mod2`'s.
+A physical channel belongs to exactly one instance: DAQmx reserves a physical channel for the task that configures it, so never configure the same physical channel on two instances. How to partition the remaining channels across instances is up to you and your hardware; a single instance's task can span channels from multiple modules on a chassis.
 
 ```python
 from instro.daq.types import Direction

--- a/docs/guides/instrumentation/daq.mdx
+++ b/docs/guides/instrumentation/daq.mdx
@@ -274,6 +274,10 @@ Different DAQ devices have different timing capabilities:
 - **Sample rate limits**: Check your device specifications
 </Warning>
 
+<Note>
+A single `InstroDAQ` instance carries one analog input sample rate. To run multiple NI DAQmx tasks at different hardware sample rates, create one `InstroDAQ` instance per task: see [Multiple InstroDAQ instances on NI](/instrumentation/daq-ni-multi-task).
+</Note>
+
 
 ## Analog Input
 

--- a/docs/guides/instrumentation/examples/daq/daq_multi_rate_ni.mdx
+++ b/docs/guides/instrumentation/examples/daq/daq_multi_rate_ni.mdx
@@ -7,13 +7,13 @@ title: "NI multi-rate acquisition with two InstroDAQ instances"
 
 Runs two analog input tasks at different hardware sample rates on one NI
 CompactDAQ chassis by giving each task its own InstroDAQ instance. Both
-instances target the same device (cDAQ1); the channels are allocated per
-module so the two tasks never share a physical channel. Each instance
-carries its own sample rate, hardware buffer, and background daemon,
-started and stopped independently.
+instances target the same device (cDAQ1) with non-overlapping channels.
+Each instance carries its own sample rate, hardware buffer, and background
+daemon, started and stopped independently.
 
-How many tasks a device can run concurrently is device specific; see the
-"Multiple InstroDAQ instances on NI" guide.
+How to partition channels across tasks, and how many tasks a device can run
+concurrently, is device specific; see the "Multiple InstroDAQ instances on
+NI" guide.
 """
 
 import time
@@ -22,8 +22,8 @@ from instro.daq import InstroDAQ
 from instro.daq.drivers.ni import NIDAQDriver
 from instro.daq.types import Direction
 
-# NI device name, as defined in NI MAX. Both instances share the device;
-# each instance owns the channels of one module.
+# NI device name, as defined in NI MAX. Both instances share the device
+# with non-overlapping channels.
 DEVICE = "cDAQ1"
 FAST_CHANNEL = f"{DEVICE}Mod1/ai0"
 SLOW_CHANNEL = f"{DEVICE}Mod2/ai0"

--- a/docs/guides/instrumentation/examples/daq/daq_multi_rate_ni.mdx
+++ b/docs/guides/instrumentation/examples/daq/daq_multi_rate_ni.mdx
@@ -6,15 +6,14 @@ title: "NI multi-rate acquisition with two InstroDAQ instances"
 """Example: NI multi-rate acquisition with two InstroDAQ instances.
 
 Runs two analog input tasks at different hardware sample rates on one NI
-CompactDAQ chassis by giving each module its own InstroDAQ instance. One
-InstroDAQ + NIDAQDriver pair owns one DAQmx analog input task, so each
-instance carries its own sample rate, hardware buffer, and background
-daemon, started and stopped independently.
+CompactDAQ chassis by giving each task its own InstroDAQ instance. Both
+instances target the same device (cDAQ1); the channels are allocated per
+module so the two tasks never share a physical channel. Each instance
+carries its own sample rate, hardware buffer, and background daemon,
+started and stopped independently.
 
-Each cDAQ module is its own DAQmx device (cDAQ1Mod1, cDAQ1Mod2, ...), and
-the chassis runs multiple hardware-timed analog input tasks concurrently as
-long as each task stays on its own module. See the "Multiple InstroDAQ
-instances on NI" guide for the full set of constraints.
+How many tasks a device can run concurrently is device specific; see the
+"Multiple InstroDAQ instances on NI" guide.
 """
 
 import time
@@ -23,17 +22,19 @@ from instro.daq import InstroDAQ
 from instro.daq.drivers.ni import NIDAQDriver
 from instro.daq.types import Direction
 
-# cDAQ module names, as defined in NI MAX. One module per InstroDAQ instance.
-FAST_DEVICE = "cDAQ1Mod1"
-SLOW_DEVICE = "cDAQ1Mod2"
+# NI device name, as defined in NI MAX. Both instances share the device;
+# each instance owns the channels of one module.
+DEVICE = "cDAQ1"
+FAST_CHANNEL = f"{DEVICE}Mod1/ai0"
+SLOW_CHANNEL = f"{DEVICE}Mod2/ai0"
 
 FAST_SAMPLE_RATE = 1000  # Hz
 SLOW_SAMPLE_RATE = 10  # Hz
 
 ### Main code
 
-daq_fast = InstroDAQ(name="daqFast", driver=NIDAQDriver(device_id=FAST_DEVICE))
-daq_slow = InstroDAQ(name="daqSlow", driver=NIDAQDriver(device_id=SLOW_DEVICE))
+daq_fast = InstroDAQ(name="daqFast", driver=NIDAQDriver(device_id=DEVICE))
+daq_slow = InstroDAQ(name="daqSlow", driver=NIDAQDriver(device_id=DEVICE))
 
 daq_fast.open()
 daq_slow.open()
@@ -41,10 +42,10 @@ daq_slow.open()
 try:
     # A physical channel belongs to exactly one instance; allocate without overlap.
     daq_fast.configure_analog_channel(
-        direction=Direction.INPUT, physical_channel=f"{FAST_DEVICE}/ai0", alias="vibration", range_min=-5, range_max=5
+        direction=Direction.INPUT, physical_channel=FAST_CHANNEL, alias="vibration", range_min=-5, range_max=5
     )
     daq_slow.configure_analog_channel(
-        direction=Direction.INPUT, physical_channel=f"{SLOW_DEVICE}/ai0", alias="temperature", range_min=0, range_max=5
+        direction=Direction.INPUT, physical_channel=SLOW_CHANNEL, alias="temperature", range_min=0, range_max=5
     )
 
     # Each instance gets its own hardware sample rate.

--- a/docs/guides/instrumentation/examples/daq/daq_multi_rate_ni.mdx
+++ b/docs/guides/instrumentation/examples/daq/daq_multi_rate_ni.mdx
@@ -1,0 +1,76 @@
+---
+title: "NI multi-rate acquisition with two InstroDAQ instances"
+---
+
+```python daq_multi_rate_ni.py
+"""Example: NI multi-rate acquisition with two InstroDAQ instances.
+
+Runs two analog input tasks at different hardware sample rates on one NI
+CompactDAQ chassis by giving each module its own InstroDAQ instance. One
+InstroDAQ + NIDAQDriver pair owns one DAQmx analog input task, so each
+instance carries its own sample rate, hardware buffer, and background
+daemon, started and stopped independently.
+
+Each cDAQ module is its own DAQmx device (cDAQ1Mod1, cDAQ1Mod2, ...), and
+the chassis runs multiple hardware-timed analog input tasks concurrently as
+long as each task stays on its own module. See the "Multiple InstroDAQ
+instances on NI" guide for the full set of constraints.
+"""
+
+import time
+
+from instro.daq import InstroDAQ
+from instro.daq.drivers.ni import NIDAQDriver
+from instro.daq.types import Direction
+
+# cDAQ module names, as defined in NI MAX. One module per InstroDAQ instance.
+FAST_DEVICE = "cDAQ1Mod1"
+SLOW_DEVICE = "cDAQ1Mod2"
+
+FAST_SAMPLE_RATE = 1000  # Hz
+SLOW_SAMPLE_RATE = 10  # Hz
+
+### Main code
+
+daq_fast = InstroDAQ(name="daqFast", driver=NIDAQDriver(device_id=FAST_DEVICE))
+daq_slow = InstroDAQ(name="daqSlow", driver=NIDAQDriver(device_id=SLOW_DEVICE))
+
+daq_fast.open()
+daq_slow.open()
+
+try:
+    # A physical channel belongs to exactly one instance; allocate without overlap.
+    daq_fast.configure_analog_channel(
+        direction=Direction.INPUT, physical_channel=f"{FAST_DEVICE}/ai0", alias="vibration", range_min=-5, range_max=5
+    )
+    daq_slow.configure_analog_channel(
+        direction=Direction.INPUT, physical_channel=f"{SLOW_DEVICE}/ai0", alias="temperature", range_min=0, range_max=5
+    )
+
+    # Each instance gets its own hardware sample rate.
+    daq_fast.configure_ai_sample_rate(sample_rate=FAST_SAMPLE_RATE)
+    daq_slow.configure_ai_sample_rate(sample_rate=SLOW_SAMPLE_RATE)
+
+    # Each start() launches that instance's own background daemon.
+    daq_fast.start()
+    daq_slow.start()
+
+    while True:
+        try:
+            vibration = daq_fast.get_channel("daqFast.vibration", 100, True)  # Block for the latest sample
+            temperature = daq_slow.get_channel("daqSlow.temperature", 1, False)  # Return immediately
+            print(f"vibration latest: {vibration.latest} ({len(vibration.values)} samples)")
+            print(f"temperature latest: {temperature.latest}")
+            time.sleep(0.5)
+        except KeyboardInterrupt:
+            print("Exiting main loop")
+            break
+
+    # The acquisitions are independent: stopping one does not affect the other.
+    daq_fast.stop()
+    daq_slow.stop()
+finally:
+    print("Closing DAQs")
+    daq_fast.close()
+    daq_slow.close()
+```

--- a/docs/guides/instrumentation/examples/daq/daq_multi_rate_ni.mdx
+++ b/docs/guides/instrumentation/examples/daq/daq_multi_rate_ni.mdx
@@ -6,10 +6,10 @@ title: "NI multi-rate acquisition with two InstroDAQ instances"
 """Example: NI multi-rate acquisition with two InstroDAQ instances.
 
 Runs two analog input tasks at different hardware sample rates on one NI
-CompactDAQ chassis by giving each task its own InstroDAQ instance. Both
-instances target the same device (cDAQ1) with non-overlapping channels.
-Each instance carries its own sample rate, hardware buffer, and background
-daemon, started and stopped independently.
+CompactDAQ chassis by giving each task its own InstroDAQ instance. Each
+task streams five channels; both instances target the same device (cDAQ1)
+with non-overlapping channels. Each instance carries its own sample rate,
+hardware buffer, and background daemon, started and stopped independently.
 
 How to partition channels across tasks, and how many tasks a device can run
 concurrently, is device specific; see the "Multiple InstroDAQ instances on
@@ -24,12 +24,13 @@ from instro.daq.types import Direction
 
 # NI device name, as defined in NI MAX. Both instances share the device
 # with non-overlapping channels.
-DEVICE = "cDAQ1"
-FAST_CHANNEL = f"{DEVICE}Mod1/ai0"
-SLOW_CHANNEL = f"{DEVICE}Mod2/ai0"
+DEVICE = "cDAQ"
+CHANNELS_PER_TASK = 3
+FAST_MODULE = f"{DEVICE}Mod1"
+SLOW_MODULE = f"{DEVICE}Mod2"
 
-FAST_SAMPLE_RATE = 1000  # Hz
-SLOW_SAMPLE_RATE = 10  # Hz
+FAST_SAMPLE_RATE = 50000  # Hz
+SLOW_SAMPLE_RATE = 1000  # Hz
 
 ### Main code
 
@@ -41,12 +42,22 @@ daq_slow.open()
 
 try:
     # A physical channel belongs to exactly one instance; allocate without overlap.
-    daq_fast.configure_analog_channel(
-        direction=Direction.INPUT, physical_channel=FAST_CHANNEL, alias="vibration", range_min=-5, range_max=5
-    )
-    daq_slow.configure_analog_channel(
-        direction=Direction.INPUT, physical_channel=SLOW_CHANNEL, alias="temperature", range_min=0, range_max=5
-    )
+    # Each instance streams CHANNELS_PER_TASK channels from its own module.
+    for i in range(CHANNELS_PER_TASK):
+        daq_fast.configure_analog_channel(
+            direction=Direction.INPUT,
+            physical_channel=f"{FAST_MODULE}/ai{i}",
+            alias=f"fast_channel{i}",
+            range_min=-5,
+            range_max=5,
+        )
+        daq_slow.configure_analog_channel(
+            direction=Direction.INPUT,
+            physical_channel=f"{SLOW_MODULE}/ai{i}",
+            alias=f"slow_channel{i}",
+            range_min=0,
+            range_max=5,
+        )
 
     # Each instance gets its own hardware sample rate.
     daq_fast.configure_ai_sample_rate(sample_rate=FAST_SAMPLE_RATE)
@@ -58,11 +69,7 @@ try:
 
     while True:
         try:
-            vibration = daq_fast.get_channel("daqFast.vibration", 100, True)  # Block for the latest sample
-            temperature = daq_slow.get_channel("daqSlow.temperature", 1, False)  # Return immediately
-            print(f"vibration latest: {vibration.latest} ({len(vibration.values)} samples)")
-            print(f"temperature latest: {temperature.latest}")
-            time.sleep(0.5)
+            time.sleep(1)
         except KeyboardInterrupt:
             print("Exiting main loop")
             break

--- a/examples/daq/daq_multi_rate_ni.py
+++ b/examples/daq/daq_multi_rate_ni.py
@@ -1,15 +1,14 @@
 """Example: NI multi-rate acquisition with two InstroDAQ instances.
 
 Runs two analog input tasks at different hardware sample rates on one NI
-CompactDAQ chassis by giving each module its own InstroDAQ instance. One
-InstroDAQ + NIDAQDriver pair owns one DAQmx analog input task, so each
-instance carries its own sample rate, hardware buffer, and background
-daemon, started and stopped independently.
+CompactDAQ chassis by giving each task its own InstroDAQ instance. Both
+instances target the same device (cDAQ1); the channels are allocated per
+module so the two tasks never share a physical channel. Each instance
+carries its own sample rate, hardware buffer, and background daemon,
+started and stopped independently.
 
-Each cDAQ module is its own DAQmx device (cDAQ1Mod1, cDAQ1Mod2, ...), and
-the chassis runs multiple hardware-timed analog input tasks concurrently as
-long as each task stays on its own module. See the "Multiple InstroDAQ
-instances on NI" guide for the full set of constraints.
+How many tasks a device can run concurrently is device specific; see the
+"Multiple InstroDAQ instances on NI" guide.
 """
 
 import time
@@ -18,17 +17,19 @@ from instro.daq import InstroDAQ
 from instro.daq.drivers.ni import NIDAQDriver
 from instro.daq.types import Direction
 
-# cDAQ module names, as defined in NI MAX. One module per InstroDAQ instance.
-FAST_DEVICE = "cDAQ1Mod1"
-SLOW_DEVICE = "cDAQ1Mod2"
+# NI device name, as defined in NI MAX. Both instances share the device;
+# each instance owns the channels of one module.
+DEVICE = "cDAQ1"
+FAST_CHANNEL = f"{DEVICE}Mod1/ai0"
+SLOW_CHANNEL = f"{DEVICE}Mod2/ai0"
 
 FAST_SAMPLE_RATE = 1000  # Hz
 SLOW_SAMPLE_RATE = 10  # Hz
 
 ### Main code
 
-daq_fast = InstroDAQ(name="daqFast", driver=NIDAQDriver(device_id=FAST_DEVICE))
-daq_slow = InstroDAQ(name="daqSlow", driver=NIDAQDriver(device_id=SLOW_DEVICE))
+daq_fast = InstroDAQ(name="daqFast", driver=NIDAQDriver(device_id=DEVICE))
+daq_slow = InstroDAQ(name="daqSlow", driver=NIDAQDriver(device_id=DEVICE))
 
 daq_fast.open()
 daq_slow.open()
@@ -36,10 +37,10 @@ daq_slow.open()
 try:
     # A physical channel belongs to exactly one instance; allocate without overlap.
     daq_fast.configure_analog_channel(
-        direction=Direction.INPUT, physical_channel=f"{FAST_DEVICE}/ai0", alias="vibration", range_min=-5, range_max=5
+        direction=Direction.INPUT, physical_channel=FAST_CHANNEL, alias="vibration", range_min=-5, range_max=5
     )
     daq_slow.configure_analog_channel(
-        direction=Direction.INPUT, physical_channel=f"{SLOW_DEVICE}/ai0", alias="temperature", range_min=0, range_max=5
+        direction=Direction.INPUT, physical_channel=SLOW_CHANNEL, alias="temperature", range_min=0, range_max=5
     )
 
     # Each instance gets its own hardware sample rate.

--- a/examples/daq/daq_multi_rate_ni.py
+++ b/examples/daq/daq_multi_rate_ni.py
@@ -1,0 +1,70 @@
+"""Example: NI multi-rate acquisition with two InstroDAQ instances.
+
+Runs two analog input tasks at different hardware sample rates on one NI
+CompactDAQ chassis by giving each module its own InstroDAQ instance. One
+InstroDAQ + NIDAQDriver pair owns one DAQmx analog input task, so each
+instance carries its own sample rate, hardware buffer, and background
+daemon, started and stopped independently.
+
+Each cDAQ module is its own DAQmx device (cDAQ1Mod1, cDAQ1Mod2, ...), and
+the chassis runs multiple hardware-timed analog input tasks concurrently as
+long as each task stays on its own module. See the "Multiple InstroDAQ
+instances on NI" guide for the full set of constraints.
+"""
+
+import time
+
+from instro.daq import InstroDAQ
+from instro.daq.drivers.ni import NIDAQDriver
+from instro.daq.types import Direction
+
+# cDAQ module names, as defined in NI MAX. One module per InstroDAQ instance.
+FAST_DEVICE = "cDAQ1Mod1"
+SLOW_DEVICE = "cDAQ1Mod2"
+
+FAST_SAMPLE_RATE = 1000  # Hz
+SLOW_SAMPLE_RATE = 10  # Hz
+
+### Main code
+
+daq_fast = InstroDAQ(name="daqFast", driver=NIDAQDriver(device_id=FAST_DEVICE))
+daq_slow = InstroDAQ(name="daqSlow", driver=NIDAQDriver(device_id=SLOW_DEVICE))
+
+daq_fast.open()
+daq_slow.open()
+
+try:
+    # A physical channel belongs to exactly one instance; allocate without overlap.
+    daq_fast.configure_analog_channel(
+        direction=Direction.INPUT, physical_channel=f"{FAST_DEVICE}/ai0", alias="vibration", range_min=-5, range_max=5
+    )
+    daq_slow.configure_analog_channel(
+        direction=Direction.INPUT, physical_channel=f"{SLOW_DEVICE}/ai0", alias="temperature", range_min=0, range_max=5
+    )
+
+    # Each instance gets its own hardware sample rate.
+    daq_fast.configure_ai_sample_rate(sample_rate=FAST_SAMPLE_RATE)
+    daq_slow.configure_ai_sample_rate(sample_rate=SLOW_SAMPLE_RATE)
+
+    # Each start() launches that instance's own background daemon.
+    daq_fast.start()
+    daq_slow.start()
+
+    while True:
+        try:
+            vibration = daq_fast.get_channel("daqFast.vibration", 100, True)  # Block for the latest sample
+            temperature = daq_slow.get_channel("daqSlow.temperature", 1, False)  # Return immediately
+            print(f"vibration latest: {vibration.latest} ({len(vibration.values)} samples)")
+            print(f"temperature latest: {temperature.latest}")
+            time.sleep(0.5)
+        except KeyboardInterrupt:
+            print("Exiting main loop")
+            break
+
+    # The acquisitions are independent: stopping one does not affect the other.
+    daq_fast.stop()
+    daq_slow.stop()
+finally:
+    print("Closing DAQs")
+    daq_fast.close()
+    daq_slow.close()

--- a/examples/daq/daq_multi_rate_ni.py
+++ b/examples/daq/daq_multi_rate_ni.py
@@ -2,13 +2,13 @@
 
 Runs two analog input tasks at different hardware sample rates on one NI
 CompactDAQ chassis by giving each task its own InstroDAQ instance. Both
-instances target the same device (cDAQ1); the channels are allocated per
-module so the two tasks never share a physical channel. Each instance
-carries its own sample rate, hardware buffer, and background daemon,
-started and stopped independently.
+instances target the same device (cDAQ1) with non-overlapping channels.
+Each instance carries its own sample rate, hardware buffer, and background
+daemon, started and stopped independently.
 
-How many tasks a device can run concurrently is device specific; see the
-"Multiple InstroDAQ instances on NI" guide.
+How to partition channels across tasks, and how many tasks a device can run
+concurrently, is device specific; see the "Multiple InstroDAQ instances on
+NI" guide.
 """
 
 import time
@@ -17,8 +17,8 @@ from instro.daq import InstroDAQ
 from instro.daq.drivers.ni import NIDAQDriver
 from instro.daq.types import Direction
 
-# NI device name, as defined in NI MAX. Both instances share the device;
-# each instance owns the channels of one module.
+# NI device name, as defined in NI MAX. Both instances share the device
+# with non-overlapping channels.
 DEVICE = "cDAQ1"
 FAST_CHANNEL = f"{DEVICE}Mod1/ai0"
 SLOW_CHANNEL = f"{DEVICE}Mod2/ai0"

--- a/examples/daq/daq_multi_rate_ni.py
+++ b/examples/daq/daq_multi_rate_ni.py
@@ -1,10 +1,10 @@
 """Example: NI multi-rate acquisition with two InstroDAQ instances.
 
 Runs two analog input tasks at different hardware sample rates on one NI
-CompactDAQ chassis by giving each task its own InstroDAQ instance. Both
-instances target the same device (cDAQ1) with non-overlapping channels.
-Each instance carries its own sample rate, hardware buffer, and background
-daemon, started and stopped independently.
+CompactDAQ chassis by giving each task its own InstroDAQ instance. Each
+task streams five channels; both instances target the same device (cDAQ1)
+with non-overlapping channels. Each instance carries its own sample rate,
+hardware buffer, and background daemon, started and stopped independently.
 
 How to partition channels across tasks, and how many tasks a device can run
 concurrently, is device specific; see the "Multiple InstroDAQ instances on
@@ -19,12 +19,13 @@ from instro.daq.types import Direction
 
 # NI device name, as defined in NI MAX. Both instances share the device
 # with non-overlapping channels.
-DEVICE = "cDAQ1"
-FAST_CHANNEL = f"{DEVICE}Mod1/ai0"
-SLOW_CHANNEL = f"{DEVICE}Mod2/ai0"
+DEVICE = "cDAQ"
+CHANNELS_PER_TASK = 3
+FAST_MODULE = f"{DEVICE}Mod1"
+SLOW_MODULE = f"{DEVICE}Mod2"
 
-FAST_SAMPLE_RATE = 1000  # Hz
-SLOW_SAMPLE_RATE = 10  # Hz
+FAST_SAMPLE_RATE = 50000  # Hz
+SLOW_SAMPLE_RATE = 1000  # Hz
 
 ### Main code
 
@@ -36,12 +37,22 @@ daq_slow.open()
 
 try:
     # A physical channel belongs to exactly one instance; allocate without overlap.
-    daq_fast.configure_analog_channel(
-        direction=Direction.INPUT, physical_channel=FAST_CHANNEL, alias="vibration", range_min=-5, range_max=5
-    )
-    daq_slow.configure_analog_channel(
-        direction=Direction.INPUT, physical_channel=SLOW_CHANNEL, alias="temperature", range_min=0, range_max=5
-    )
+    # Each instance streams CHANNELS_PER_TASK channels from its own module.
+    for i in range(CHANNELS_PER_TASK):
+        daq_fast.configure_analog_channel(
+            direction=Direction.INPUT,
+            physical_channel=f"{FAST_MODULE}/ai{i}",
+            alias=f"fast_channel{i}",
+            range_min=-5,
+            range_max=5,
+        )
+        daq_slow.configure_analog_channel(
+            direction=Direction.INPUT,
+            physical_channel=f"{SLOW_MODULE}/ai{i}",
+            alias=f"slow_channel{i}",
+            range_min=0,
+            range_max=5,
+        )
 
     # Each instance gets its own hardware sample rate.
     daq_fast.configure_ai_sample_rate(sample_rate=FAST_SAMPLE_RATE)
@@ -53,11 +64,7 @@ try:
 
     while True:
         try:
-            vibration = daq_fast.get_channel("daqFast.vibration", 100, True)  # Block for the latest sample
-            temperature = daq_slow.get_channel("daqSlow.temperature", 1, False)  # Return immediately
-            print(f"vibration latest: {vibration.latest} ({len(vibration.values)} samples)")
-            print(f"temperature latest: {temperature.latest}")
-            time.sleep(0.5)
+            time.sleep(1)
         except KeyboardInterrupt:
             print("Exiting main loop")
             break

--- a/packages/instro-daq-ni/instro/daq/drivers/ni/nidaq.py
+++ b/packages/instro-daq-ni/instro/daq/drivers/ni/nidaq.py
@@ -1,5 +1,6 @@
 import time
 from dataclasses import dataclass
+from itertools import count
 from typing import Mapping
 
 import nidaqmx
@@ -31,12 +32,18 @@ class DAQmxData:
     dt: int | None
 
 
+_instance_ids = count()
+
+
 class NIDAQDriver(DAQDriverBase):
     """NI-DAQmx DAQ driver."""
 
     def __init__(self, device_id: str):
         super().__init__()
         self._device_id = device_id
+        # DAQmx task names must be unique per process, and multiple driver instances
+        # may target the same device_id (one InstroDAQ per task), so suffix the names.
+        self._task_prefix = f"{device_id}_{next(_instance_ids)}"
         self._tasks: dict[ChannelType, nidaqmx.Task] = {}
         self._ao_sw_tasks: dict[str, nidaqmx.Task] = {}
 
@@ -97,7 +104,7 @@ class NIDAQDriver(DAQDriverBase):
         task = self._tasks.get(channel_type, None)
         if not task:
             # Task does not yet exist for that channel_type
-            task_name = f"{self._device_id}_{channel_type.value}"
+            task_name = f"{self._task_prefix}_{channel_type.value}"
             task = nidaqmx.Task(task_name)
             self._tasks[channel_type] = task
         return task
@@ -157,7 +164,7 @@ class NIDAQDriver(DAQDriverBase):
         if task:
             raise ValueError("Channel already exists and is configured")
 
-        task_name = f"{self._device_id}_{channel.alias}"
+        task_name = f"{self._task_prefix}_{channel.alias}"
         task = nidaqmx.Task(task_name)
         self._ao_sw_tasks[channel.alias] = task
 
@@ -231,7 +238,7 @@ class NIDAQDriver(DAQDriverBase):
     ):
         """Parse ``DevN/portM``, add as CHAN_FOR_ALL_LINES to a dedicated DI task, and register the port."""
         channel = self._build_port_channel(physical_channel, Direction.INPUT, logic, port_width, logic_level, alias)
-        task = nidaqmx.Task(f"{self._device_id}_di_port_{channel.alias}")
+        task = nidaqmx.Task(f"{self._task_prefix}_di_port_{channel.alias}")
         task.di_channels.add_di_chan(
             lines=channel.physical_channel,
             name_to_assign_to_lines=channel.alias,
@@ -250,7 +257,7 @@ class NIDAQDriver(DAQDriverBase):
     ):
         """Parse ``DevN/portM``, add as CHAN_FOR_ALL_LINES to a dedicated DO task, and register the port."""
         channel = self._build_port_channel(physical_channel, Direction.OUTPUT, logic, port_width, logic_level, alias)
-        task = nidaqmx.Task(f"{self._device_id}_do_port_{channel.alias}")
+        task = nidaqmx.Task(f"{self._task_prefix}_do_port_{channel.alias}")
         task.do_channels.add_do_chan(
             lines=channel.physical_channel,
             name_to_assign_to_lines=channel.alias,


### PR DESCRIPTION
Closes INSTRO-325 (https://linear.app/nominal-io/issue/INSTRO-325).

InstroDAQ has no task framework; multi-task / multi-rate NI workflows use multiple `InstroDAQ` instances, one per DAQmx task.

## Changes

- `examples/daq/daq_multi_rate_ni.py`: two `InstroDAQ` instances against the same device (`cDAQ1`), each running a hardware-timed AI task at its own sample rate with non-overlapping channels, started and read independently.
- `docs/guides/instrumentation/daq-ni-multi-task.mdx`: new guide covering when to use the pattern, instance construction, channel allocation, and per-instance lifecycle. The guide stays out of device specifics: it does not prescribe how to partition channels across instances, and capability limits (how many concurrent tasks, at which rates) are deferred to the device documentation.
- `packages/instro-daq-ni`: suffix DAQmx task names with a per-instance id. DAQmx task names must be unique per process, and the prescribed pattern puts two `NIDAQDriver` instances on one `device_id`, which previously collided on the `{device_id}_{subsystem}` task name.
- `docs/guides/instrumentation/daq.mdx`: cross-link from the hardware-timed sample rate section.
- `docs/guides/docs.json` + generated example page via `just gen-examples`.

## Verification

- `just check` and `just test` pass.
- `mint broken-links` reports no broken links.

Demonstrating multi rate data shows up properly in Core:
<img width="1363" height="1194" alt="Screenshot 2026-06-10 at 1 12 44 PM" src="https://github.com/user-attachments/assets/3ecf220d-893f-46a1-89f2-0799018f6b38" />
