### PR TITLE
docs(examples): use the instrument context manager in examples

### DIFF
--- a/docs/guides/instrumentation/examples/daq/daq_analog_loopback.mdx
+++ b/docs/guides/instrumentation/examples/daq/daq_analog_loopback.mdx
@@ -51,9 +51,7 @@ DATASET_RID = "<dataset_rid>"  # Replace with your dataset RID.
 daq = InstroDAQ(name="myDAQ", driver=driver)
 daq.add_publisher(NominalCorePublisher(dataset_rid=DATASET_RID))
 
-daq.open()
-
-try:
+with daq:
     daq.configure_analog_channel(
         direction=Direction.INPUT, physical_channel=AI_CH0, alias="ai_0", range_min=0, range_max=5
     )
@@ -86,8 +84,4 @@ try:
             break
 
     daq.stop()
-
-finally:
-    print("Closing DAQ")
-    daq.close()
 ```

--- a/docs/guides/instrumentation/examples/daq/daq_multi_rate_ni.mdx
+++ b/docs/guides/instrumentation/examples/daq/daq_multi_rate_ni.mdx
@@ -37,10 +37,7 @@ SLOW_SAMPLE_RATE = 1000  # Hz
 daq_fast = InstroDAQ(name="daqFast", driver=NIDAQDriver(device_id=DEVICE))
 daq_slow = InstroDAQ(name="daqSlow", driver=NIDAQDriver(device_id=DEVICE))
 
-daq_fast.open()
-daq_slow.open()
-
-try:
+with daq_fast, daq_slow:
     # A physical channel belongs to exactly one instance; allocate without overlap.
     # Each instance streams CHANNELS_PER_TASK channels from its own module.
     for i in range(CHANNELS_PER_TASK):
@@ -77,8 +74,4 @@ try:
     # The acquisitions are independent: stopping one does not affect the other.
     daq_fast.stop()
     daq_slow.stop()
-finally:
-    print("Closing DAQs")
-    daq_fast.close()
-    daq_slow.close()
 ```

--- a/docs/guides/instrumentation/examples/daq/daq_read_analog_hw_timed.mdx
+++ b/docs/guides/instrumentation/examples/daq/daq_read_analog_hw_timed.mdx
@@ -56,9 +56,7 @@ DATASET_RID = "<dataset_rid>"  # Replace with your dataset RID.
 daq = InstroDAQ(name="myDAQ", driver=driver)
 daq.add_publisher(NominalCorePublisher(dataset_rid=DATASET_RID))
 
-daq.open()
-
-try:
+with daq:
     daq.configure_analog_channel(
         direction=Direction.INPUT, physical_channel=CHANNEL_0, alias=f"ch_0", range_min=0, range_max=5
     )
@@ -85,7 +83,4 @@ try:
             break
 
     daq.stop()
-finally:
-    print("Closing DAQ")
-    daq.close()
 ```

--- a/docs/guides/instrumentation/examples/daq/daq_read_analog_hw_timed_no_background.mdx
+++ b/docs/guides/instrumentation/examples/daq/daq_read_analog_hw_timed_no_background.mdx
@@ -54,9 +54,7 @@ DATASET_RID = "<dataset_rid>"  # Replace with your dataset RID.
 daq = InstroDAQ(name="myDAQ", driver=driver)
 daq.add_publisher(NominalCorePublisher(dataset_rid=DATASET_RID))
 
-daq.open()
-
-try:
+with daq:
     daq.configure_analog_channel(
         direction=Direction.INPUT, physical_channel=CHANNEL_0, alias=f"ch_0", range_min=0, range_max=5
     )
@@ -80,7 +78,4 @@ try:
             break
 
     daq.stop()
-finally:
-    print("Closing DAQ")
-    daq.close()
 ```

--- a/docs/guides/instrumentation/examples/daq/daq_read_analog_sw_timed.mdx
+++ b/docs/guides/instrumentation/examples/daq/daq_read_analog_sw_timed.mdx
@@ -56,9 +56,7 @@ DATASET_RID = "<dataset_rid>"  # Replace with your dataset RID.
 daq = InstroDAQ(name="myDAQ", driver=driver)
 daq.add_publisher(NominalCorePublisher(dataset_rid=DATASET_RID))
 
-daq.open()
-
-try:
+with daq:
     daq.configure_analog_channel(
         direction=Direction.INPUT, physical_channel=CHANNEL_0, alias=f"ch_0", range_min=0, range_max=5
     )
@@ -71,8 +69,4 @@ try:
         measurement = daq.read_analog()
         print(measurement)
         time.sleep(1)  # Software sleep. Then request daq to sample new points.
-
-finally:
-    print("Closing DAQ")
-    daq.close()
 ```

--- a/docs/guides/instrumentation/examples/daq/daq_read_digital_line.mdx
+++ b/docs/guides/instrumentation/examples/daq/daq_read_digital_line.mdx
@@ -54,9 +54,7 @@ DATASET_RID = "<dataset_rid>"  # Replace with your dataset RID.
 daq = InstroDAQ(name="myDAQ", driver=driver)
 daq.add_publisher(NominalCorePublisher(dataset_rid=DATASET_RID))
 
-daq.open()
-
-try:
+with daq:
     daq.configure_digital_line(
         direction=Direction.INPUT,
         physical_channel=CHANNEL_0,
@@ -73,8 +71,4 @@ try:
     read0 = daq.read_digital_line(channel="di_0")
     read1 = daq.read_digital_line(channel="di_1")
     print(f"Values: ", read0.latest, read1.latest)
-
-finally:
-    print("Closing DAQ")
-    daq.close()
 ```

--- a/docs/guides/instrumentation/examples/daq/daq_read_digital_port.mdx
+++ b/docs/guides/instrumentation/examples/daq/daq_read_digital_port.mdx
@@ -41,9 +41,7 @@ DATASET_RID = "<dataset_rid>"  # Replace with your dataset RID.
 daq = InstroDAQ(name="myDAQ", driver=driver)
 daq.add_publisher(NominalCorePublisher(dataset_rid=DATASET_RID))
 
-daq.open()
-
-try:
+with daq:
     daq.configure_digital_port(
         direction=Direction.INPUT,
         physical_channel=PORT,
@@ -54,8 +52,4 @@ try:
 
     measurement = daq.read_digital_port(channel="di_port")
     print(f"Port value: {int(measurement.latest)}")
-
-finally:
-    print("Closing DAQ")
-    daq.close()
 ```

--- a/docs/guides/instrumentation/examples/daq/daq_relays.mdx
+++ b/docs/guides/instrumentation/examples/daq/daq_relays.mdx
@@ -32,9 +32,7 @@ DATASET_RID = "<dataset_rid>"  # Replace with your dataset RID.
 daq = InstroDAQ(name="myDAQ", driver=driver)
 daq.add_publisher(NominalCorePublisher(dataset_rid=DATASET_RID))
 
-daq.open()
-
-try:
+with daq:
     daq.configure_relay_channel(physical_channel=CHANNEL_0, alias="relay0")
     daq.configure_relay_channel(physical_channel=CHANNEL_1, alias="relay1")
     daq.close_relay("relay0")
@@ -44,8 +42,4 @@ try:
     daq.open_relay("relay0")
     time.sleep(1)
     daq.open_relay("relay1")
-
-finally:
-    print("Closing DAQ")
-    daq.close()
 ```

--- a/docs/guides/instrumentation/examples/daq/daq_write_analog_sw_timed.mdx
+++ b/docs/guides/instrumentation/examples/daq/daq_write_analog_sw_timed.mdx
@@ -44,9 +44,7 @@ DATASET_RID = "<dataset_rid>"  # Replace with your dataset RID.
 daq = InstroDAQ(name="myDAQ", driver=driver)
 daq.add_publisher(NominalCorePublisher(dataset_rid=DATASET_RID))
 
-daq.open()
-
-try:
+with daq:
     daq.configure_analog_channel(
         direction=Direction.OUTPUT, physical_channel=CHANNEL_0, alias=f"ao_0", range_min=0, range_max=5
     )
@@ -56,8 +54,4 @@ try:
 
     daq.write_analog_value("ao_0", 2.2)
     daq.write_analog_value("ao_1", 3.4)
-
-finally:
-    print("Closing DAQ")
-    daq.close()
 ```

--- a/docs/guides/instrumentation/examples/daq/daq_write_digital_line.mdx
+++ b/docs/guides/instrumentation/examples/daq/daq_write_digital_line.mdx
@@ -50,9 +50,7 @@ DATASET_RID = "<dataset_rid>"  # Replace with your dataset RID.
 daq = InstroDAQ(name="myDAQ", driver=driver)
 daq.add_publisher(NominalCorePublisher(dataset_rid=DATASET_RID))
 
-daq.open()
-
-try:
+with daq:
     daq.configure_digital_line(
         direction=Direction.OUTPUT, physical_channel=CHANNEL_0, alias=f"do_0", logic=Logic.HIGH, logic_level=5.0
     )
@@ -62,8 +60,4 @@ try:
 
     daq.write_digital_line(channel="do_0", data=1)
     daq.write_digital_line(channel="do_1", data=0)
-
-finally:
-    print("Closing DAQ")
-    daq.close()
 ```

--- a/docs/guides/instrumentation/examples/daq/daq_write_digital_port.mdx
+++ b/docs/guides/instrumentation/examples/daq/daq_write_digital_port.mdx
@@ -41,9 +41,7 @@ DATASET_RID = "<dataset_rid>"  # Replace with your dataset RID.
 daq = InstroDAQ(name="myDAQ", driver=driver)
 daq.add_publisher(NominalCorePublisher(dataset_rid=DATASET_RID))
 
-daq.open()
-
-try:
+with daq:
     daq.configure_digital_port(
         direction=Direction.OUTPUT,
         physical_channel=PORT,
@@ -55,8 +53,4 @@ try:
 
     # Drive lines 0-3 high, 4-7 low.
     daq.write_digital_port(channel="do_port", data=0x0F)
-
-finally:
-    print("Closing DAQ")
-    daq.close()
 ```

--- a/docs/guides/instrumentation/examples/dmm/dmm_basic.mdx
+++ b/docs/guides/instrumentation/examples/dmm/dmm_basic.mdx
@@ -28,11 +28,8 @@ dmm = InstroDMM(
     ),
     publishers=[NominalCorePublisher(dataset_rid=DATASET_RID)],
 )
-dmm.open()
-
-dmm.set_measurement_function(function=MeasurementFunction.DC_VOLTAGE)
-response = dmm.read()
-print(response)
-
-dmm.close()
+with dmm:
+    dmm.set_measurement_function(function=MeasurementFunction.DC_VOLTAGE)
+    response = dmm.read()
+    print(response)
 ```

--- a/docs/guides/instrumentation/examples/eload/eload.mdx
+++ b/docs/guides/instrumentation/examples/eload/eload.mdx
@@ -33,9 +33,8 @@ eload = InstroELoad(
 eload.add_publisher(NominalCorePublisher(dataset_rid=DATASET_RID))
 
 eload.background_interval = 0.5  # query eload for new values every half second.
-eload.open()
 
-try:
+with eload:
     # This launches a background daemon that queries the measured voltage, current, and output state.
     eload.start()
 
@@ -62,7 +61,4 @@ try:
     time.sleep(0.5)
 
     eload.output_enable(enable=False)
-
-finally:
-    eload.close()
 ```

--- a/docs/guides/instrumentation/examples/i2c/i2c_basic.mdx
+++ b/docs/guides/instrumentation/examples/i2c/i2c_basic.mdx
@@ -103,8 +103,7 @@ i2c = I2CInterface(
 )
 i2c.add_publisher(NominalCorePublisher(dataset_rid=DATASET_RID))
 
-i2c.open()
-try:
+with i2c:
     i2c.write("power_gpio", "LED_DIRECTION", 0x00)
     i2c.write("power_gpio", "LED_OUTPUT_STATE", 0xFF)
 
@@ -114,7 +113,4 @@ try:
         for i in range(1, 6):
             i2c.write("power_gpio", "LED_OUTPUT_STATE", int(state), f"led_{i}")
             time.sleep(0.25)
-
-finally:
-    i2c.close()
 ```

--- a/docs/guides/instrumentation/examples/i2c/i2c_command.mdx
+++ b/docs/guides/instrumentation/examples/i2c/i2c_command.mdx
@@ -83,11 +83,7 @@ i2c = I2CInterface(
 )
 i2c.add_publisher(NominalCorePublisher(dataset_rid=DATASET_RID))
 
-i2c.open()
-try:
+with i2c:
     value = i2c.query("VOLTAGE_ADC", "ch0")
     print(value)
-
-finally:
-    i2c.close()
 ```

--- a/docs/guides/instrumentation/examples/modbus/labjack_t4_loopback_test.mdx
+++ b/docs/guides/instrumentation/examples/modbus/labjack_t4_loopback_test.mdx
@@ -71,11 +71,10 @@ def _value(measurement, channel: str) -> float:
 
 def main() -> None:
     lj = ModbusDevice(config=CONFIG)
-    lj.open()
 
     failures: list[str] = []
 
-    try:
+    with lj:
         print(f"Connected to LabJack T4 at {HOST}:{PORT}")
 
         # --- Device identity ---
@@ -124,10 +123,6 @@ def main() -> None:
                 print(f"  - {f}")
         else:
             print("LOOPBACK PASSED")
-
-    finally:
-        print("\nClosing connection")
-        lj.close()
 
 
 if __name__ == "__main__":

--- a/docs/guides/instrumentation/examples/modbus/minimal_example.mdx
+++ b/docs/guides/instrumentation/examples/modbus/minimal_example.mdx
@@ -22,8 +22,7 @@ CONNECTION = {"transport": "tcp", "host": "127.0.0.1", "port": 5020}
 
 def main() -> None:
     device = ModbusDevice(config=CONFIG_PATH, connection=CONNECTION)
-    device.open()
-    try:
+    with device:
         # Read a holding register (float32 temperature, seeded to 72.5 in the sim).
         m = device.read("temperature")
         print(f"temperature: {m.latest}")
@@ -35,8 +34,6 @@ def main() -> None:
         # Read back to confirm the write landed.
         m = device.read("setpoint")
         print(f"setpoint (after write): {m.latest}")
-    finally:
-        device.close()
 
 
 if __name__ == "__main__":

--- a/docs/guides/instrumentation/examples/psu/psu.mdx
+++ b/docs/guides/instrumentation/examples/psu/psu.mdx
@@ -35,10 +35,8 @@ psu = InstroPSU(
 psu.add_publisher(NominalCorePublisher(dataset_rid=DATASET_RID))
 
 
-try:
+with psu:
     # Set up initial state of test
-    psu.open()
-
     psu.output_enable(False, channel=2)
     psu.set_current_limit(0.2, channel=2)
     psu.set_voltage(0, channel=2)
@@ -58,7 +56,4 @@ try:
         time.sleep(1)
 
     psu.output_enable(False, channel=2)
-
-finally:
-    psu.close()
 ```

--- a/docs/guides/instrumentation/examples/psu/psu_background_daemon.mdx
+++ b/docs/guides/instrumentation/examples/psu/psu_background_daemon.mdx
@@ -26,9 +26,8 @@ psu = InstroPSU(
 psu.add_publisher(NominalCorePublisher(dataset_rid=DATASET_RID))
 
 psu.background_interval = 0.5  # query psu for new values every half second.
-psu.open()
 
-try:
+with psu:
     # This launches a background daemon that queries the measured voltage, current, and output state.
     psu.start()
 
@@ -52,7 +51,4 @@ try:
 
     print("Done")
     psu.output_enable(False, 1)
-
-finally:
-    psu.close()
 ```

--- a/docs/guides/instrumentation/examples/publishers/publish_buffered.mdx
+++ b/docs/guides/instrumentation/examples/publishers/publish_buffered.mdx
@@ -28,10 +28,8 @@ buffered_publisher = BasicBufferedPublisher(core_publisher, buffer_size=20)  # e
 
 psu.add_publisher(buffered_publisher)
 
-try:
+with psu:
     # Set up initial state of test
-    psu.open()
-
     psu.output_enable(False, channel=2)
     psu.set_current_limit(0.2, channel=2)
     psu.set_voltage(0, channel=2)
@@ -49,8 +47,4 @@ try:
         psu.get_voltage(channel=2)  # This value will not be printed
 
     psu.output_enable(False, channel=2)
-
-finally:
-    # Shut it down
-    psu.close()
 ```

--- a/docs/guides/instrumentation/examples/publishers/publish_custom.mdx
+++ b/docs/guides/instrumentation/examples/publishers/publish_custom.mdx
@@ -35,10 +35,8 @@ class PrintChannelDelegate:
 psu = InstroPSU(name="myPSU", driver=SimulatedPSU(VISA_RESOURCE), num_channels=2)
 psu.add_publisher(PrintChannelDelegate(channel_name="myPSU.ch2.current"))
 
-try:
+with psu:
     # Set up initial state of test
-    psu.open()
-
     psu.output_enable(False, channel=2)
     psu.set_current_limit(0.2, channel=2)
     psu.set_voltage(0, channel=2)
@@ -56,8 +54,4 @@ try:
         psu.get_voltage(channel=2)  # This value will not be printed
 
     psu.output_enable(False, channel=2)
-
-finally:
-    # Shut it down
-    psu.close()
 ```

--- a/docs/guides/instrumentation/examples/publishers/publish_file.mdx
+++ b/docs/guides/instrumentation/examples/publishers/publish_file.mdx
@@ -27,21 +27,23 @@ daq = InstroDAQ(
     publishers=[FilePublisher(directory="./captures", format="avro", custom_file_name="test_file")],
 )
 
-daq.open()
+with daq:
+    daq.configure_analog_channel(
+        direction=Direction.INPUT, physical_channel=AI_CH0, alias="ai_0", range_min=0, range_max=5
+    )
+    daq.configure_analog_channel(
+        direction=Direction.INPUT, physical_channel=AI_CH1, alias="ai_1", range_min=0, range_max=5
+    )
+    daq.configure_analog_channel(
+        direction=Direction.OUTPUT, physical_channel=AO_CH0, alias="ao_0", range_min=0, range_max=5
+    )
+    daq.configure_analog_channel(
+        direction=Direction.OUTPUT, physical_channel=AO_CH1, alias="ao_1", range_min=0, range_max=5
+    )
+    daq.configure_ai_sample_rate(sample_rate=100)
 
-daq.configure_analog_channel(direction=Direction.INPUT, physical_channel=AI_CH0, alias="ai_0", range_min=0, range_max=5)
-daq.configure_analog_channel(direction=Direction.INPUT, physical_channel=AI_CH1, alias="ai_1", range_min=0, range_max=5)
-daq.configure_analog_channel(
-    direction=Direction.OUTPUT, physical_channel=AO_CH0, alias="ao_0", range_min=0, range_max=5
-)
-daq.configure_analog_channel(
-    direction=Direction.OUTPUT, physical_channel=AO_CH1, alias="ao_1", range_min=0, range_max=5
-)
-daq.configure_ai_sample_rate(sample_rate=100)
+    daq.start()
 
-daq.start()
-
-try:
     while True:
         try:
             ai_0 = daq.get_channel("myDAQ.ai_0", 1, True).latest
@@ -51,6 +53,4 @@ try:
         except KeyboardInterrupt:
             break
     daq.stop()
-finally:
-    daq.close()
 ```

--- a/docs/guides/instrumentation/examples/publishers/publish_queued.mdx
+++ b/docs/guides/instrumentation/examples/publishers/publish_queued.mdx
@@ -26,10 +26,8 @@ queued_publisher = QueuedPublisher(core_publisher, max_queue_size=100, wait_for_
 
 psu.add_publisher(queued_publisher)
 
-try:
+with psu:
     # Set up initial state of test
-    psu.open()
-
     psu.output_enable(False, channel=2)
     psu.set_current_limit(0.2, channel=2)
     psu.set_voltage(0, channel=2)
@@ -53,8 +51,4 @@ try:
     psu.output_enable(False, channel=2)
 
     print("Done, waiting for queue to be empty...")
-
-finally:
-    # Shut it down
-    psu.close()
 ```

--- a/docs/guides/instrumentation/examples/test_rack_example/test_rack.mdx
+++ b/docs/guides/instrumentation/examples/test_rack_example/test_rack.mdx
@@ -28,94 +28,87 @@ DATASET_RID = "<dataset_rid>"  # Replace with your dataset RID.
 
 
 def main():
-    try:
-        # ====== SETUP =========
-        # Define instruments
-        daq = InstroDAQ(
-            name="myDAQ",
-            driver=Keysight34980A("USB0::0x0957::0x0507::MY44001757::INSTR"),
-            dataset_rid=DATASET_RID,
-        )
-        psu = InstroPSU(
-            name="myPSU",
-            driver=BK9115("USB0::0xFFFF::0x9115::800422020766920015::INSTR"),
-            num_channels=2,
-            dataset_rid=DATASET_RID,
-        )
-        eload = InstroELoad(
-            name="myELoad",
-            driver=BK85XXB(
-                VisaConfig(
-                    visa_resource="ASRL19::INSTR",
-                    serial_config=SerialConfig(baud_rate=9600),
-                )
-            ),
-            dataset_rid=DATASET_RID,
-        )
+    # ====== SETUP =========
+    # Define instruments
+    daq = InstroDAQ(
+        name="myDAQ",
+        driver=Keysight34980A("USB0::0x0957::0x0507::MY44001757::INSTR"),
+        dataset_rid=DATASET_RID,
+    )
+    psu = InstroPSU(
+        name="myPSU",
+        driver=BK9115("USB0::0xFFFF::0x9115::800422020766920015::INSTR"),
+        num_channels=2,
+        dataset_rid=DATASET_RID,
+    )
+    eload = InstroELoad(
+        name="myELoad",
+        driver=BK85XXB(
+            VisaConfig(
+                visa_resource="ASRL19::INSTR",
+                serial_config=SerialConfig(baud_rate=9600),
+            )
+        ),
+        dataset_rid=DATASET_RID,
+    )
 
-        # Open instruments
-        daq.open()
-        psu.open()
-        eload.open()
+    # The context manager opens each instrument on entry and closes them on exit,
+    # including if the block raises.
+    with daq, psu, eload:
+        try:
+            # Configure DAQ
+            daq.configure_analog_channel(direction=Direction.INPUT, physical_channel="1010", alias="psu_v")
+            daq.configure_ai_sample_rate(sample_rate=1000)
 
-        # Configure DAQ
-        daq.configure_analog_channel(direction=Direction.INPUT, physical_channel="1010", alias="psu_v")
-        daq.configure_ai_sample_rate(sample_rate=1000)
+            # Start the DAQ to monitor the power supply/eload prior to using it
+            daq.start()
 
-        # Start the DAQ to monitor the power supply/eload prior to using it
-        daq.start()
+            time.sleep(2)  # Let's chill...for fun. Grab a drink
 
-        time.sleep(2)  # Let's chill...for fun. Grab a drink
+            # Ensure powersupply is in a known state
+            psu.output_enable(False, channel=1)
+            psu.set_voltage(0, channel=1)
+            psu.set_current_limit(1.5, channel=1)
 
-        # Ensure powersupply is in a known state
-        psu.output_enable(False, channel=1)
-        psu.set_voltage(0, channel=1)
-        psu.set_current_limit(1.5, channel=1)
+            time.sleep(2)  # More fun. More drinks.
 
-        time.sleep(2)  # More fun. More drinks.
+            # Ensure eload is in a known state
+            eload.output_enable(False)
+            eload.set_mode(LoadMode.CR)  # Constant Resistance
+            eload.set_level(10)  # Ohms
 
-        # Ensure eload is in a known state
-        eload.output_enable(False)
-        eload.set_mode(LoadMode.CR)  # Constant Resistance
-        eload.set_level(10)  # Ohms
+            # Start the power supply and eload monitoring
+            psu.background_interval = 0.1
+            eload.background_interval = 0.1
+            psu.start()
+            eload.start()
 
-        # Start the power supply and eload monitoring
-        psu.background_interval = 0.1
-        eload.background_interval = 0.1
-        psu.start()
-        eload.start()
+            time.sleep(2)  # More time to drink and chill
 
-        time.sleep(2)  # More time to drink and chill
+            # Power up the power supply
+            psu.output_enable(True, channel=1)
 
-        # Power up the power supply
-        psu.output_enable(True, channel=1)
+            time.sleep(2)  # Drink up, it's time to do work.
 
-        time.sleep(2)  # Drink up, it's time to do work.
+            # ========= THE TEST =========
+            # Ramp up the PSU voltage
+            eload.output_enable(True)
+            for voltage in range(10):
+                psu.set_voltage(voltage)
+                time.sleep(1)
 
-        # ========= THE TEST =========
-        # Ramp up the PSU voltage
-        eload.output_enable(True)
-        for voltage in range(10):
-            psu.set_voltage(voltage)
-            time.sleep(1)
+            # Now keep the psu the same level and ramp up the eload resistance
+            for resistance in range(10, 100, 10):
+                eload.set_level(resistance)
+                time.sleep(1)
+            # ========== END TEST =======
 
-        # Now keep the psu the same level and ramp up the eload resistance
-        for resistance in range(10, 100, 10):
-            eload.set_level(resistance)
-            time.sleep(1)
-        # ========== END TEST =======
+        finally:
+            # Put the test stand into a safe state before the instruments close.
+            eload.output_enable(False)
+            psu.output_enable(False)
 
-    finally:
-        # ==== CLEANUP =======
-        #  Put the test stand into a safe state
-        eload.output_enable(False)
-        psu.output_enable(False)
-
-        time.sleep(3)  # give space so that shutdown is observed
-
-        eload.close()
-        psu.close()
-        daq.close()
+            time.sleep(3)  # give space so that shutdown is observed
 
 
 if __name__ == "__main__":

--- a/examples/daq/daq_analog_loopback.py
+++ b/examples/daq/daq_analog_loopback.py
@@ -46,9 +46,7 @@ DATASET_RID = "<dataset_rid>"  # Replace with your dataset RID.
 daq = InstroDAQ(name="myDAQ", driver=driver)
 daq.add_publisher(NominalCorePublisher(dataset_rid=DATASET_RID))
 
-daq.open()
-
-try:
+with daq:
     daq.configure_analog_channel(
         direction=Direction.INPUT, physical_channel=AI_CH0, alias="ai_0", range_min=0, range_max=5
     )
@@ -81,7 +79,3 @@ try:
             break
 
     daq.stop()
-
-finally:
-    print("Closing DAQ")
-    daq.close()

--- a/examples/daq/daq_multi_rate_ni.py
+++ b/examples/daq/daq_multi_rate_ni.py
@@ -32,10 +32,7 @@ SLOW_SAMPLE_RATE = 1000  # Hz
 daq_fast = InstroDAQ(name="daqFast", driver=NIDAQDriver(device_id=DEVICE))
 daq_slow = InstroDAQ(name="daqSlow", driver=NIDAQDriver(device_id=DEVICE))
 
-daq_fast.open()
-daq_slow.open()
-
-try:
+with daq_fast, daq_slow:
     # A physical channel belongs to exactly one instance; allocate without overlap.
     # Each instance streams CHANNELS_PER_TASK channels from its own module.
     for i in range(CHANNELS_PER_TASK):
@@ -72,7 +69,3 @@ try:
     # The acquisitions are independent: stopping one does not affect the other.
     daq_fast.stop()
     daq_slow.stop()
-finally:
-    print("Closing DAQs")
-    daq_fast.close()
-    daq_slow.close()

--- a/examples/daq/daq_read_analog_hw_timed.py
+++ b/examples/daq/daq_read_analog_hw_timed.py
@@ -51,9 +51,7 @@ DATASET_RID = "<dataset_rid>"  # Replace with your dataset RID.
 daq = InstroDAQ(name="myDAQ", driver=driver)
 daq.add_publisher(NominalCorePublisher(dataset_rid=DATASET_RID))
 
-daq.open()
-
-try:
+with daq:
     daq.configure_analog_channel(
         direction=Direction.INPUT, physical_channel=CHANNEL_0, alias=f"ch_0", range_min=0, range_max=5
     )
@@ -80,6 +78,3 @@ try:
             break
 
     daq.stop()
-finally:
-    print("Closing DAQ")
-    daq.close()

--- a/examples/daq/daq_read_analog_hw_timed_no_background.py
+++ b/examples/daq/daq_read_analog_hw_timed_no_background.py
@@ -49,9 +49,7 @@ DATASET_RID = "<dataset_rid>"  # Replace with your dataset RID.
 daq = InstroDAQ(name="myDAQ", driver=driver)
 daq.add_publisher(NominalCorePublisher(dataset_rid=DATASET_RID))
 
-daq.open()
-
-try:
+with daq:
     daq.configure_analog_channel(
         direction=Direction.INPUT, physical_channel=CHANNEL_0, alias=f"ch_0", range_min=0, range_max=5
     )
@@ -75,6 +73,3 @@ try:
             break
 
     daq.stop()
-finally:
-    print("Closing DAQ")
-    daq.close()

--- a/examples/daq/daq_read_analog_sw_timed.py
+++ b/examples/daq/daq_read_analog_sw_timed.py
@@ -51,9 +51,7 @@ DATASET_RID = "<dataset_rid>"  # Replace with your dataset RID.
 daq = InstroDAQ(name="myDAQ", driver=driver)
 daq.add_publisher(NominalCorePublisher(dataset_rid=DATASET_RID))
 
-daq.open()
-
-try:
+with daq:
     daq.configure_analog_channel(
         direction=Direction.INPUT, physical_channel=CHANNEL_0, alias=f"ch_0", range_min=0, range_max=5
     )
@@ -66,7 +64,3 @@ try:
         measurement = daq.read_analog()
         print(measurement)
         time.sleep(1)  # Software sleep. Then request daq to sample new points.
-
-finally:
-    print("Closing DAQ")
-    daq.close()

--- a/examples/daq/daq_read_digital_line.py
+++ b/examples/daq/daq_read_digital_line.py
@@ -49,9 +49,7 @@ DATASET_RID = "<dataset_rid>"  # Replace with your dataset RID.
 daq = InstroDAQ(name="myDAQ", driver=driver)
 daq.add_publisher(NominalCorePublisher(dataset_rid=DATASET_RID))
 
-daq.open()
-
-try:
+with daq:
     daq.configure_digital_line(
         direction=Direction.INPUT,
         physical_channel=CHANNEL_0,
@@ -68,7 +66,3 @@ try:
     read0 = daq.read_digital_line(channel="di_0")
     read1 = daq.read_digital_line(channel="di_1")
     print(f"Values: ", read0.latest, read1.latest)
-
-finally:
-    print("Closing DAQ")
-    daq.close()

--- a/examples/daq/daq_read_digital_port.py
+++ b/examples/daq/daq_read_digital_port.py
@@ -36,9 +36,7 @@ DATASET_RID = "<dataset_rid>"  # Replace with your dataset RID.
 daq = InstroDAQ(name="myDAQ", driver=driver)
 daq.add_publisher(NominalCorePublisher(dataset_rid=DATASET_RID))
 
-daq.open()
-
-try:
+with daq:
     daq.configure_digital_port(
         direction=Direction.INPUT,
         physical_channel=PORT,
@@ -49,7 +47,3 @@ try:
 
     measurement = daq.read_digital_port(channel="di_port")
     print(f"Port value: {int(measurement.latest)}")
-
-finally:
-    print("Closing DAQ")
-    daq.close()

--- a/examples/daq/daq_relays.py
+++ b/examples/daq/daq_relays.py
@@ -27,9 +27,7 @@ DATASET_RID = "<dataset_rid>"  # Replace with your dataset RID.
 daq = InstroDAQ(name="myDAQ", driver=driver)
 daq.add_publisher(NominalCorePublisher(dataset_rid=DATASET_RID))
 
-daq.open()
-
-try:
+with daq:
     daq.configure_relay_channel(physical_channel=CHANNEL_0, alias="relay0")
     daq.configure_relay_channel(physical_channel=CHANNEL_1, alias="relay1")
     daq.close_relay("relay0")
@@ -39,7 +37,3 @@ try:
     daq.open_relay("relay0")
     time.sleep(1)
     daq.open_relay("relay1")
-
-finally:
-    print("Closing DAQ")
-    daq.close()

--- a/examples/daq/daq_write_analog_sw_timed.py
+++ b/examples/daq/daq_write_analog_sw_timed.py
@@ -39,9 +39,7 @@ DATASET_RID = "<dataset_rid>"  # Replace with your dataset RID.
 daq = InstroDAQ(name="myDAQ", driver=driver)
 daq.add_publisher(NominalCorePublisher(dataset_rid=DATASET_RID))
 
-daq.open()
-
-try:
+with daq:
     daq.configure_analog_channel(
         direction=Direction.OUTPUT, physical_channel=CHANNEL_0, alias=f"ao_0", range_min=0, range_max=5
     )
@@ -51,7 +49,3 @@ try:
 
     daq.write_analog_value("ao_0", 2.2)
     daq.write_analog_value("ao_1", 3.4)
-
-finally:
-    print("Closing DAQ")
-    daq.close()

--- a/examples/daq/daq_write_digital_line.py
+++ b/examples/daq/daq_write_digital_line.py
@@ -45,9 +45,7 @@ DATASET_RID = "<dataset_rid>"  # Replace with your dataset RID.
 daq = InstroDAQ(name="myDAQ", driver=driver)
 daq.add_publisher(NominalCorePublisher(dataset_rid=DATASET_RID))
 
-daq.open()
-
-try:
+with daq:
     daq.configure_digital_line(
         direction=Direction.OUTPUT, physical_channel=CHANNEL_0, alias=f"do_0", logic=Logic.HIGH, logic_level=5.0
     )
@@ -57,7 +55,3 @@ try:
 
     daq.write_digital_line(channel="do_0", data=1)
     daq.write_digital_line(channel="do_1", data=0)
-
-finally:
-    print("Closing DAQ")
-    daq.close()

--- a/examples/daq/daq_write_digital_port.py
+++ b/examples/daq/daq_write_digital_port.py
@@ -36,9 +36,7 @@ DATASET_RID = "<dataset_rid>"  # Replace with your dataset RID.
 daq = InstroDAQ(name="myDAQ", driver=driver)
 daq.add_publisher(NominalCorePublisher(dataset_rid=DATASET_RID))
 
-daq.open()
-
-try:
+with daq:
     daq.configure_digital_port(
         direction=Direction.OUTPUT,
         physical_channel=PORT,
@@ -50,7 +48,3 @@ try:
 
     # Drive lines 0-3 high, 4-7 low.
     daq.write_digital_port(channel="do_port", data=0x0F)
-
-finally:
-    print("Closing DAQ")
-    daq.close()

--- a/examples/dmm/dmm_basic.py
+++ b/examples/dmm/dmm_basic.py
@@ -23,10 +23,7 @@ dmm = InstroDMM(
     ),
     publishers=[NominalCorePublisher(dataset_rid=DATASET_RID)],
 )
-dmm.open()
-
-dmm.set_measurement_function(function=MeasurementFunction.DC_VOLTAGE)
-response = dmm.read()
-print(response)
-
-dmm.close()
+with dmm:
+    dmm.set_measurement_function(function=MeasurementFunction.DC_VOLTAGE)
+    response = dmm.read()
+    print(response)

--- a/examples/eload/eload.py
+++ b/examples/eload/eload.py
@@ -28,9 +28,8 @@ eload = InstroELoad(
 eload.add_publisher(NominalCorePublisher(dataset_rid=DATASET_RID))
 
 eload.background_interval = 0.5  # query eload for new values every half second.
-eload.open()
 
-try:
+with eload:
     # This launches a background daemon that queries the measured voltage, current, and output state.
     eload.start()
 
@@ -57,6 +56,3 @@ try:
     time.sleep(0.5)
 
     eload.output_enable(enable=False)
-
-finally:
-    eload.close()

--- a/examples/i2c/i2c_basic.py
+++ b/examples/i2c/i2c_basic.py
@@ -98,8 +98,7 @@ i2c = I2CInterface(
 )
 i2c.add_publisher(NominalCorePublisher(dataset_rid=DATASET_RID))
 
-i2c.open()
-try:
+with i2c:
     i2c.write("power_gpio", "LED_DIRECTION", 0x00)
     i2c.write("power_gpio", "LED_OUTPUT_STATE", 0xFF)
 
@@ -109,6 +108,3 @@ try:
         for i in range(1, 6):
             i2c.write("power_gpio", "LED_OUTPUT_STATE", int(state), f"led_{i}")
             time.sleep(0.25)
-
-finally:
-    i2c.close()

--- a/examples/i2c/i2c_command.py
+++ b/examples/i2c/i2c_command.py
@@ -78,10 +78,6 @@ i2c = I2CInterface(
 )
 i2c.add_publisher(NominalCorePublisher(dataset_rid=DATASET_RID))
 
-i2c.open()
-try:
+with i2c:
     value = i2c.query("VOLTAGE_ADC", "ch0")
     print(value)
-
-finally:
-    i2c.close()

--- a/examples/modbus/labjack_t4_loopback_test.py
+++ b/examples/modbus/labjack_t4_loopback_test.py
@@ -66,11 +66,10 @@ def _value(measurement, channel: str) -> float:
 
 def main() -> None:
     lj = ModbusDevice(config=CONFIG)
-    lj.open()
 
     failures: list[str] = []
 
-    try:
+    with lj:
         print(f"Connected to LabJack T4 at {HOST}:{PORT}")
 
         # --- Device identity ---
@@ -119,10 +118,6 @@ def main() -> None:
                 print(f"  - {f}")
         else:
             print("LOOPBACK PASSED")
-
-    finally:
-        print("\nClosing connection")
-        lj.close()
 
 
 if __name__ == "__main__":

--- a/examples/modbus/minimal_example.py
+++ b/examples/modbus/minimal_example.py
@@ -17,8 +17,7 @@ CONNECTION = {"transport": "tcp", "host": "127.0.0.1", "port": 5020}
 
 def main() -> None:
     device = ModbusDevice(config=CONFIG_PATH, connection=CONNECTION)
-    device.open()
-    try:
+    with device:
         # Read a holding register (float32 temperature, seeded to 72.5 in the sim).
         m = device.read("temperature")
         print(f"temperature: {m.latest}")
@@ -30,8 +29,6 @@ def main() -> None:
         # Read back to confirm the write landed.
         m = device.read("setpoint")
         print(f"setpoint (after write): {m.latest}")
-    finally:
-        device.close()
 
 
 if __name__ == "__main__":

--- a/examples/psu/psu.py
+++ b/examples/psu/psu.py
@@ -30,10 +30,8 @@ psu = InstroPSU(
 psu.add_publisher(NominalCorePublisher(dataset_rid=DATASET_RID))
 
 
-try:
+with psu:
     # Set up initial state of test
-    psu.open()
-
     psu.output_enable(False, channel=2)
     psu.set_current_limit(0.2, channel=2)
     psu.set_voltage(0, channel=2)
@@ -53,6 +51,3 @@ try:
         time.sleep(1)
 
     psu.output_enable(False, channel=2)
-
-finally:
-    psu.close()

--- a/examples/psu/psu_background_daemon.py
+++ b/examples/psu/psu_background_daemon.py
@@ -21,9 +21,8 @@ psu = InstroPSU(
 psu.add_publisher(NominalCorePublisher(dataset_rid=DATASET_RID))
 
 psu.background_interval = 0.5  # query psu for new values every half second.
-psu.open()
 
-try:
+with psu:
     # This launches a background daemon that queries the measured voltage, current, and output state.
     psu.start()
 
@@ -47,6 +46,3 @@ try:
 
     print("Done")
     psu.output_enable(False, 1)
-
-finally:
-    psu.close()

--- a/examples/publishers/publish_buffered.py
+++ b/examples/publishers/publish_buffered.py
@@ -23,10 +23,8 @@ buffered_publisher = BasicBufferedPublisher(core_publisher, buffer_size=20)  # e
 
 psu.add_publisher(buffered_publisher)
 
-try:
+with psu:
     # Set up initial state of test
-    psu.open()
-
     psu.output_enable(False, channel=2)
     psu.set_current_limit(0.2, channel=2)
     psu.set_voltage(0, channel=2)
@@ -44,7 +42,3 @@ try:
         psu.get_voltage(channel=2)  # This value will not be printed
 
     psu.output_enable(False, channel=2)
-
-finally:
-    # Shut it down
-    psu.close()

--- a/examples/publishers/publish_custom.py
+++ b/examples/publishers/publish_custom.py
@@ -30,10 +30,8 @@ class PrintChannelDelegate:
 psu = InstroPSU(name="myPSU", driver=SimulatedPSU(VISA_RESOURCE), num_channels=2)
 psu.add_publisher(PrintChannelDelegate(channel_name="myPSU.ch2.current"))
 
-try:
+with psu:
     # Set up initial state of test
-    psu.open()
-
     psu.output_enable(False, channel=2)
     psu.set_current_limit(0.2, channel=2)
     psu.set_voltage(0, channel=2)
@@ -51,7 +49,3 @@ try:
         psu.get_voltage(channel=2)  # This value will not be printed
 
     psu.output_enable(False, channel=2)
-
-finally:
-    # Shut it down
-    psu.close()

--- a/examples/publishers/publish_file.py
+++ b/examples/publishers/publish_file.py
@@ -22,21 +22,23 @@ daq = InstroDAQ(
     publishers=[FilePublisher(directory="./captures", format="avro", custom_file_name="test_file")],
 )
 
-daq.open()
+with daq:
+    daq.configure_analog_channel(
+        direction=Direction.INPUT, physical_channel=AI_CH0, alias="ai_0", range_min=0, range_max=5
+    )
+    daq.configure_analog_channel(
+        direction=Direction.INPUT, physical_channel=AI_CH1, alias="ai_1", range_min=0, range_max=5
+    )
+    daq.configure_analog_channel(
+        direction=Direction.OUTPUT, physical_channel=AO_CH0, alias="ao_0", range_min=0, range_max=5
+    )
+    daq.configure_analog_channel(
+        direction=Direction.OUTPUT, physical_channel=AO_CH1, alias="ao_1", range_min=0, range_max=5
+    )
+    daq.configure_ai_sample_rate(sample_rate=100)
 
-daq.configure_analog_channel(direction=Direction.INPUT, physical_channel=AI_CH0, alias="ai_0", range_min=0, range_max=5)
-daq.configure_analog_channel(direction=Direction.INPUT, physical_channel=AI_CH1, alias="ai_1", range_min=0, range_max=5)
-daq.configure_analog_channel(
-    direction=Direction.OUTPUT, physical_channel=AO_CH0, alias="ao_0", range_min=0, range_max=5
-)
-daq.configure_analog_channel(
-    direction=Direction.OUTPUT, physical_channel=AO_CH1, alias="ao_1", range_min=0, range_max=5
-)
-daq.configure_ai_sample_rate(sample_rate=100)
+    daq.start()
 
-daq.start()
-
-try:
     while True:
         try:
             ai_0 = daq.get_channel("myDAQ.ai_0", 1, True).latest
@@ -46,5 +48,3 @@ try:
         except KeyboardInterrupt:
             break
     daq.stop()
-finally:
-    daq.close()

--- a/examples/publishers/publish_queued.py
+++ b/examples/publishers/publish_queued.py
@@ -21,10 +21,8 @@ queued_publisher = QueuedPublisher(core_publisher, max_queue_size=100, wait_for_
 
 psu.add_publisher(queued_publisher)
 
-try:
+with psu:
     # Set up initial state of test
-    psu.open()
-
     psu.output_enable(False, channel=2)
     psu.set_current_limit(0.2, channel=2)
     psu.set_voltage(0, channel=2)
@@ -48,7 +46,3 @@ try:
     psu.output_enable(False, channel=2)
 
     print("Done, waiting for queue to be empty...")
-
-finally:
-    # Shut it down
-    psu.close()

--- a/examples/test_rack_example/test_rack.py
+++ b/examples/test_rack_example/test_rack.py
@@ -23,94 +23,87 @@ DATASET_RID = "<dataset_rid>"  # Replace with your dataset RID.
 
 
 def main():
-    try:
-        # ====== SETUP =========
-        # Define instruments
-        daq = InstroDAQ(
-            name="myDAQ",
-            driver=Keysight34980A("USB0::0x0957::0x0507::MY44001757::INSTR"),
-            dataset_rid=DATASET_RID,
-        )
-        psu = InstroPSU(
-            name="myPSU",
-            driver=BK9115("USB0::0xFFFF::0x9115::800422020766920015::INSTR"),
-            num_channels=2,
-            dataset_rid=DATASET_RID,
-        )
-        eload = InstroELoad(
-            name="myELoad",
-            driver=BK85XXB(
-                VisaConfig(
-                    visa_resource="ASRL19::INSTR",
-                    serial_config=SerialConfig(baud_rate=9600),
-                )
-            ),
-            dataset_rid=DATASET_RID,
-        )
+    # ====== SETUP =========
+    # Define instruments
+    daq = InstroDAQ(
+        name="myDAQ",
+        driver=Keysight34980A("USB0::0x0957::0x0507::MY44001757::INSTR"),
+        dataset_rid=DATASET_RID,
+    )
+    psu = InstroPSU(
+        name="myPSU",
+        driver=BK9115("USB0::0xFFFF::0x9115::800422020766920015::INSTR"),
+        num_channels=2,
+        dataset_rid=DATASET_RID,
+    )
+    eload = InstroELoad(
+        name="myELoad",
+        driver=BK85XXB(
+            VisaConfig(
+                visa_resource="ASRL19::INSTR",
+                serial_config=SerialConfig(baud_rate=9600),
+            )
+        ),
+        dataset_rid=DATASET_RID,
+    )
 
-        # Open instruments
-        daq.open()
-        psu.open()
-        eload.open()
+    # The context manager opens each instrument on entry and closes them on exit,
+    # including if the block raises.
+    with daq, psu, eload:
+        try:
+            # Configure DAQ
+            daq.configure_analog_channel(direction=Direction.INPUT, physical_channel="1010", alias="psu_v")
+            daq.configure_ai_sample_rate(sample_rate=1000)
 
-        # Configure DAQ
-        daq.configure_analog_channel(direction=Direction.INPUT, physical_channel="1010", alias="psu_v")
-        daq.configure_ai_sample_rate(sample_rate=1000)
+            # Start the DAQ to monitor the power supply/eload prior to using it
+            daq.start()
 
-        # Start the DAQ to monitor the power supply/eload prior to using it
-        daq.start()
+            time.sleep(2)  # Let's chill...for fun. Grab a drink
 
-        time.sleep(2)  # Let's chill...for fun. Grab a drink
+            # Ensure powersupply is in a known state
+            psu.output_enable(False, channel=1)
+            psu.set_voltage(0, channel=1)
+            psu.set_current_limit(1.5, channel=1)
 
-        # Ensure powersupply is in a known state
-        psu.output_enable(False, channel=1)
-        psu.set_voltage(0, channel=1)
-        psu.set_current_limit(1.5, channel=1)
+            time.sleep(2)  # More fun. More drinks.
 
-        time.sleep(2)  # More fun. More drinks.
+            # Ensure eload is in a known state
+            eload.output_enable(False)
+            eload.set_mode(LoadMode.CR)  # Constant Resistance
+            eload.set_level(10)  # Ohms
 
-        # Ensure eload is in a known state
-        eload.output_enable(False)
-        eload.set_mode(LoadMode.CR)  # Constant Resistance
-        eload.set_level(10)  # Ohms
+            # Start the power supply and eload monitoring
+            psu.background_interval = 0.1
+            eload.background_interval = 0.1
+            psu.start()
+            eload.start()
 
-        # Start the power supply and eload monitoring
-        psu.background_interval = 0.1
-        eload.background_interval = 0.1
-        psu.start()
-        eload.start()
+            time.sleep(2)  # More time to drink and chill
 
-        time.sleep(2)  # More time to drink and chill
+            # Power up the power supply
+            psu.output_enable(True, channel=1)
 
-        # Power up the power supply
-        psu.output_enable(True, channel=1)
+            time.sleep(2)  # Drink up, it's time to do work.
 
-        time.sleep(2)  # Drink up, it's time to do work.
+            # ========= THE TEST =========
+            # Ramp up the PSU voltage
+            eload.output_enable(True)
+            for voltage in range(10):
+                psu.set_voltage(voltage)
+                time.sleep(1)
 
-        # ========= THE TEST =========
-        # Ramp up the PSU voltage
-        eload.output_enable(True)
-        for voltage in range(10):
-            psu.set_voltage(voltage)
-            time.sleep(1)
+            # Now keep the psu the same level and ramp up the eload resistance
+            for resistance in range(10, 100, 10):
+                eload.set_level(resistance)
+                time.sleep(1)
+            # ========== END TEST =======
 
-        # Now keep the psu the same level and ramp up the eload resistance
-        for resistance in range(10, 100, 10):
-            eload.set_level(resistance)
-            time.sleep(1)
-        # ========== END TEST =======
+        finally:
+            # Put the test stand into a safe state before the instruments close.
+            eload.output_enable(False)
+            psu.output_enable(False)
 
-    finally:
-        # ==== CLEANUP =======
-        #  Put the test stand into a safe state
-        eload.output_enable(False)
-        psu.output_enable(False)
-
-        time.sleep(3)  # give space so that shutdown is observed
-
-        eload.close()
-        psu.close()
-        daq.close()
+            time.sleep(3)  # give space so that shutdown is observed
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #51.

## What

Migrate the example scripts from manual `open()` + `try`/`finally`/`close()` to the `with` form. Every category inherits the context-manager protocol from `Instrument` (open on entry, close on exit including on exception), so the `with` block is shorter, exception-safe, and showcases the idiomatic API.

The mirrored example pages under `docs/guides/instrumentation/examples/` are auto-generated from the scripts (`just gen-examples`); regenerated in the same commit.

## Migrated (24 scripts)

All `examples/daq/*.py`, `dmm/dmm_basic.py`, `eload/eload.py`, `i2c/i2c_basic.py`, `i2c/i2c_command.py`, `modbus/minimal_example.py`, `modbus/labjack_t4_loopback_test.py`, `psu/psu.py`, `psu/psu_background_daemon.py`, all `publishers/*.py`, `test_rack_example/test_rack.py`.

## Scope notes (reconciled against recent commits)

- `psu_background_worker.py` (named in the issue) is now `psu_background_daemon.py` — migrated.
- `examples/custom/simple_temp_controller.py` already uses `with` — no change.
- `examples/modbus/modbus_example.py` and `programmatic_config_example.py` use `ModbusDevice(..., autostart=True)`, which opens + starts polling in `__init__`. They never use the manual pattern, so wrapping them in `with` would re-open an already-open device. **Out of scope**, left as-is.
- Prose HAL guides (`psu.mdx`, `daq.mdx`, etc.) were intentionally **not** mass-converted: `quickstart.mdx` deliberately documents both explicit `open()`/`close()` and the `with` block as first-class, and many `.open()`/`.close()` occurrences there are transport-level (`visa.open()`) or driver method definitions, not instrument-lifecycle usage.

## Behavior preserved where `finally` did more than close

- `test_rack.py`: the safe-state shutdown (disable outputs + settle) is kept in an inner `try`/`finally` inside the `with` block, so it still runs before the instruments close.
- `daq_sine_wave_dac0_t4.py`: the `KeyboardInterrupt` handler that parks the DAC at 0 V is kept as an inner `try`/`except` inside the `with` block.

## Verification

`just check` passes (ruff format, mypy, ruff lint all clean); all example scripts byte-compile.
