### PR TITLE
fix(test): bind ephemeral port in simulated PSU socket test

### DIFF
--- a/instro/psu/scpi_sim_server.py
+++ b/instro/psu/scpi_sim_server.py
@@ -701,10 +701,16 @@ class SimulatedPSUServer:
         self._thread: threading.Thread | None = None
         self._socket: socket.socket | None = None
 
+    @property
+    def port(self) -> int:
+        """The bound TCP port (resolved from the OS when started with port 0)."""
+        return self._port
+
     def start(self) -> None:
         self._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self._socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         self._socket.bind((self._host, self._port))
+        self._port = self._socket.getsockname()[1]
         self._socket.listen(1)
         self._socket.settimeout(0.5)
         self._thread = threading.Thread(target=self._run, daemon=True, name="psu-sim-server")

--- a/tests/psu/simulated/test_simulated_psu_hardware.py
+++ b/tests/psu/simulated/test_simulated_psu_hardware.py
@@ -584,9 +584,11 @@ class _SimulatedTarget:
     @classmethod
     def start(cls) -> "_SimulatedTarget":
         simulator = SimulatedPSUSimulator(num_channels=2)
-        server = SimulatedPSUServer(simulator, host="127.0.0.1", port=5025)
+        # Bind an ephemeral port to avoid EADDRINUSE collisions on shared CI runners.
+        server = SimulatedPSUServer(simulator, host="127.0.0.1", port=0)
         server.start()
-        return cls(simulator, server, VISA_ADDRESS)
+        visa_address = f"TCPIP0::127.0.0.1::{server.port}::SOCKET"
+        return cls(simulator, server, visa_address)
 
     def shutdown(self) -> None:
         self.server.shutdown()


### PR DESCRIPTION
## Summary

The simulated-PSU socket test bound a **hardcoded TCP port 5025**, which raced to `OSError: [Errno 98] Address already in use` on shared CI runners — surfacing as intermittent failures on the Python 3.11 shard (all ~70 tests in the module erroring at fixture setup). This was unrelated to whatever PR happened to draw the unlucky run.

## Changes

- `instro/psu/scpi_sim_server.py` — `SimulatedPSUServer.start()` records the actual bound port via `getsockname()[1]` and exposes it through a new `port` property. Works whether a fixed port or `0` is passed, so the CLI sim server's default is unaffected.
- `tests/psu/simulated/test_simulated_psu_hardware.py` — `_SimulatedTarget.start()` binds an ephemeral port (`port=0`) and builds the VISA address from the resolved port, removing the fixed-port collision.

## Testing

- `just check` clean.
- `tests/psu/simulated/test_simulated_psu_hardware.py` — 70 passed (run 3×, stable).
- `tests/psu/test_scpi_sim_server.py` — 171 passed.

Closes INSTRO-358.
