### PR TITLE
refactor: switch VISA backend from ivi to pyvisa-py

### DIFF
--- a/docs/guides/instrumentation/driver-dependencies.mdx
+++ b/docs/guides/instrumentation/driver-dependencies.mdx
@@ -26,21 +26,19 @@ Before using `instro` with specific instrument types, you must install the corre
 
 ## VISA
 
-VISA (Virtual Instrument Software Architecture) is required by `instro` for all SCPI/VISA based instrument connections.
+VISA (Virtual Instrument Software Architecture) is used by `instro` for all SCPI/VISA based instrument connections. `instro` installs `pyvisa` and the default Python backend, so many TCP/IP, USB-TMC, and serial resources work without a vendor VISA runtime.
 
-- **NI VISA** (IVI-compatible VISA driver) like NI-VISA
 - **pyvisa** (Python VISA library)
-
-VISA must be installed and configured before using instruments that communicate via SCPI over VISA connections.
+- **pyvisa-py** (default Python backend)
+- **Vendor VISA runtimes** (optional, instrument/interface dependent)
 
 ### Installation
 
-**NI VISA:**
-- Download and install from [National Instruments](https://www.ni.com/en/support/downloads/drivers/download.ni-visa.html)
+**Default Python backend:**
+- Installed with `instro`: `pyvisa` and `pyvisa-py`
 
-**pyvisa:**
-- Install via pip: `pip install pyvisa`
-- You may also need backend drivers depending on your connection type (USB, TCP/IP, Serial)
+**Vendor VISA backend:**
+- Download and install the runtime required by your instrument vendor.
 
 ## NI-DAQmx
 

--- a/docs/guides/instrumentation/transports/visa.mdx
+++ b/docs/guides/instrumentation/transports/visa.mdx
@@ -10,7 +10,7 @@ description: VISA transport driver for building custom SCPI instrument drivers
 It is intentionally narrow: it opens, closes, and locks a VISA resource and exposes text and raw byte I/O. The caller chooses the command strings.
 
 <Note>
-[VISA (Virtual Instrument Software Architecture)](https://www.ivifoundation.org/specifications/) is the IVI Foundation standard for talking to instruments over GPIB, USB-TMC, TCP/IP (SOCKET, VXI-11, HiSLIP), and RS-232/RS-485. `VisaDriver` uses pyvisa under the hood, so any backend pyvisa supports (NI-VISA, Keysight IO Libraries, pyvisa-py) is reachable.
+[VISA (Virtual Instrument Software Architecture)](https://www.ivifoundation.org/specifications/) is the IVI Foundation standard for talking to instruments over GPIB, USB-TMC, TCP/IP (SOCKET, VXI-11, HiSLIP), and RS-232/RS-485. `VisaDriver` uses pyvisa under the hood.
 </Note>
 
 ## When to Reach For It
@@ -106,7 +106,7 @@ When the VISA resource is an ASRL (RS-232 / RS-485) interface, `VisaDriver` appl
 
 ### Backends
 
-`VisaConfig.visa_backend` selects which pyvisa backend handles the resource. Defaults to `"@ivi"`, which uses a vendor VISA implementation (NI-VISA or Keysight IO Libraries) when one is installed on the host. Set it to `"@py"` to use [pyvisa-py](https://pyvisa.readthedocs.io/projects/pyvisa-py/), the pure-Python backend, which avoids the vendor install at the cost of fewer interface types and slower performance.
+`VisaConfig.visa_backend` selects which pyvisa backend handles the resource. Most callers should let the default backend drive.
 
 ## Building a Custom Driver
 
@@ -202,7 +202,7 @@ Two patterns from this example are worth calling out because they recur in every
 
 ## Configuration
 
-For non-default backends, terminators, timeouts, or serial settings, pass a `VisaConfig` instead of a plain resource string:
+For terminators, timeouts, or serial settings, pass a `VisaConfig` instead of a plain resource string:
 
 ```python
 from instro.lib.transports import (
@@ -218,7 +218,6 @@ from instro.lib.transports import (
 
 config = VisaConfig(
     visa_resource="ASRL/dev/ttyUSB0::INSTR",
-    visa_backend="@py",
     serial_config=SerialConfig(
         baud_rate=19200,
         data_bits=8,
@@ -240,7 +239,7 @@ Top-level connection parameters.
 | Field | Required | Default | Description |
 |-------|----------|---------|-------------|
 | `visa_resource` | Yes | | VISA resource string, e.g. `TCPIP0::host::5025::SOCKET` or `USB0::0x2A8D::0x0101::MY12345::INSTR` |
-| `visa_backend` | No | `"@ivi"` | pyvisa backend specifier: `"@ivi"` for vendor VISA, `"@py"` for pyvisa-py |
+| `visa_backend` | No | `"@py"` | pyvisa backend specifier |
 | `serial_config` | No | `SerialConfig()` | Serial settings, applied only when the resource is an ASRL interface |
 | `terminator` | No | `TerminatorConfig()` | Read and write terminators |
 | `timeout` | No | `TimeoutConfig()` | Operation timeouts |
@@ -293,7 +292,7 @@ To discover what's attached, you can use pyvisa's resource manager directly:
 
 ```python
 import pyvisa
-rm = pyvisa.ResourceManager("@ivi")  # or "@py"
+rm = pyvisa.ResourceManager()
 print(rm.list_resources())
 ```
 </Tip>
@@ -320,7 +319,7 @@ print(rm.list_resources())
 |-------|-------|
 | `RuntimeError: VisaDriver is not open. Call open() first.` | A `write`/`read`/`query`/`*_raw` call was made before `open()`, or after `close()`. |
 | `pyvisa.errors.VisaIOError` | The underlying VISA call failed: timeout, resource not found, bus error, instrument disconnected, etc. The `error_code` attribute identifies the cause (e.g. `VI_ERROR_TMO` for timeout). |
-| `pyvisa.errors.LibraryError` | The selected VISA backend could not be loaded: typically a missing NI-VISA / Keysight VISA install when using `"@ivi"`. Switch to `"@py"` or install a vendor VISA runtime. |
+| `pyvisa.errors.LibraryError` | The selected VISA backend could not be loaded. Because `instro` installs the default backend, this most often means an explicitly selected alternate backend is unavailable. Use the default backend or install the required vendor runtime. |
 
 <Tip>
 `VisaDriver` deliberately does not retry, reconnect, or wrap pyvisa errors. Higher-level recovery (retry policies, reconnection on transient failures, escalation to operators) belongs in the instrument driver or application code on top.

--- a/instro/lib/transports/visa.py
+++ b/instro/lib/transports/visa.py
@@ -85,8 +85,7 @@ class VisaConfig:
     Attributes:
         visa_resource: VISA resource string, e.g. ``TCPIP0::host::5025::SOCKET``
             or ``USB0::0x2A8D::0x0101::MY12345::INSTR``.
-        visa_backend: pyvisa backend specifier. Defaults to ``@ivi`` (NI-VISA);
-            use ``@py`` for pyvisa-py.
+        visa_backend: pyvisa backend specifier. Defaults to ``@py``.
         serial_config: Serial settings applied when the VISA resource is an
             ASRL (RS-232/RS-485) interface.
         terminator: Read and write terminators.
@@ -94,7 +93,7 @@ class VisaConfig:
     """
 
     visa_resource: str
-    visa_backend: str = "@ivi"
+    visa_backend: str = "@py"
     serial_config: SerialConfig = dataclasses.field(default_factory=SerialConfig)
     terminator: TerminatorConfig = dataclasses.field(default_factory=TerminatorConfig)
     timeout: TimeoutConfig = dataclasses.field(default_factory=TimeoutConfig)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "pymodbus>=3.10,<3.13",
     "pyserial>=3.5",
     "pyvisa>=1.15",
+    "pyvisa-py>=0.8.1,<0.9",
     "textual>=0.80",
     "thermocouples>=2.1.2",
 ]

--- a/tests/dmm/test_instro_dmm.py
+++ b/tests/dmm/test_instro_dmm.py
@@ -45,7 +45,6 @@ def test_agilent_init_builds_visa_from_resource(agilent_visa_cls: MagicMock) -> 
 def test_agilent_init_accepts_prebuilt_connection_config(agilent_visa_cls: MagicMock) -> None:
     config = VisaConfig(
         visa_resource="ASRL3::INSTR",
-        visa_backend="@py",
         serial_config=SerialConfig(baud_rate=19_200),
     )
 

--- a/tests/eload/test_eload_drivers.py
+++ b/tests/eload/test_eload_drivers.py
@@ -40,7 +40,6 @@ def test_init_builds_visa_driver_from_resource(visa_driver_cls: MagicMock) -> No
 def test_init_accepts_prebuilt_connection_config(visa_driver_cls: MagicMock) -> None:
     config = VisaConfig(
         visa_resource="ASRL19::INSTR",
-        visa_backend="@py",
         serial_config=SerialConfig(baud_rate=19_200),
     )
 

--- a/tests/lib/test_visa_driver.py
+++ b/tests/lib/test_visa_driver.py
@@ -64,7 +64,7 @@ def test_construction_accepts_raw_resource_string(mock_pyvisa):
 
     driver.open()
 
-    rm_class.assert_called_once_with("@ivi")
+    rm_class.assert_called_once_with("@py")
     rm_instance.open_resource.assert_called_once_with("USB0::0x1234::0x5678::SERIAL::INSTR")
 
 

--- a/tests/psu/keysight/test_keysight_e36100_hardware.py
+++ b/tests/psu/keysight/test_keysight_e36100_hardware.py
@@ -13,11 +13,9 @@ from instro.psu.drivers.keysight_e36100 import KeysightE36100
 pytestmark = pytest.mark.hardware
 
 # HARDWARE TEST SETUP - EDIT THESE VALUES BEFORE RUNNING THIS FILE.
-# Set VISA_ADDRESS to the bench unit's VISA resource string. Set VISA_BACKEND
-# to "@ivi" for NI-VISA or Keysight IO Libraries, or "@py" for pyvisa-py.
+# Set VISA_ADDRESS to the bench unit's VISA resource string.
 # Keep the programmed values comfortably inside the specific unit's ratings.
 VISA_ADDRESS = "USB0::0x0957::0x1502::MY_SERIAL_NUMBER::INSTR"
-VISA_BACKEND = "@ivi"
 CHANNEL = 1
 PROGRAMMED_VOLTAGE = 1.0
 PROGRAMMED_CURRENT_LIMIT = 0.1
@@ -31,7 +29,6 @@ def driver(request: pytest.FixtureRequest) -> KeysightE36100:
     psu_driver = KeysightE36100(
         VisaConfig(
             visa_resource=VISA_ADDRESS,
-            visa_backend=VISA_BACKEND,
         )
     )
     try:

--- a/tests/psu/siglent/test_siglent_spd3303_hardware.py
+++ b/tests/psu/siglent/test_siglent_spd3303_hardware.py
@@ -60,7 +60,6 @@ def driver() -> Iterator[SiglentSPD3303]:
     psu_driver = SiglentSPD3303(
         VisaConfig(
             visa_resource=VISA_RESOURCE,
-            visa_backend="@ivi",
         )
     )
     try:

--- a/tests/psu/test_psu_drivers.py
+++ b/tests/psu/test_psu_drivers.py
@@ -646,7 +646,6 @@ def test_publish_measurement_passes_through_none() -> None:
 def test_bk_single_init_passes_prebuilt_config_to_visa_driver(bk_single_visa_cls: MagicMock) -> None:
     config = VisaConfig(
         visa_resource="ASRL19::INSTR",
-        visa_backend="@py",
         serial_config=SerialConfig(baud_rate=19_200),
     )
     BK9115(config)

--- a/uv.lock
+++ b/uv.lock
@@ -453,6 +453,7 @@ dependencies = [
     { name = "pymodbus" },
     { name = "pyserial" },
     { name = "pyvisa" },
+    { name = "pyvisa-py" },
     { name = "textual" },
     { name = "thermocouples" },
 ]
@@ -522,6 +523,7 @@ requires-dist = [
     { name = "pymodbus", specifier = ">=3.10,<3.13" },
     { name = "pyserial", specifier = ">=3.5" },
     { name = "pyvisa", specifier = ">=1.15" },
+    { name = "pyvisa-py", specifier = ">=0.8.1,<0.9" },
     { name = "textual", specifier = ">=0.80" },
     { name = "thermocouples", specifier = ">=2.1.2" },
 ]
@@ -1602,6 +1604,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/52/04/1833acfa4ddefc5cdcfd76607f1bf494e7b7b658d890626e23026655d599/pyvisa-1.15.0.tar.gz", hash = "sha256:cec3cb91703a2849f6faa42b1ecd7689a0175baabff8ca33fce9f45934ce45e6", size = 236289, upload-time = "2025-04-01T15:52:25.377Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a1/12/4979772f36acceb57664bde282fc7bd3e67f8d0ce85f2a521a05e90baaa5/pyvisa-1.15.0-py3-none-any.whl", hash = "sha256:e3ac8d9e863fbdbbe7e6d4d91401bceb7914d1c4a558a89b2cc755789f1e8309", size = 179199, upload-time = "2025-04-01T15:52:23.631Z" },
+]
+
+[[package]]
+name = "pyvisa-py"
+version = "0.8.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyvisa" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/8d/0f1af2b39feca8868d0692a2c5d0c47f4ad559a051fb678c441fe1e99536/pyvisa_py-0.8.1.tar.gz", hash = "sha256:db53d3219d971d16b8f7c764a93e08475875063635b9ad8ea3c988439833ccdd", size = 102061, upload-time = "2025-09-04T20:48:21.639Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/70/0b/06ccf917ce30d78d75e452d0afc89236b1d384b776c5c33d75c8cc55fbe7/pyvisa_py-0.8.1-py3-none-any.whl", hash = "sha256:31208a2933c1793b4e829ba5f07d265b83f280668df440ee7ee6ac505dea4ee9", size = 82206, upload-time = "2025-09-04T20:48:20.13Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Closes INSTRO-32. Moves the VISA backend from IVI to pyvisa-py.

## Type of change

- [ ] Bug fix (`fix`)
- [ ] New feature (`feat`)
- [ ] Breaking change (`feat!` / `fix!`)
- [X] Refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] Chore / tooling (`chore`)

## Verification
Tests pass.

## Tests

- [ ] Unit tests added or updated
- [X] Existing tests cover this change
- [ ] No tests — explain why:

## Checklist

- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(driver): add support for Keysight E36300`)
- [X] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [X] Documentation updated if user-facing behavior changed
- [X] Code follows the style/conventions of the surrounding code

## Notes for reviewers

_Optional — call out specific files, edge cases, or decisions you'd like eyes on._
