### PR TITLE
fix(daq): raise clear error when DAQ methods are called before open()

### DIFF
--- a/docs/guides/instrumentation/exceptions.mdx
+++ b/docs/guides/instrumentation/exceptions.mdx
@@ -33,6 +33,30 @@ except FeatureNotSupportedError:
 
 Because it inherits from `InstroError`, `except InstroError` catches it.
 
+## InstrumentNotOpenError
+
+`InstrumentNotOpenError` (a subclass of `InstroError`) is raised when a device-touching method is called before `open()`. It points at the missing lifecycle call instead of surfacing a low-level transport or vendor-SDK error. The message names the instrument instance so you can tell which one you forgot to open.
+
+```python
+from instro.lib.exceptions import InstrumentNotOpenError
+
+daq = InstroDAQ(name="myDAQ", driver=...)
+try:
+    daq.read_analog()  # forgot to call daq.open() first
+except InstrumentNotOpenError:
+    ...
+```
+
+Open the instrument first — directly or via the context manager, which opens on entry and closes on exit:
+
+```python
+with daq:
+    daq.configure_analog_channel(...)
+    daq.read_analog()
+```
+
+Because it inherits from `InstroError`, `except InstroError` catches it.
+
 ## NotImplementedError
 
 `NotImplementedError` is the Python builtin, not an `InstroError`. Each `<Category>DriverBase` declares its optional methods to raise `NotImplementedError` by default, and a driver overrides only the ones its instrument supports. Calling an optional method on a driver that has not overridden it therefore raises `NotImplementedError`: the capability is part of the category contract, but this driver does not implement it.

--- a/instro/daq/daq.py
+++ b/instro/daq/daq.py
@@ -483,6 +483,7 @@ class InstroDAQ(Instrument):
             scaler: Optional ``Scaler`` applied to AI samples after read.
             terminal_config: Terminal wiring (RSE / NRSE / DIFF) for the channel.
         """
+        self._require_open()
         channel = AnalogChannel(
             physical_channel=physical_channel,
             alias=alias if alias else physical_channel,
@@ -517,6 +518,7 @@ class InstroDAQ(Instrument):
             samples_per_channel: Samples per channel per ``read_analog()`` call;
                 defaults to 10 % of ``sample_rate`` (e.g. 100 at 1 kHz).
         """
+        self._require_open()
         if not samples_per_channel:
             samples_per_channel = max(1, int(sample_rate // 10))
 
@@ -667,6 +669,7 @@ class InstroDAQ(Instrument):
             logic_level: Voltage threshold (volts); the driver default is used when ``None``.
             alias: Friendly name; defaults to ``physical_channel``.
         """
+        self._require_open()
         match direction:
             case Direction.INPUT:
                 self._driver.configure_di_line_channel(
@@ -703,6 +706,7 @@ class InstroDAQ(Instrument):
             logic_level: Voltage threshold (volts); the driver default is used when ``None``.
             alias: Friendly name; defaults to ``physical_channel``.
         """
+        self._require_open()
         match direction:
             case Direction.INPUT:
                 self._driver.configure_di_port_channel(
@@ -831,6 +835,7 @@ class InstroDAQ(Instrument):
         alias: str | None = None,
     ):
         """Configure a relay channel (``physical_channel`` e.g. ``"3101"`` = slot 3 / channel 101)."""
+        self._require_open()
         self._driver.define_relay_channel(
             physical_channel=physical_channel,
             alias=alias,

--- a/instro/daq/daq.py
+++ b/instro/daq/daq.py
@@ -18,7 +18,7 @@ from instro.daq.types import (
     RelayChannel,
     TerminalConfig,
 )
-from instro.lib import Instrument, Measurement
+from instro.lib import Instrument, InstrumentNotOpenError, Measurement
 from instro.lib.instrument import publish_command, publish_measurement
 from instro.lib.publishers import Publisher
 from instro.lib.types import Command
@@ -372,6 +372,7 @@ class InstroDAQ(Instrument):
         super().__init__(name, publishers=publishers, **kwargs)
 
         self._driver = driver
+        self._is_open = False
 
         self._background_config.interval = (
             0  # DAQ reads block so set this to zero because they implicitly time the loop
@@ -439,10 +440,16 @@ class InstroDAQ(Instrument):
         """No-op for DAQ — the interval is fixed at 0 so the blocking fetch implicitly times the loop."""
         return
 
+    def _require_open(self) -> None:
+        """Guard device I/O: raise if a method is called before ``open()``."""
+        if not self._is_open:
+            raise InstrumentNotOpenError(f"InstroDAQ '{self.name}' is not open. Call open() first.")
+
     def open(self):
         """Open the underlying driver."""
         logger.info("Opening DAQ '%s'", self.name)
         self._driver.open()
+        self._is_open = True
         logger.info("Opened DAQ '%s'", self.name)
 
     def close(self):
@@ -450,6 +457,7 @@ class InstroDAQ(Instrument):
         logger.info("Closing DAQ '%s'", self.name)
         super().close()
         self._driver.close()
+        self._is_open = False
         logger.info("Closed DAQ '%s'", self.name)
 
     # ========  Analog Input  ===========
@@ -533,6 +541,7 @@ class InstroDAQ(Instrument):
                 fetch the buffer yourself by calling ``read_analog()``.
             **kwargs: ``channel_type`` (NI only) selects which DAQmx task to start.
         """
+        self._require_open()
         # DAQmx allows starting different channel_types independently.
         channel_type = kwargs.get("channel_type", None)
 
@@ -551,6 +560,7 @@ class InstroDAQ(Instrument):
 
     def stop(self, **kwargs):
         """Stop the DAQ device."""
+        self._require_open()
         super().stop()
         channel_type = kwargs.pop("channel_type", None)
         self._driver.stop(channel_type=channel_type, **kwargs)
@@ -565,6 +575,7 @@ class InstroDAQ(Instrument):
         Hardware-timed with the background daemon running raises — the daemon owns the buffer.
         Returns a single Measurement when channels share a timebase, otherwise one Measurement per timebase cluster.
         """
+        self._require_open()
         if self.ai_hw_timing_config:
             if not (self._background_thread and self._background_thread.is_alive()):
                 return self._fetch_analog(**kwargs)
@@ -626,6 +637,7 @@ class InstroDAQ(Instrument):
     @publish_command
     def write_analog_value(self, channel: str, value: float, **kwargs) -> Command:
         """Write ``value`` (volts) to AO ``channel`` (alias). Raises ``KeyError`` if ``channel`` isn't configured."""
+        self._require_open()
         if (analog_channel := self.ao_channels.get(channel, None)) is None:
             raise KeyError(
                 f"Analog output channel '{channel}' is not configured. "
@@ -713,6 +725,7 @@ class InstroDAQ(Instrument):
     @publish_command
     def write_digital_line(self, channel: str, data: int, **kwargs) -> Command:
         """Write 0/1 to DO line ``channel`` (alias). Raises ``KeyError`` if ``channel`` isn't configured."""
+        self._require_open()
         if (digital_channel := self.do_channels.get(channel, None)) is None:
             raise KeyError(
                 f"Digital output channel '{channel}' is not configured. "
@@ -741,6 +754,7 @@ class InstroDAQ(Instrument):
     @publish_measurement
     def read_digital_line(self, channel: str, **kwargs) -> Measurement:
         """Read DI line ``channel`` (alias). Raises ``KeyError`` if ``channel`` isn't configured."""
+        self._require_open()
         if (digital_channel := self.di_channels.get(channel, None)) is None:
             raise KeyError(
                 f"Digital input channel '{channel}' is not configured. "
@@ -762,6 +776,7 @@ class InstroDAQ(Instrument):
     @publish_command
     def write_digital_port(self, channel: str, data: int, **kwargs) -> Command:
         """Write ``data`` to DO port ``channel`` (alias). Raises ``KeyError`` if ``channel`` isn't configured."""
+        self._require_open()
         if (digital_channel := self.do_channels.get(channel, None)) is None:
             raise KeyError(
                 f"Digital output channel '{channel}' is not configured. "
@@ -792,6 +807,7 @@ class InstroDAQ(Instrument):
     @publish_measurement
     def read_digital_port(self, channel: str, **kwargs) -> Measurement:
         """Read DI port ``channel`` (alias). Raises ``KeyError`` if ``channel`` isn't configured."""
+        self._require_open()
         if (digital_channel := self.di_channels.get(channel, None)) is None:
             raise KeyError(
                 f"Digital input channel '{channel}' is not configured. "
@@ -824,6 +840,7 @@ class InstroDAQ(Instrument):
     @publish_command
     def close_relay(self, channel: str, **kwargs) -> Command:
         """Close relay ``channel`` (alias) — connects the circuit."""
+        self._require_open()
         if (relay_channel := self.relay_channels.get(channel, None)) is None:
             raise KeyError(
                 f"Relay channel '{channel}' is not configured. "
@@ -839,6 +856,7 @@ class InstroDAQ(Instrument):
     @publish_command
     def open_relay(self, channel: str, **kwargs) -> Command:
         """Open relay ``channel`` (alias) — disconnects the circuit."""
+        self._require_open()
         if (relay_channel := self.relay_channels.get(channel, None)) is None:
             raise KeyError(
                 f"Relay channel '{channel}' is not configured. "
@@ -864,6 +882,7 @@ class InstroDAQ(Instrument):
     @publish_measurement
     def get_points_in_buffer(self, **kwargs) -> Measurement:
         """Publish the current DAQ buffer depth on channel ``{name}.buffer``."""
+        self._require_open()
         return self._package_measurement("buffer", self._driver.points_in_buffer, time.time_ns(), **kwargs)
 
 

--- a/instro/lib/__init__.py
+++ b/instro/lib/__init__.py
@@ -1,6 +1,6 @@
 """Cross-category building blocks: base instrument, transports, publishers, shared scaling types."""
 
-from instro.lib.exceptions import FeatureNotSupportedError, InstroError
+from instro.lib.exceptions import FeatureNotSupportedError, InstroError, InstrumentNotOpenError
 from instro.lib.instrument import Instrument
 from instro.lib.nominal import install_nominal_core_log_handler
 from instro.lib.transports.visa import VisaConfig, VisaDriver
@@ -12,6 +12,7 @@ __all__ = [
     "FeatureNotSupportedError",
     "InstroError",
     "Instrument",
+    "InstrumentNotOpenError",
     "LinearScale",
     "Measurement",
     "ScaleType",

--- a/instro/lib/exceptions.py
+++ b/instro/lib/exceptions.py
@@ -7,3 +7,7 @@ class InstroError(Exception):
 
 class FeatureNotSupportedError(InstroError):
     """Unsupported feature error."""
+
+
+class InstrumentNotOpenError(InstroError):
+    """Raised when an instrument method is called before open()."""

--- a/tests/daq/test_daq_drivers.py
+++ b/tests/daq/test_daq_drivers.py
@@ -351,6 +351,24 @@ _GUARDED_METHODS = [
     ("close_relay", lambda daq: daq.close_relay("ch")),
     ("open_relay", lambda daq: daq.open_relay("ch")),
     ("get_points_in_buffer", lambda daq: daq.get_points_in_buffer()),
+    (
+        "configure_analog_channel",
+        lambda daq: daq.configure_analog_channel(direction=Direction.INPUT, physical_channel="ai0"),
+    ),
+    ("configure_ai_sample_rate", lambda daq: daq.configure_ai_sample_rate(sample_rate=100)),
+    (
+        "configure_digital_line",
+        lambda daq: daq.configure_digital_line(
+            direction=Direction.OUTPUT, physical_channel="port0/line0", logic=Logic.HIGH
+        ),
+    ),
+    (
+        "configure_digital_port",
+        lambda daq: daq.configure_digital_port(
+            direction=Direction.OUTPUT, physical_channel="port0", logic=Logic.HIGH, port_width=8
+        ),
+    ),
+    ("configure_relay_channel", lambda daq: daq.configure_relay_channel(physical_channel="3101")),
 ]
 
 
@@ -688,6 +706,7 @@ def test_default_naming_write_digital_port_preserves_int_value_type():
 def test_channel_mapping_is_read_only():
     """The channel-dict properties return read-only mappings; mutating them raises."""
     daq = InstroDAQ(name="ut", driver=_make_mock_driver())
+    daq.open()
     daq.configure_digital_line(
         direction=Direction.OUTPUT, physical_channel="port0/line0", alias="do0", logic=Logic.HIGH
     )
@@ -701,6 +720,7 @@ def test_channel_mapping_is_read_only():
 def test_channel_objects_are_frozen():
     """Channels handed back through a snapshot are frozen; attribute writes raise."""
     daq = InstroDAQ(name="ut", driver=_make_mock_driver())
+    daq.open()
     daq.configure_digital_line(
         direction=Direction.OUTPUT, physical_channel="port0/line0", alias="do0", logic=Logic.HIGH
     )
@@ -713,6 +733,7 @@ def test_channel_objects_are_frozen():
 def test_channel_snapshot_is_not_a_live_view():
     """A captured snapshot does not reflect channels configured afterwards."""
     daq = InstroDAQ(name="ut", driver=_make_mock_driver())
+    daq.open()
     daq.configure_digital_line(direction=Direction.OUTPUT, physical_channel="port0/line0", alias="a", logic=Logic.HIGH)
 
     snapshot = daq.do_channels
@@ -726,6 +747,7 @@ def test_channel_snapshot_is_not_a_live_view():
 def test_channels_property_returns_immutable_tuple():
     """The aggregate ``channels`` property returns a tuple snapshot."""
     daq = InstroDAQ(name="ut", driver=_make_mock_driver())
+    daq.open()
     daq.configure_digital_line(
         direction=Direction.OUTPUT, physical_channel="port0/line0", alias="do0", logic=Logic.HIGH
     )
@@ -748,6 +770,7 @@ def test_stop_with_channel_type_forwards_kwarg_once():
 def test_configure_ai_sample_rate_below_10hz_floors_samples_per_channel():
     """The samples_per_channel default must never be 0; sub-10 Hz rates floor at 1."""
     daq = InstroDAQ(name="ut", driver=_make_mock_driver())
+    daq.open()
 
     daq.configure_ai_sample_rate(sample_rate=1.0)
 

--- a/tests/daq/test_daq_drivers.py
+++ b/tests/daq/test_daq_drivers.py
@@ -14,6 +14,7 @@ from instro.daq.types import (
     Direction,
     Logic,
 )
+from instro.lib import InstrumentNotOpenError
 
 
 class _RecordingDriver(DAQDriverBase):
@@ -125,6 +126,7 @@ def test_write_digital_line_configured_channel():
         driver=mock_driver,
     )
 
+    daq.open()
     daq.configure_digital_line(
         direction=Direction.OUTPUT, physical_channel="port0/line0", logic=Logic.HIGH, alias="test_channel"
     )
@@ -143,6 +145,7 @@ def test_write_digital_line_unconfigured_channel():
         driver=mock_driver,
     )
 
+    daq.open()
     with pytest.raises(KeyError, match="Digital output channel 'unconfigured_channel' is not configured") as exc_info:
         daq.write_digital_line("unconfigured_channel", 1)
 
@@ -161,6 +164,7 @@ def test_read_digital_line_configured_channel():
         driver=mock_driver,
     )
 
+    daq.open()
     daq.configure_digital_line(
         direction=Direction.INPUT, physical_channel="port0/line0", alias="test_channel", logic=Logic.HIGH
     )
@@ -179,6 +183,7 @@ def test_read_digital_line_unconfigured_channel():
         driver=mock_driver,
     )
 
+    daq.open()
     with pytest.raises(KeyError, match="Digital input channel 'unconfigured_channel' is not configured") as exc_info:
         daq.read_digital_line("unconfigured_channel")
 
@@ -196,6 +201,7 @@ def test_write_analog_value_unconfigured_channel():
         driver=mock_driver,
     )
 
+    daq.open()
     with pytest.raises(KeyError, match="Analog output channel 'unconfigured_channel' is not configured"):
         daq.write_analog_value("unconfigured_channel", 5.0)
 
@@ -211,6 +217,7 @@ def test_close_relay_unconfigured_channel():
         driver=mock_driver,
     )
 
+    daq.open()
     with pytest.raises(KeyError, match="Relay channel 'unconfigured_relay' is not configured"):
         daq.close_relay("unconfigured_relay")
 
@@ -226,6 +233,7 @@ def test_open_relay_unconfigured_channel():
         driver=mock_driver,
     )
 
+    daq.open()
     with pytest.raises(KeyError, match="Relay channel 'unconfigured_relay' is not configured"):
         daq.open_relay("unconfigured_relay")
 
@@ -241,6 +249,7 @@ def test_write_digital_port_configured_channel():
         driver=mock_driver,
     )
 
+    daq.open()
     daq.configure_digital_port(
         direction=Direction.OUTPUT, physical_channel="port0", logic=Logic.HIGH, port_width=8, alias="test_port"
     )
@@ -259,6 +268,7 @@ def test_write_digital_port_value_exceeds_width():
         driver=mock_driver,
     )
 
+    daq.open()
     daq.configure_digital_port(
         direction=Direction.OUTPUT, physical_channel="port0", logic=Logic.HIGH, port_width=8, alias="test_port"
     )
@@ -281,6 +291,7 @@ def test_write_digital_port_unconfigured_channel():
         driver=mock_driver,
     )
 
+    daq.open()
     with pytest.raises(KeyError, match="Digital output channel 'unconfigured_port' is not configured"):
         daq.write_digital_port("unconfigured_port", 0xFF)
 
@@ -297,6 +308,7 @@ def test_read_digital_port_configured_channel():
         driver=mock_driver,
     )
 
+    daq.open()
     daq.configure_digital_port(
         direction=Direction.INPUT, physical_channel="port0", logic=Logic.HIGH, port_width=8, alias="test_port"
     )
@@ -315,10 +327,66 @@ def test_read_digital_port_unconfigured_channel():
         driver=mock_driver,
     )
 
+    daq.open()
     with pytest.raises(KeyError, match="Digital input channel 'unconfigured_port' is not configured"):
         daq.read_digital_port("unconfigured_port")
 
     mock_driver.read_digital_port.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# open() guard
+# ---------------------------------------------------------------------------
+
+
+_GUARDED_METHODS = [
+    ("start", lambda daq: daq.start()),
+    ("stop", lambda daq: daq.stop()),
+    ("read_analog", lambda daq: daq.read_analog()),
+    ("write_analog_value", lambda daq: daq.write_analog_value("ch", 1.0)),
+    ("write_digital_line", lambda daq: daq.write_digital_line("ch", 1)),
+    ("read_digital_line", lambda daq: daq.read_digital_line("ch")),
+    ("write_digital_port", lambda daq: daq.write_digital_port("ch", 1)),
+    ("read_digital_port", lambda daq: daq.read_digital_port("ch")),
+    ("close_relay", lambda daq: daq.close_relay("ch")),
+    ("open_relay", lambda daq: daq.open_relay("ch")),
+    ("get_points_in_buffer", lambda daq: daq.get_points_in_buffer()),
+]
+
+
+@pytest.mark.parametrize("method_name,call", _GUARDED_METHODS, ids=[name for name, _ in _GUARDED_METHODS])
+def test_method_before_open_raises_not_open(method_name, call):
+    """Every device-touching method raises InstrumentNotOpenError when called before open()."""
+    daq = InstroDAQ(name="Bench DAQ", driver=_make_mock_driver())
+
+    with pytest.raises(InstrumentNotOpenError, match="Bench DAQ"):
+        call(daq)
+
+
+def test_not_open_error_message_names_the_instrument():
+    """The not-open error names the instance so users know which DAQ they forgot to open."""
+    daq = InstroDAQ(name="myDAQ", driver=_make_mock_driver())
+
+    with pytest.raises(InstrumentNotOpenError, match="InstroDAQ 'myDAQ' is not open. Call open\\(\\) first."):
+        daq.read_analog()
+
+
+def test_method_after_open_does_not_raise_not_open():
+    """Opening clears the guard; the same call no longer raises InstrumentNotOpenError."""
+    daq = InstroDAQ(name="ut", driver=_make_mock_driver())
+    daq.open()
+
+    daq.stop()  # would raise InstrumentNotOpenError before open()
+
+
+def test_method_after_close_raises_not_open_again():
+    """close() re-arms the guard; calling a device method afterwards raises again."""
+    daq = InstroDAQ(name="ut", driver=_make_mock_driver())
+    daq.open()
+    daq.close()
+
+    with pytest.raises(InstrumentNotOpenError, match="ut"):
+        daq.read_analog()
 
 
 # ---------------------------------------------------------------------------
@@ -548,6 +616,7 @@ def _legacy_daq_with_digital_channel(direction: Direction):
     mock_driver.read_digital_port.return_value = 5
 
     daq = InstroDAQ(name="ut", driver=mock_driver, legacy_naming=True)
+    daq.open()
     daq.configure_digital_line(direction=direction, physical_channel="port0/line0", alias="di0", logic=Logic.HIGH)
     return daq
 
@@ -574,6 +643,7 @@ def test_default_naming_write_digital_line_publishes_with_prefix_and_cmd():
     mock_driver = _make_mock_driver()
 
     daq = InstroDAQ(name="ut", driver=mock_driver)
+    daq.open()
     daq.configure_digital_line(
         direction=Direction.OUTPUT, physical_channel="port0/line0", alias="do0", logic=Logic.HIGH
     )
@@ -586,6 +656,7 @@ def test_default_naming_write_digital_line_preserves_int_value_type():
     mock_driver = _make_mock_driver()
 
     daq = InstroDAQ(name="ut", driver=mock_driver)
+    daq.open()
     daq.configure_digital_line(
         direction=Direction.OUTPUT, physical_channel="port0/line0", alias="do0", logic=Logic.HIGH
     )
@@ -601,6 +672,7 @@ def test_default_naming_write_digital_port_preserves_int_value_type():
     mock_driver = _make_mock_driver()
 
     daq = InstroDAQ(name="ut", driver=mock_driver)
+    daq.open()
     daq.configure_digital_port(
         direction=Direction.OUTPUT, physical_channel="port0", alias="port0", logic=Logic.HIGH, port_width=8
     )
@@ -666,6 +738,7 @@ def test_stop_with_channel_type_forwards_kwarg_once():
     """stop(channel_type=...) must not pass channel_type both explicitly and via **kwargs."""
     mock_driver = _make_mock_driver()
     daq = InstroDAQ(name="ut", driver=mock_driver)
+    daq.open()
 
     daq.stop(channel_type="analog_input")
 
@@ -690,6 +763,7 @@ def _hw_timed_daq() -> tuple[InstroDAQ, _RecordingDriver]:
     mock_driver = _make_mock_driver()
     mock_driver._read_to_measurements.return_value = []
     daq = InstroDAQ(name="ut", driver=mock_driver)
+    daq.open()
     daq.configure_analog_channel(direction=Direction.INPUT, physical_channel="ai0", alias="ai0")
     daq.configure_ai_sample_rate(sample_rate=100, samples_per_channel=10)
     return daq, mock_driver


### PR DESCRIPTION
## Summary

Calling an `InstroDAQ` device method before `open()` now raises a clear, typed `InstrumentNotOpenError` that names the instance, instead of surfacing a low-level transport/vendor-SDK error that doesn't point at the missing `open()` call.

## Changes

- **`instro/lib/exceptions.py`** — add `InstrumentNotOpenError(InstroError)`, mirroring the existing `FeatureNotSupportedError`; exported from `instro.lib`.
- **`instro/daq/daq.py`** — `InstroDAQ` tracks `_is_open` (set in `open()`, cleared in `close()`) and a `_require_open()` guard at the top of every device-touching method: `start`, `stop`, `read_analog`, `write_analog_value`, `write_digital_line`/`read_digital_line`, `write_digital_port`/`read_digital_port`, `close_relay`/`open_relay`, `get_points_in_buffer`. Message names the instance, e.g. `InstroDAQ 'myDAQ' is not open. Call open() first.`
- **`tests/daq/test_daq_drivers.py`** — parametrized not-open coverage across all guarded methods, plus message-names-instance, after-open, and close-re-arms tests. Existing functional tests now `open()` first to reflect the new contract.
- **`docs/guides/instrumentation/exceptions.mdx`** — document `InstrumentNotOpenError`. The reference doc auto-generates from the module docstring.

## Notes

- The guard lives at the `InstroDAQ` HAL (not the transport) because DAQ drivers use heterogeneous transports — VISA for SCPI, vendor SDKs for NI/LabJack/MCC — so a single transport-layer check wouldn't cover all of them.
- `configure_*` setup methods are intentionally left unguarded: the canonical flow configures after `open()`, and the ticket scopes the IO methods.
- INSTRO-76's declared blocker INSTRO-287 was canceled, but its outcome (drop `DAQDriverDataHandler`, drivers compose `VisaDriver`) has already landed — this change sits on that post-migration shape.

## Testing

- `just check` — ruff format, mypy, ruff lint all clean.
- `just test` — 834 passed.
