### PR TITLE
test: fix socket warning message on just test

### DIFF
--- a/tests/modbus/test_modbus_write_safety.py
+++ b/tests/modbus/test_modbus_write_safety.py
@@ -20,7 +20,7 @@ from pymodbus.datastore import (
     ModbusSequentialDataBlock,
     ModbusServerContext,
 )
-from pymodbus.server import StartAsyncTcpServer
+from pymodbus.server import ModbusTcpServer
 
 from instro.lib.types import DeviceInfo, LinearScale
 from instro.modbus import ModbusConfig, ModbusDevice, RegisterDef
@@ -56,13 +56,12 @@ def modbus_server():
     async def _run():
         nonlocal shutdown
         shutdown = asyncio.Event()
-        server_task = asyncio.create_task(StartAsyncTcpServer(context=context, address=("127.0.0.1", TEST_PORT)))
-        await shutdown.wait()
-        server_task.cancel()
+        server = ModbusTcpServer(context=context, address=("127.0.0.1", TEST_PORT))
+        await server.serve_forever(background=True)
         try:
-            await server_task
-        except asyncio.CancelledError:
-            pass
+            await shutdown.wait()
+        finally:
+            await server.shutdown()
 
     def _thread_target():
         asyncio.set_event_loop(loop)


### PR DESCRIPTION
## Summary

Fixes the socket warning on just test. Closes INSTRO-347

## Type of change

- [ ] Bug fix (`fix`)
- [ ] New feature (`feat`)
- [ ] Breaking change (`feat!` / `fix!`)
- [ ] Refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] Chore / tooling (`chore`)
- [X] Test ('test')

## Verification

Ran just test.

## Tests

- [ ] Unit tests added or updated
- [ ] Existing tests cover this change
- [X] No tests — explain why: problem is with test fixture, not production code.

## Checklist

- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(driver): add support for Keysight E36300`)
- [X] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [X] Documentation updated if user-facing behavior changed
- [X] Code follows the style/conventions of the surrounding code
