### PR TITLE
refactor: use instro.lib.publishers re-exports in examples and docs

### DIFF
--- a/docs/guides/instrumentation/examples/daq/daq_analog_loopback.mdx
+++ b/docs/guides/instrumentation/examples/daq/daq_analog_loopback.mdx
@@ -9,7 +9,7 @@ import time
 
 from instro.daq import InstroDAQ
 from instro.daq.types import DAQVendor, Direction
-from instro.lib.publishers.nominal_core import NominalCorePublisher
+from instro.lib.publishers import NominalCorePublisher
 
 # Configuration: Choose your vendor.
 VENDOR = DAQVendor.LABJACK_T_SERIES

--- a/docs/guides/instrumentation/examples/daq/daq_read_analog_hw_timed.mdx
+++ b/docs/guides/instrumentation/examples/daq/daq_read_analog_hw_timed.mdx
@@ -13,7 +13,7 @@ import time
 
 from instro.daq import InstroDAQ
 from instro.daq.types import DAQVendor, Direction
-from instro.lib.publishers.nominal_core import NominalCorePublisher
+from instro.lib.publishers import NominalCorePublisher
 
 # Configuration: Choose your vendor.
 VENDOR = DAQVendor.LABJACK_T_SERIES

--- a/docs/guides/instrumentation/examples/daq/daq_read_analog_hw_timed_no_background.mdx
+++ b/docs/guides/instrumentation/examples/daq/daq_read_analog_hw_timed_no_background.mdx
@@ -11,7 +11,7 @@ Demonstrates publishing measurements/commands to a dataset (Nominal Core publish
 
 from instro.daq import InstroDAQ
 from instro.daq.types import DAQVendor, Direction
-from instro.lib.publishers.nominal_core import NominalCorePublisher
+from instro.lib.publishers import NominalCorePublisher
 
 # Configuration: Choose your vendor.
 VENDOR = DAQVendor.LABJACK_T_SERIES

--- a/docs/guides/instrumentation/examples/daq/daq_read_analog_sw_timed.mdx
+++ b/docs/guides/instrumentation/examples/daq/daq_read_analog_sw_timed.mdx
@@ -13,7 +13,7 @@ import time
 
 from instro.daq import InstroDAQ
 from instro.daq.types import DAQVendor, Direction
-from instro.lib.publishers.nominal_core import NominalCorePublisher
+from instro.lib.publishers import NominalCorePublisher
 
 # Configuration: Choose your vendor.
 VENDOR = DAQVendor.LABJACK_T_SERIES

--- a/docs/guides/instrumentation/examples/daq/daq_write_analog_sw_timed.mdx
+++ b/docs/guides/instrumentation/examples/daq/daq_write_analog_sw_timed.mdx
@@ -7,7 +7,7 @@ title: "DAQ write analog SW timed"
 
 from instro.daq import InstroDAQ
 from instro.daq.types import DAQVendor, Direction
-from instro.lib.publishers.nominal_core import NominalCorePublisher
+from instro.lib.publishers import NominalCorePublisher
 
 # Configuration: Choose your vendor.
 VENDOR = DAQVendor.LABJACK_T_SERIES

--- a/docs/guides/instrumentation/examples/eload/eload.mdx
+++ b/docs/guides/instrumentation/examples/eload/eload.mdx
@@ -14,7 +14,7 @@ import time
 from instro.eload import InstroELoad
 from instro.eload.drivers.bk_85xxb import BK85XXB
 from instro.eload.types import LoadMode
-from instro.lib.publishers.nominal_core import NominalCorePublisher
+from instro.lib.publishers import NominalCorePublisher
 from instro.lib.transports import SerialConfig, VisaConfig
 
 VISA_RESOURCE = "ASRL7::INSTR"

--- a/docs/guides/instrumentation/publishers.mdx
+++ b/docs/guides/instrumentation/publishers.mdx
@@ -132,7 +132,7 @@ NominalConnectPublisher(
 ```python
 from instro.daq.drivers.labjack import LabJackTSeriesDriver
 from instro.daq import InstroDAQ
-from instro.lib.publishers.nominal_connect import NominalConnectPublisher
+from instro.lib.publishers import NominalConnectPublisher
 
 import connect_python
 

--- a/examples/daq/daq_analog_loopback.py
+++ b/examples/daq/daq_analog_loopback.py
@@ -4,7 +4,7 @@ import time
 
 from instro.daq import InstroDAQ
 from instro.daq.types import DAQVendor, Direction
-from instro.lib.publishers.nominal_core import NominalCorePublisher
+from instro.lib.publishers import NominalCorePublisher
 
 # Configuration: Choose your vendor.
 VENDOR = DAQVendor.LABJACK_T_SERIES

--- a/examples/daq/daq_read_analog_hw_timed.py
+++ b/examples/daq/daq_read_analog_hw_timed.py
@@ -8,7 +8,7 @@ import time
 
 from instro.daq import InstroDAQ
 from instro.daq.types import DAQVendor, Direction
-from instro.lib.publishers.nominal_core import NominalCorePublisher
+from instro.lib.publishers import NominalCorePublisher
 
 # Configuration: Choose your vendor.
 VENDOR = DAQVendor.LABJACK_T_SERIES

--- a/examples/daq/daq_read_analog_hw_timed_no_background.py
+++ b/examples/daq/daq_read_analog_hw_timed_no_background.py
@@ -6,7 +6,7 @@ Demonstrates publishing measurements/commands to a dataset (Nominal Core publish
 
 from instro.daq import InstroDAQ
 from instro.daq.types import DAQVendor, Direction
-from instro.lib.publishers.nominal_core import NominalCorePublisher
+from instro.lib.publishers import NominalCorePublisher
 
 # Configuration: Choose your vendor.
 VENDOR = DAQVendor.LABJACK_T_SERIES

--- a/examples/daq/daq_read_analog_sw_timed.py
+++ b/examples/daq/daq_read_analog_sw_timed.py
@@ -8,7 +8,7 @@ import time
 
 from instro.daq import InstroDAQ
 from instro.daq.types import DAQVendor, Direction
-from instro.lib.publishers.nominal_core import NominalCorePublisher
+from instro.lib.publishers import NominalCorePublisher
 
 # Configuration: Choose your vendor.
 VENDOR = DAQVendor.LABJACK_T_SERIES

--- a/examples/daq/daq_write_analog_sw_timed.py
+++ b/examples/daq/daq_write_analog_sw_timed.py
@@ -2,7 +2,7 @@
 
 from instro.daq import InstroDAQ
 from instro.daq.types import DAQVendor, Direction
-from instro.lib.publishers.nominal_core import NominalCorePublisher
+from instro.lib.publishers import NominalCorePublisher
 
 # Configuration: Choose your vendor.
 VENDOR = DAQVendor.LABJACK_T_SERIES

--- a/examples/eload/eload.py
+++ b/examples/eload/eload.py
@@ -9,7 +9,7 @@ import time
 from instro.eload import InstroELoad
 from instro.eload.drivers.bk_85xxb import BK85XXB
 from instro.eload.types import LoadMode
-from instro.lib.publishers.nominal_core import NominalCorePublisher
+from instro.lib.publishers import NominalCorePublisher
 from instro.lib.transports import SerialConfig, VisaConfig
 
 VISA_RESOURCE = "ASRL7::INSTR"

--- a/tests/daq/mcc/test_mccdaq_hardware.py
+++ b/tests/daq/mcc/test_mccdaq_hardware.py
@@ -71,7 +71,7 @@ from nominal.core import EventType, NominalClient
 from instro.daq import InstroDAQ
 from instro.daq.drivers.mcc import MCCDriver
 from instro.daq.types import DigitalPortWidth, Direction, Logic, TerminalConfig
-from instro.lib.publishers.nominal_core import NominalCorePublisher
+from instro.lib.publishers import NominalCorePublisher
 
 # ---------------------------------------------------------------------------
 # Configuration from environment

--- a/tests/lib/test_nominal_connect_publisher.py
+++ b/tests/lib/test_nominal_connect_publisher.py
@@ -2,7 +2,7 @@
 
 from unittest.mock import Mock, patch
 
-from instro.lib.publishers.nominal_connect import NominalConnectPublisher
+from instro.lib.publishers import NominalConnectPublisher
 from instro.lib.types import Measurement
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -444,7 +444,7 @@ wheels = [
 
 [[package]]
 name = "instro"
-version = "0.8.0"
+version = "0.9.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastavro", extra = ["snappy"] },
@@ -553,7 +553,7 @@ requires-dist = [{ name = "instro", editable = "." }]
 
 [[package]]
 name = "instro-daq-labjack"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "packages/instro-daq-labjack" }
 dependencies = [
     { name = "instro" },
@@ -568,7 +568,7 @@ requires-dist = [
 
 [[package]]
 name = "instro-daq-mcc"
-version = "0.4.0"
+version = "0.5.0"
 source = { editable = "packages/instro-daq-mcc" }
 dependencies = [
     { name = "instro" },
@@ -583,7 +583,7 @@ requires-dist = [
 
 [[package]]
 name = "instro-daq-ni"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "packages/instro-daq-ni" }
 dependencies = [
     { name = "instro" },


### PR DESCRIPTION
Fixes INSTRO-348

The public publisher classes are already re-exported from `instro.lib.publishers`, but examples, tests, and docs still imported from the private submodules (`instro.lib.publishers.nominal_core`, `instro.lib.publishers.nominal_connect`). This switches all of those imports to the package re-exports.

- `examples/daq/*.py` (5 files) and `examples/eload/eload.py`: `NominalCorePublisher` now imported from `instro.lib.publishers`
- `tests/daq/mcc/test_mccdaq_hardware.py`: same
- `tests/lib/test_nominal_connect_publisher.py` and `docs/guides/instrumentation/publishers.mdx`: `NominalConnectPublisher` likewise (the `patch("instro.lib.publishers.nominal_connect.logger...")` targets are unchanged since patching must target the defining module)
- `docs/guides/instrumentation/examples/*.mdx` regenerated via `just gen-examples`
- `uv.lock` refreshed for the release-please version bumps from #57 (the lock was stale on `main`, so any `uv` invocation re-locked it)

`docs/reference/src/reference/publishers.md` is untouched: its `:::` directives document the modules themselves.