### PR TITLE
feat(psu): update tdk genesys with ovp, ocp, remote sense

### DIFF
--- a/docs/guides/instrumentation/psu.mdx
+++ b/docs/guides/instrumentation/psu.mdx
@@ -5,7 +5,7 @@ description: Using InstroPSU for SCPI-based programmable power supplies
 
 # InstroPSU
 
-`InstroPSU` is a hardware abstraction layer (HAL) that provides a unified interface for programmable power supplies. The category class defines the vendor-independent API (`set_voltage`, `get_voltage`, `output_enable`, …). A vendor-specific driver (e.g. `BK9115`, `KeysightE36100`, `RigolDP800`) owns its connection details and translates those calls into vendor commands.
+`InstroPSU` is a hardware abstraction layer (HAL) that provides a unified interface for programmable power supplies. The category class defines the vendor-independent API (`set_voltage`, `get_voltage`, `output_enable`, …). A vendor-specific driver (e.g. `BK9115`, `KeysightE36100`, `TDKLambdaGenesys`, `RigolDP800`) owns its connection details and translates those calls into vendor commands.
 
 ## Supported Vendors
 
@@ -14,7 +14,7 @@ description: Using InstroPSU for SCPI-based programmable power supplies
 - **Keysight**: E36100-series single-channel via SCPI/VISA (`KeysightE36100`)
 - **Rigol**: DP-series via SCPI/VISA (`RigolDP800`)
 - **Siglent**: SPD-series via SCPI/VISA (`SiglentSPD3303`)
-- **TDK Lambda**: Genesys family via SCPI/VISA (`TDKLambdaGenesys`)
+- **TDK Lambda**: Genesys family via SCPI/VISA (`TDKLambdaGenesys`), including white-label Agilent/Keysight N5700-series supplies
 - **Simulated**: `SimulatedPSU` for use with the bundled SCPI simulator
 
 If your vendor or model is not listed, see [Custom Driver Development](#custom-driver-development) below.
@@ -66,7 +66,7 @@ psu = InstroPSU(
 
 ### Choosing a Driver
 
-Choose the concrete driver that matches the power supply model, then pass the instrument connection settings to that driver. For example, use `BK9140` for the B&K 9140-series, `KeysightE36100` for Keysight E36100-series supplies, or `RigolDP800` for Rigol DP-series.
+Choose the concrete driver that matches the power supply model, then pass the instrument connection settings to that driver. For example, use `BK9140` for the B&K 9140-series, `KeysightE36100` for Keysight E36100-series supplies, `TDKLambdaGenesys` for TDK Genesys and white-label Agilent/Keysight N5700-series supplies, or `RigolDP800` for Rigol DP-series.
 
 To inspect a VISA instrument's identity before choosing a driver:
 
@@ -443,9 +443,9 @@ class BK9115(PSUDriverBase):
 
 Different PSU vendors use different SCPI command sets:
 - **Siglent**: `CH<n>:VOLT`, `MEAS:VOLT? CH<n>`, `SYST:ERR?` (positive-zero prefix)
-- **Keysight**: `VOLT`, `MEAS:VOLT?`, `SYST:ERR?` (single channel)
+- **Keysight E36100**: `VOLT`, `MEAS:VOLT?`, `SYST:ERR?` (single channel)
 - **Rigol**: `:SOUR<n>:VOLT`, `:MEAS:VOLT? CH<n>`, `:SYST:ERR?`
-- **TDK Lambda**: `VOLT`, `MEAS:VOLT?`, `SYSTEM:ERROR?` (single channel)
+- **TDK Lambda Genesys / white-label Agilent/Keysight N5700**: `VOLT`, `MEAS:VOLT?`, `SYSTEM:ERROR?` (single channel)
 
 Always consult your PSU's programming manual for the correct SCPI syntax.
 </Tip>

--- a/docs/guides/instrumentation/psu.mdx
+++ b/docs/guides/instrumentation/psu.mdx
@@ -66,7 +66,7 @@ psu = InstroPSU(
 
 ### Choosing a Driver
 
-Choose the concrete driver that matches the power supply model, then pass the instrument connection settings to that driver. For example, use `BK9140` for the B&K 9140-series, `KeysightE36100` for Keysight E36100-series supplies, `TDKLambdaGenesys` for TDK Genesys and white-label Agilent/Keysight N5700-series supplies, or `RigolDP800` for Rigol DP-series.
+Choose the concrete driver that matches the power supply model, then pass the instrument connection settings to that driver. For example, use `BK9140` for B&K 9140-series supplies or `KeysightE36100` for Keysight E36100-series supplies.
 
 To inspect a VISA instrument's identity before choosing a driver:
 

--- a/instro/psu/drivers/__init__.py
+++ b/instro/psu/drivers/__init__.py
@@ -4,6 +4,7 @@ from instro.psu import PSUDriverBase
 from instro.psu.drivers.bk_9115 import BK9115
 from instro.psu.drivers.bk_9140 import BK9140
 from instro.psu.drivers.keysight_e36100 import KeysightE36100
+from instro.psu.drivers.keysight_n5700 import KeysightN5700
 from instro.psu.drivers.rigol_dp800 import RigolDP800
 from instro.psu.drivers.siglent_spd3303 import SiglentSPD3303
 from instro.psu.drivers.simulated import SimulatedPSU
@@ -14,6 +15,7 @@ __all__ = [
     "BK9115",
     "BK9140",
     "KeysightE36100",
+    "KeysightN5700",
     "RigolDP800",
     "SiglentSPD3303",
     "SimulatedPSU",

--- a/instro/psu/drivers/keysight_n5700.py
+++ b/instro/psu/drivers/keysight_n5700.py
@@ -1,0 +1,9 @@
+"""Keysight N5700 compatibility driver."""
+
+from instro.psu.drivers.tdk_lambda_genesys import TDKLambdaGenesys
+
+
+class KeysightN5700(TDKLambdaGenesys):
+    """Keysight N5700-series PSU via the TDK Lambda Genesys SCPI interface."""
+
+    FRIENDLY_NAME = "Keysight N5700-series PSU using the TDK Lambda Genesys SCPI interface"

--- a/instro/psu/drivers/tdk_lambda_genesys.py
+++ b/instro/psu/drivers/tdk_lambda_genesys.py
@@ -65,27 +65,19 @@ class TDKLambdaGenesys(PSUDriverBase):
 
     def set_overvoltage_protection_delay(self, delay: float, channel: int) -> None:
         self._require_channel(channel)
-        raise FeatureNotSupportedError(
-            f"set_overvoltage_protection_delay is not supported by the {self.FRIENDLY_NAME}"
-        )
+        raise FeatureNotSupportedError(f"set_overvoltage_protection_delay is not supported by the {self.FRIENDLY_NAME}")
 
     def get_overvoltage_protection_delay(self, channel: int) -> float:
         self._require_channel(channel)
-        raise FeatureNotSupportedError(
-            f"get_overvoltage_protection_delay is not supported by the {self.FRIENDLY_NAME}"
-        )
+        raise FeatureNotSupportedError(f"get_overvoltage_protection_delay is not supported by the {self.FRIENDLY_NAME}")
 
     def set_overcurrent_protection_level(self, current: float, channel: int) -> None:
         self._require_channel(channel)
-        raise FeatureNotSupportedError(
-            f"set_overcurrent_protection_level is not supported by the {self.FRIENDLY_NAME}"
-        )
+        raise FeatureNotSupportedError(f"set_overcurrent_protection_level is not supported by the {self.FRIENDLY_NAME}")
 
     def get_overcurrent_protection_level(self, channel: int) -> float:
         self._require_channel(channel)
-        raise FeatureNotSupportedError(
-            f"get_overcurrent_protection_level is not supported by the {self.FRIENDLY_NAME}"
-        )
+        raise FeatureNotSupportedError(f"get_overcurrent_protection_level is not supported by the {self.FRIENDLY_NAME}")
 
     def set_overcurrent_protection_enabled(self, enabled: bool, channel: int) -> None:
         self._require_channel(channel)
@@ -97,15 +89,11 @@ class TDKLambdaGenesys(PSUDriverBase):
 
     def set_remote_sense_enabled(self, enabled: bool, channel: int) -> None:
         self._require_channel(channel)
-        raise FeatureNotSupportedError(
-            f"set_remote_sense_enabled is not supported by the {self.FRIENDLY_NAME}"
-        )
+        raise FeatureNotSupportedError(f"set_remote_sense_enabled is not supported by the {self.FRIENDLY_NAME}")
 
     def get_remote_sense_enabled(self, channel: int) -> bool:
         self._require_channel(channel)
-        raise FeatureNotSupportedError(
-            f"get_remote_sense_enabled is not supported by the {self.FRIENDLY_NAME}"
-        )
+        raise FeatureNotSupportedError(f"get_remote_sense_enabled is not supported by the {self.FRIENDLY_NAME}")
 
     def _require_channel(self, channel: int) -> None:
         if channel != 1:

--- a/instro/psu/drivers/tdk_lambda_genesys.py
+++ b/instro/psu/drivers/tdk_lambda_genesys.py
@@ -1,11 +1,14 @@
 """TDK Lambda Genesys-family PSU driver (single-channel)."""
 
+from instro.lib.exceptions import FeatureNotSupportedError
 from instro.lib.transports.visa import VisaConfig, VisaDriver
 from instro.psu import PSUDriverBase
 
 
 class TDKLambdaGenesys(PSUDriverBase):
     """TDK Lambda Genesys-family single-channel PSU."""
+
+    FRIENDLY_NAME = "TDK Lambda Genesys-family PSU"
 
     def __init__(self, visa_resource: str | VisaConfig) -> None:
         self._visa = VisaDriver(visa_resource)
@@ -17,25 +20,96 @@ class TDKLambdaGenesys(PSUDriverBase):
         self._visa.close()
 
     def set_voltage(self, voltage: float, channel: int) -> None:
+        self._require_channel(channel)
         self._write_checked(f"VOLT {voltage:.3f}")
 
     def get_voltage(self, channel: int) -> float:
+        self._require_channel(channel)
         return self._query_checked_float("MEAS:VOLT?")
 
     def set_current_limit(self, current_limit: float, channel: int) -> None:
+        self._require_channel(channel)
         self._write_checked(f"CURR {current_limit:.3f}")
 
     def get_current(self, channel: int) -> float:
+        self._require_channel(channel)
         return self._query_checked_float("MEAS:CURR?")
 
     def output_enable(self, enable: bool, channel: int) -> None:
+        self._require_channel(channel)
         self._write_checked("OUTP:STAT ON" if enable else "OUTP:STAT OFF")
 
     def get_output_status(self, channel: int) -> bool:
-        with self._visa.lock():
-            resp = self._visa.query("OUTP:STAT?")
-            self._check_errors()
-        return resp == "ON"
+        self._require_channel(channel)
+        return self._query_checked_bool("OUTP:STAT?")
+
+    def set_overvoltage_protection_level(self, voltage: float, channel: int) -> None:
+        self._require_channel(channel)
+        self._write_checked(f"VOLT:PROT:LEV {voltage:.3f}")
+
+    def get_overvoltage_protection_level(self, channel: int) -> float:
+        self._require_channel(channel)
+        return self._query_checked_float("VOLT:PROT:LEV?")
+
+    def set_overvoltage_protection_enabled(self, enabled: bool, channel: int) -> None:
+        self._require_channel(channel)
+        raise FeatureNotSupportedError(
+            f"set_overvoltage_protection_enabled is not supported by the {self.FRIENDLY_NAME}"
+        )
+
+    def get_overvoltage_protection_enabled(self, channel: int) -> bool:
+        self._require_channel(channel)
+        raise FeatureNotSupportedError(
+            f"get_overvoltage_protection_enabled is not supported by the {self.FRIENDLY_NAME}"
+        )
+
+    def set_overvoltage_protection_delay(self, delay: float, channel: int) -> None:
+        self._require_channel(channel)
+        raise FeatureNotSupportedError(
+            f"set_overvoltage_protection_delay is not supported by the {self.FRIENDLY_NAME}"
+        )
+
+    def get_overvoltage_protection_delay(self, channel: int) -> float:
+        self._require_channel(channel)
+        raise FeatureNotSupportedError(
+            f"get_overvoltage_protection_delay is not supported by the {self.FRIENDLY_NAME}"
+        )
+
+    def set_overcurrent_protection_level(self, current: float, channel: int) -> None:
+        self._require_channel(channel)
+        raise FeatureNotSupportedError(
+            f"set_overcurrent_protection_level is not supported by the {self.FRIENDLY_NAME}"
+        )
+
+    def get_overcurrent_protection_level(self, channel: int) -> float:
+        self._require_channel(channel)
+        raise FeatureNotSupportedError(
+            f"get_overcurrent_protection_level is not supported by the {self.FRIENDLY_NAME}"
+        )
+
+    def set_overcurrent_protection_enabled(self, enabled: bool, channel: int) -> None:
+        self._require_channel(channel)
+        self._write_checked("CURR:PROT:STAT ON" if enabled else "CURR:PROT:STAT OFF")
+
+    def get_overcurrent_protection_enabled(self, channel: int) -> bool:
+        self._require_channel(channel)
+        return self._query_checked_bool("CURR:PROT:STAT?")
+
+    def set_remote_sense_enabled(self, enabled: bool, channel: int) -> None:
+        self._require_channel(channel)
+        raise FeatureNotSupportedError(
+            f"set_remote_sense_enabled is not supported by the {self.FRIENDLY_NAME}"
+        )
+
+    def get_remote_sense_enabled(self, channel: int) -> bool:
+        self._require_channel(channel)
+        raise FeatureNotSupportedError(
+            f"get_remote_sense_enabled is not supported by the {self.FRIENDLY_NAME}"
+        )
+
+    def _require_channel(self, channel: int) -> None:
+        if channel != 1:
+            raise ValueError(f"The {self.FRIENDLY_NAME} supports only channel 1")
 
     def _write_checked(self, command: str) -> None:
         with self._visa.lock():
@@ -48,7 +122,14 @@ class TDKLambdaGenesys(PSUDriverBase):
             self._check_errors()
             return float(value)
 
+    def _query_checked_bool(self, command: str) -> bool:
+        with self._visa.lock():
+            value = self._visa.query(command)
+            self._check_errors()
+        return value.strip().upper() in {"1", "ON"}
+
     def _check_errors(self) -> None:
         err = self._visa.query("SYSTEM:ERROR?")
-        if not err.startswith("+0"):
-            raise RuntimeError(f"TDK Lambda PSU reported error: {err}")
+        code = err.strip().split(",", 1)[0].lstrip("+").strip()
+        if code != "0":
+            raise RuntimeError(f"The {self.FRIENDLY_NAME} reported error: {err.strip()}")

--- a/tests/psu/keysight/test_keysight_n5700_software.py
+++ b/tests/psu/keysight/test_keysight_n5700_software.py
@@ -1,0 +1,9 @@
+"""Software tests for the Keysight N5700 compatibility driver."""
+
+from instro.psu.drivers import KeysightN5700, TDKLambdaGenesys
+
+
+def test_keysight_n5700_instantiates_as_tdk_genesys_type() -> None:
+    keysight_n5700 = KeysightN5700("TCPIP0::keysight-n5700::INSTR")
+
+    assert isinstance(keysight_n5700, TDKLambdaGenesys)

--- a/tests/psu/tdk/test_tdk_lambda_genesys_hardware.py
+++ b/tests/psu/tdk/test_tdk_lambda_genesys_hardware.py
@@ -1,0 +1,293 @@
+"""Optional TDK Lambda Genesys-family hardware smoke tests."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from instro.lib.exceptions import FeatureNotSupportedError
+from instro.lib.transports import VisaConfig
+from instro.psu.drivers.tdk_lambda_genesys import TDKLambdaGenesys
+
+pytestmark = pytest.mark.hardware
+
+# HARDWARE TEST SETUP - EDIT THESE VALUES BEFORE RUNNING THIS FILE.
+# Set VISA_ADDRESSES to the bench unit's connected VISA resource strings.
+# Remove any interface that is not connected before running this file.
+# Use this driver for TDK Genesys-family supplies and white-label
+# Agilent/Keysight N5700-series supplies.
+# Keep the programmed values comfortably inside the specific unit's ratings.
+VISA_ADDRESSES = [
+    pytest.param("TCPIP0::169.254.57.0::INSTR", id="lan"),
+    pytest.param("USB0::2391::41991::US17D5493P::0::INSTR", id="usb"),
+]
+CHANNEL = 1
+PROGRAMMED_VOLTAGE = 1.0
+PROGRAMMED_CURRENT_LIMIT = 0.1
+OVP_LEVEL = 5.0
+VOLTAGE_READBACK_TOLERANCE = 0.15
+CURRENT_READBACK_TOLERANCE = 0.01
+
+
+@pytest.fixture(scope="module", params=VISA_ADDRESSES)
+def driver(request: pytest.FixtureRequest) -> TDKLambdaGenesys:
+    visa_address = str(request.param)
+    psu_driver = TDKLambdaGenesys(
+        VisaConfig(
+            visa_resource=visa_address,
+        )
+    )
+    try:
+        psu_driver.open()
+    except Exception:
+        psu_driver.close()
+        raise
+
+    request.addfinalizer(psu_driver.close)
+    return psu_driver
+
+
+def _reset_driver(driver: TDKLambdaGenesys) -> None:
+    driver._visa.write("*CLS")
+    driver._visa.write("*RST")
+    time.sleep(0.25)
+    driver._visa.write("*CLS")
+    driver._check_errors()
+
+
+@pytest.fixture(autouse=True)
+def reset_before_each_test(driver: TDKLambdaGenesys) -> None:
+    _reset_driver(driver)
+
+
+def test_set_voltage(driver: TDKLambdaGenesys) -> None:
+    driver.set_current_limit(PROGRAMMED_CURRENT_LIMIT, channel=CHANNEL)
+    driver.set_voltage(PROGRAMMED_VOLTAGE, channel=CHANNEL)
+    try:
+        driver.output_enable(True, channel=CHANNEL)
+        time.sleep(1)
+
+        assert driver.get_voltage(channel=CHANNEL) == pytest.approx(
+            PROGRAMMED_VOLTAGE,
+            abs=VOLTAGE_READBACK_TOLERANCE,
+        )
+    finally:
+        driver.output_enable(False, channel=CHANNEL)
+
+
+def test_set_voltage_rejects_negative_value(driver: TDKLambdaGenesys) -> None:
+    try:
+        with pytest.raises(RuntimeError, match="TDK Lambda Genesys-family PSU reported error"):
+            driver.set_voltage(-1.0, channel=CHANNEL)
+    finally:
+        _reset_driver(driver)
+
+
+def test_set_voltage_rejects_value_at_ovp_limit(driver: TDKLambdaGenesys) -> None:
+    driver.set_overvoltage_protection_level(OVP_LEVEL, channel=CHANNEL)
+
+    try:
+        with pytest.raises(RuntimeError, match="TDK Lambda Genesys-family PSU reported error"):
+            driver.set_voltage(OVP_LEVEL, channel=CHANNEL)
+    finally:
+        _reset_driver(driver)
+
+
+def test_get_voltage(driver: TDKLambdaGenesys) -> None:
+    driver.set_current_limit(PROGRAMMED_CURRENT_LIMIT, channel=CHANNEL)
+    driver.set_voltage(PROGRAMMED_VOLTAGE, channel=CHANNEL)
+    try:
+        driver.output_enable(True, channel=CHANNEL)
+        time.sleep(1)
+
+        voltage = driver.get_voltage(channel=CHANNEL)
+
+        assert voltage == pytest.approx(
+            PROGRAMMED_VOLTAGE,
+            abs=VOLTAGE_READBACK_TOLERANCE,
+        )
+    finally:
+        driver.output_enable(False, channel=CHANNEL)
+
+
+def test_set_current_limit(driver: TDKLambdaGenesys) -> None:
+    driver.set_current_limit(PROGRAMMED_CURRENT_LIMIT, channel=CHANNEL)
+    driver.set_voltage(PROGRAMMED_VOLTAGE, channel=CHANNEL)
+    try:
+        driver.output_enable(True, channel=CHANNEL)
+        time.sleep(1)
+
+        assert driver.get_current(channel=CHANNEL) == pytest.approx(
+            0.0,
+            abs=CURRENT_READBACK_TOLERANCE,
+        )
+    finally:
+        driver.output_enable(False, channel=CHANNEL)
+
+
+def test_set_current_limit_rejects_negative_value(driver: TDKLambdaGenesys) -> None:
+    try:
+        with pytest.raises(RuntimeError, match="TDK Lambda Genesys-family PSU reported error"):
+            driver.set_current_limit(-1.0, channel=CHANNEL)
+    finally:
+        _reset_driver(driver)
+
+
+def test_get_current(driver: TDKLambdaGenesys) -> None:
+    driver.set_current_limit(PROGRAMMED_CURRENT_LIMIT, channel=CHANNEL)
+    driver.set_voltage(PROGRAMMED_VOLTAGE, channel=CHANNEL)
+    try:
+        driver.output_enable(True, channel=CHANNEL)
+        time.sleep(1)
+
+        current = driver.get_current(channel=CHANNEL)
+
+        assert current == pytest.approx(
+            0.0,
+            abs=CURRENT_READBACK_TOLERANCE,
+        )
+    finally:
+        driver.output_enable(False, channel=CHANNEL)
+
+
+def test_output_enable(driver: TDKLambdaGenesys) -> None:
+    driver.set_current_limit(PROGRAMMED_CURRENT_LIMIT, channel=CHANNEL)
+    driver.set_voltage(PROGRAMMED_VOLTAGE, channel=CHANNEL)
+    try:
+        driver.output_enable(True, channel=CHANNEL)
+        assert driver.get_output_status(channel=CHANNEL) is True
+
+        driver.output_enable(False, channel=CHANNEL)
+        assert driver.get_output_status(channel=CHANNEL) is False
+    finally:
+        driver.output_enable(False, channel=CHANNEL)
+
+
+def test_get_output_status(driver: TDKLambdaGenesys) -> None:
+    assert driver.get_output_status(channel=CHANNEL) is False
+
+    driver.set_current_limit(PROGRAMMED_CURRENT_LIMIT, channel=CHANNEL)
+    driver.set_voltage(PROGRAMMED_VOLTAGE, channel=CHANNEL)
+    try:
+        driver.output_enable(True, channel=CHANNEL)
+
+        assert driver.get_output_status(channel=CHANNEL) is True
+    finally:
+        driver.output_enable(False, channel=CHANNEL)
+
+
+def test_set_overvoltage_protection_level(driver: TDKLambdaGenesys) -> None:
+    driver.set_overvoltage_protection_level(OVP_LEVEL, channel=CHANNEL)
+
+    assert driver.get_overvoltage_protection_level(channel=CHANNEL) == pytest.approx(OVP_LEVEL)
+
+
+def test_set_overvoltage_protection_level_rejects_value_at_programmed_voltage(driver: TDKLambdaGenesys) -> None:
+    driver.set_voltage(PROGRAMMED_VOLTAGE, channel=CHANNEL)
+
+    try:
+        with pytest.raises(RuntimeError, match="TDK Lambda Genesys-family PSU reported error"):
+            driver.set_overvoltage_protection_level(PROGRAMMED_VOLTAGE, channel=CHANNEL)
+    finally:
+        _reset_driver(driver)
+
+
+def test_get_overvoltage_protection_level(driver: TDKLambdaGenesys) -> None:
+    driver.set_overvoltage_protection_level(OVP_LEVEL, channel=CHANNEL)
+
+    level = driver.get_overvoltage_protection_level(channel=CHANNEL)
+
+    assert level == pytest.approx(OVP_LEVEL)
+
+
+def test_set_overvoltage_protection_enabled_unsupported(driver: TDKLambdaGenesys) -> None:
+    with pytest.raises(
+        FeatureNotSupportedError,
+        match="set_overvoltage_protection_enabled is not supported by the TDK Lambda Genesys-family PSU",
+    ):
+        driver.set_overvoltage_protection_enabled(True, channel=CHANNEL)
+
+
+def test_get_overvoltage_protection_enabled_unsupported(driver: TDKLambdaGenesys) -> None:
+    with pytest.raises(
+        FeatureNotSupportedError,
+        match="get_overvoltage_protection_enabled is not supported by the TDK Lambda Genesys-family PSU",
+    ):
+        driver.get_overvoltage_protection_enabled(channel=CHANNEL)
+
+
+def test_set_overvoltage_protection_delay_unsupported(driver: TDKLambdaGenesys) -> None:
+    with pytest.raises(
+        FeatureNotSupportedError,
+        match="set_overvoltage_protection_delay is not supported by the TDK Lambda Genesys-family PSU",
+    ):
+        driver.set_overvoltage_protection_delay(0.1, channel=CHANNEL)
+
+
+def test_get_overvoltage_protection_delay_unsupported(driver: TDKLambdaGenesys) -> None:
+    with pytest.raises(
+        FeatureNotSupportedError,
+        match="get_overvoltage_protection_delay is not supported by the TDK Lambda Genesys-family PSU",
+    ):
+        driver.get_overvoltage_protection_delay(channel=CHANNEL)
+
+
+def test_set_overcurrent_protection_level_unsupported(driver: TDKLambdaGenesys) -> None:
+    with pytest.raises(
+        FeatureNotSupportedError,
+        match="set_overcurrent_protection_level is not supported by the TDK Lambda Genesys-family PSU",
+    ):
+        driver.set_overcurrent_protection_level(PROGRAMMED_CURRENT_LIMIT, channel=CHANNEL)
+
+
+def test_get_overcurrent_protection_level_unsupported(driver: TDKLambdaGenesys) -> None:
+    with pytest.raises(
+        FeatureNotSupportedError,
+        match="get_overcurrent_protection_level is not supported by the TDK Lambda Genesys-family PSU",
+    ):
+        driver.get_overcurrent_protection_level(channel=CHANNEL)
+
+
+def test_set_overcurrent_protection_enabled(driver: TDKLambdaGenesys) -> None:
+    driver.set_overcurrent_protection_enabled(True, channel=CHANNEL)
+    assert driver.get_overcurrent_protection_enabled(channel=CHANNEL) is True
+
+    driver.set_overcurrent_protection_enabled(False, channel=CHANNEL)
+    assert driver.get_overcurrent_protection_enabled(channel=CHANNEL) is False
+
+
+def test_get_overcurrent_protection_enabled(driver: TDKLambdaGenesys) -> None:
+    assert driver.get_overcurrent_protection_enabled(channel=CHANNEL) is False
+
+    driver.set_overcurrent_protection_enabled(True, channel=CHANNEL)
+
+    assert driver.get_overcurrent_protection_enabled(channel=CHANNEL) is True
+
+
+def test_set_remote_sense_enabled_unsupported(driver: TDKLambdaGenesys) -> None:
+    with pytest.raises(
+        FeatureNotSupportedError,
+        match="set_remote_sense_enabled is not supported by the TDK Lambda Genesys-family PSU",
+    ):
+        driver.set_remote_sense_enabled(True, channel=CHANNEL)
+
+
+def test_get_remote_sense_enabled_unsupported(driver: TDKLambdaGenesys) -> None:
+    with pytest.raises(
+        FeatureNotSupportedError,
+        match="get_remote_sense_enabled is not supported by the TDK Lambda Genesys-family PSU",
+    ):
+        driver.get_remote_sense_enabled(channel=CHANNEL)
+
+
+def test_invalid_channel_raises(driver: TDKLambdaGenesys) -> None:
+    with pytest.raises(ValueError, match="supports only channel 1"):
+        driver.set_voltage(PROGRAMMED_VOLTAGE, channel=2)
+
+
+def test_check_errors_raises_after_instrument_error(driver: TDKLambdaGenesys) -> None:
+    driver._visa.write("INSTRO:INVALID")
+
+    with pytest.raises(RuntimeError, match="TDK Lambda Genesys-family PSU reported error"):
+        driver._check_errors()

--- a/tests/psu/tdk/test_tdk_lambda_genesys_software.py
+++ b/tests/psu/tdk/test_tdk_lambda_genesys_software.py
@@ -1,0 +1,196 @@
+"""Software tests for the TDK Lambda Genesys-family PSU driver."""
+
+from collections.abc import Iterator
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from instro.lib.exceptions import FeatureNotSupportedError
+from instro.psu.drivers import TDKLambdaGenesys
+
+CHANNEL = 1
+
+
+@pytest.fixture
+def tdk_visa_cls() -> Iterator[MagicMock]:
+    with patch("instro.psu.drivers.tdk_lambda_genesys.VisaDriver", autospec=True) as cls:
+        yield cls
+
+
+@pytest.fixture
+def tdk_visa(tdk_visa_cls: MagicMock) -> MagicMock:
+    visa = tdk_visa_cls.return_value
+    visa.query.return_value = '+0,"No error"'
+    return visa
+
+
+@pytest.fixture
+def tdk(tdk_visa_cls: MagicMock) -> TDKLambdaGenesys:
+    return TDKLambdaGenesys("TCPIP0::tdk::INSTR")
+
+
+def test_tdk_set_voltage_writes_checked(tdk: TDKLambdaGenesys, tdk_visa: MagicMock) -> None:
+    tdk.set_voltage(48.0, channel=CHANNEL)
+    tdk_visa.write.assert_called_once_with("VOLT 48.000")
+    tdk_visa.query.assert_called_once_with("SYSTEM:ERROR?")
+
+
+def test_tdk_get_current_parses_response(tdk: TDKLambdaGenesys, tdk_visa: MagicMock) -> None:
+    tdk_visa.query.side_effect = ["2.500", '+0,"No error"']
+    assert tdk.get_current(channel=CHANNEL) == pytest.approx(2.5)
+    assert tdk_visa.query.call_args_list == [call("MEAS:CURR?"), call("SYSTEM:ERROR?")]
+
+
+def test_tdk_get_output_status_parses_text_responses(tdk: TDKLambdaGenesys, tdk_visa: MagicMock) -> None:
+    tdk_visa.query.side_effect = ["ON", '+0,"No error"']
+    assert tdk.get_output_status(channel=CHANNEL) is True
+    tdk_visa.query.side_effect = ["OFF", '+0,"No error"']
+    assert tdk.get_output_status(channel=CHANNEL) is False
+
+
+def test_tdk_get_output_status_parses_numeric_responses(tdk: TDKLambdaGenesys, tdk_visa: MagicMock) -> None:
+    tdk_visa.query.side_effect = ["1", '+0,"No error"']
+    assert tdk.get_output_status(channel=CHANNEL) is True
+    tdk_visa.query.side_effect = ["0", '+0,"No error"']
+    assert tdk.get_output_status(channel=CHANNEL) is False
+
+
+def test_tdk_check_errors_raises_on_nonzero(tdk: TDKLambdaGenesys, tdk_visa: MagicMock) -> None:
+    tdk_visa.query.return_value = '-100,"Command error"'
+    with pytest.raises(RuntimeError, match="TDK Lambda Genesys-family PSU reported error"):
+        tdk.set_voltage(1.0, channel=CHANNEL)
+
+
+def test_tdk_set_overvoltage_protection_level_writes_level(
+    tdk: TDKLambdaGenesys,
+    tdk_visa: MagicMock,
+) -> None:
+    tdk.set_overvoltage_protection_level(12.5, channel=CHANNEL)
+    tdk_visa.write.assert_called_once_with("VOLT:PROT:LEV 12.500")
+    tdk_visa.query.assert_called_once_with("SYSTEM:ERROR?")
+
+
+def test_tdk_get_overvoltage_protection_level_queries_level(
+    tdk: TDKLambdaGenesys,
+    tdk_visa: MagicMock,
+) -> None:
+    tdk_visa.query.side_effect = ["12.500", '+0,"No error"']
+    assert tdk.get_overvoltage_protection_level(channel=CHANNEL) == pytest.approx(12.5)
+    assert tdk_visa.query.call_args_list == [call("VOLT:PROT:LEV?"), call("SYSTEM:ERROR?")]
+
+
+def test_tdk_overvoltage_protection_enabled_raises_unsupported(
+    tdk: TDKLambdaGenesys,
+    tdk_visa: MagicMock,
+) -> None:
+    with pytest.raises(
+        FeatureNotSupportedError,
+        match="set_overvoltage_protection_enabled is not supported by the TDK Lambda Genesys-family PSU",
+    ):
+        tdk.set_overvoltage_protection_enabled(True, channel=CHANNEL)
+    with pytest.raises(
+        FeatureNotSupportedError,
+        match="get_overvoltage_protection_enabled is not supported by the TDK Lambda Genesys-family PSU",
+    ):
+        tdk.get_overvoltage_protection_enabled(channel=CHANNEL)
+    tdk_visa.write.assert_not_called()
+    tdk_visa.query.assert_not_called()
+
+
+def test_tdk_overvoltage_protection_delay_raises_unsupported(
+    tdk: TDKLambdaGenesys,
+    tdk_visa: MagicMock,
+) -> None:
+    with pytest.raises(
+        FeatureNotSupportedError,
+        match="set_overvoltage_protection_delay is not supported by the TDK Lambda Genesys-family PSU",
+    ):
+        tdk.set_overvoltage_protection_delay(0.25, channel=CHANNEL)
+    with pytest.raises(
+        FeatureNotSupportedError,
+        match="get_overvoltage_protection_delay is not supported by the TDK Lambda Genesys-family PSU",
+    ):
+        tdk.get_overvoltage_protection_delay(channel=CHANNEL)
+    tdk_visa.write.assert_not_called()
+    tdk_visa.query.assert_not_called()
+
+
+def test_tdk_overcurrent_protection_level_raises_unsupported(
+    tdk: TDKLambdaGenesys,
+    tdk_visa: MagicMock,
+) -> None:
+    with pytest.raises(
+        FeatureNotSupportedError,
+        match="set_overcurrent_protection_level is not supported by the TDK Lambda Genesys-family PSU",
+    ):
+        tdk.set_overcurrent_protection_level(1.0, channel=CHANNEL)
+    with pytest.raises(
+        FeatureNotSupportedError,
+        match="get_overcurrent_protection_level is not supported by the TDK Lambda Genesys-family PSU",
+    ):
+        tdk.get_overcurrent_protection_level(channel=CHANNEL)
+    tdk_visa.write.assert_not_called()
+    tdk_visa.query.assert_not_called()
+
+
+def test_tdk_set_overcurrent_protection_enabled_writes_state(
+    tdk: TDKLambdaGenesys,
+    tdk_visa: MagicMock,
+) -> None:
+    tdk.set_overcurrent_protection_enabled(True, channel=CHANNEL)
+    tdk.set_overcurrent_protection_enabled(False, channel=CHANNEL)
+    assert tdk_visa.write.call_args_list == [
+        call("CURR:PROT:STAT ON"),
+        call("CURR:PROT:STAT OFF"),
+    ]
+
+
+def test_tdk_get_overcurrent_protection_enabled_parses_text_responses(
+    tdk: TDKLambdaGenesys,
+    tdk_visa: MagicMock,
+) -> None:
+    tdk_visa.query.side_effect = ["ON", '+0,"No error"']
+    assert tdk.get_overcurrent_protection_enabled(channel=CHANNEL) is True
+    tdk_visa.query.side_effect = ["OFF", '+0,"No error"']
+    assert tdk.get_overcurrent_protection_enabled(channel=CHANNEL) is False
+
+
+def test_tdk_get_overcurrent_protection_enabled_parses_numeric_responses(
+    tdk: TDKLambdaGenesys,
+    tdk_visa: MagicMock,
+) -> None:
+    tdk_visa.query.side_effect = ["1", '+0,"No error"']
+    assert tdk.get_overcurrent_protection_enabled(channel=CHANNEL) is True
+    tdk_visa.query.side_effect = ["0", '+0,"No error"']
+    assert tdk.get_overcurrent_protection_enabled(channel=CHANNEL) is False
+
+
+def test_tdk_remote_sense_raises_unsupported(
+    tdk: TDKLambdaGenesys,
+    tdk_visa: MagicMock,
+) -> None:
+    with pytest.raises(
+        FeatureNotSupportedError,
+        match="set_remote_sense_enabled is not supported by the TDK Lambda Genesys-family PSU",
+    ):
+        tdk.set_remote_sense_enabled(True, channel=CHANNEL)
+    with pytest.raises(
+        FeatureNotSupportedError,
+        match="get_remote_sense_enabled is not supported by the TDK Lambda Genesys-family PSU",
+    ):
+        tdk.get_remote_sense_enabled(channel=CHANNEL)
+    tdk_visa.write.assert_not_called()
+    tdk_visa.query.assert_not_called()
+
+
+def test_tdk_rejects_invalid_channel(tdk: TDKLambdaGenesys, tdk_visa: MagicMock) -> None:
+    with pytest.raises(ValueError, match="supports only channel 1"):
+        tdk.set_voltage(1.0, channel=2)
+    tdk_visa.write.assert_not_called()
+    tdk_visa.query.assert_not_called()
+
+
+def test_tdk_check_errors_accepts_unsigned_zero(tdk: TDKLambdaGenesys, tdk_visa: MagicMock) -> None:
+    tdk_visa.query.return_value = '0,"No error"'
+    tdk.set_voltage(1.0, channel=CHANNEL)
+    tdk_visa.query.assert_called_once_with("SYSTEM:ERROR?")

--- a/tests/psu/test_psu_drivers.py
+++ b/tests/psu/test_psu_drivers.py
@@ -5,7 +5,6 @@ from unittest.mock import MagicMock, call, patch
 
 import pytest
 
-from instro.lib.exceptions import FeatureNotSupportedError
 from instro.lib.transports import SerialConfig, VisaConfig
 from instro.psu import InstroPSU, PSUDriverBase
 from instro.psu.drivers import (
@@ -13,7 +12,6 @@ from instro.psu.drivers import (
     BK9140,
     RigolDP800,
     SiglentSPD3303,
-    TDKLambdaGenesys,
 )
 
 # --- PSUDriverBase ---
@@ -295,79 +293,6 @@ def test_rigol_check_errors_raises_on_nonzero(rigol: RigolDP800, rigol_visa: Mag
     rigol_visa.query.return_value = '-100,"Command error"'
     with pytest.raises(RuntimeError, match="Rigol PSU reported error"):
         rigol.set_voltage(1.0, channel=1)
-
-
-# --- TDKLambdaGenesys ---
-
-
-@pytest.fixture
-def tdk_visa_cls() -> Iterator[MagicMock]:
-    with patch("instro.psu.drivers.tdk_lambda_genesys.VisaDriver", autospec=True) as cls:
-        yield cls
-
-
-@pytest.fixture
-def tdk_visa(tdk_visa_cls: MagicMock) -> MagicMock:
-    visa = tdk_visa_cls.return_value
-    visa.query.return_value = '+0,"No error"'
-    return visa
-
-
-@pytest.fixture
-def tdk(tdk_visa_cls: MagicMock) -> TDKLambdaGenesys:
-    return TDKLambdaGenesys("TCPIP0::tdk::INSTR")
-
-
-def test_tdk_set_voltage_writes_checked(tdk: TDKLambdaGenesys, tdk_visa: MagicMock) -> None:
-    tdk.set_voltage(48.0, channel=1)
-    tdk_visa.write.assert_called_once_with("VOLT 48.000")
-    tdk_visa.query.assert_called_once_with("SYSTEM:ERROR?")
-
-
-def test_tdk_get_current_parses_response(tdk: TDKLambdaGenesys, tdk_visa: MagicMock) -> None:
-    tdk_visa.query.side_effect = ["2.500", '+0,"No error"']
-    assert tdk.get_current(channel=1) == pytest.approx(2.5)
-    assert tdk_visa.query.call_args_list == [call("MEAS:CURR?"), call("SYSTEM:ERROR?")]
-
-
-def test_tdk_get_output_status_parses_on(tdk: TDKLambdaGenesys, tdk_visa: MagicMock) -> None:
-    tdk_visa.query.side_effect = ["ON", '+0,"No error"']
-    assert tdk.get_output_status(channel=1) is True
-    tdk_visa.query.side_effect = ["OFF", '+0,"No error"']
-    assert tdk.get_output_status(channel=1) is False
-
-
-def test_tdk_check_errors_raises_on_nonzero(tdk: TDKLambdaGenesys, tdk_visa: MagicMock) -> None:
-    tdk_visa.query.return_value = '-100,"Command error"'
-    with pytest.raises(RuntimeError, match="TDK Lambda PSU reported error"):
-        tdk.set_voltage(1.0, channel=1)
-
-
-@pytest.mark.parametrize(
-    ("method_name", "args"),
-    [
-        ("set_overvoltage_protection_level", (12.0,)),
-        ("get_overvoltage_protection_level", ()),
-        ("set_overvoltage_protection_enabled", (True,)),
-        ("get_overvoltage_protection_enabled", ()),
-        ("set_overvoltage_protection_delay", (0.25,)),
-        ("get_overvoltage_protection_delay", ()),
-        ("set_overcurrent_protection_level", (1.0,)),
-        ("get_overcurrent_protection_level", ()),
-        ("set_overcurrent_protection_enabled", (True,)),
-        ("get_overcurrent_protection_enabled", ()),
-        ("set_remote_sense_enabled", (True,)),
-        ("get_remote_sense_enabled", ()),
-    ],
-)
-def test_tdk_unimplemented_optional_features_raise_from_base(
-    tdk: TDKLambdaGenesys,
-    method_name: str,
-    args: tuple[object, ...],
-) -> None:
-    with pytest.raises(NotImplementedError, match=f"{method_name} is not implemented for TDKLambdaGenesys"):
-        getattr(tdk, method_name)(*args, channel=1)
-
 
 # --- InstroPSU composition ---
 

--- a/tests/psu/test_psu_drivers.py
+++ b/tests/psu/test_psu_drivers.py
@@ -294,6 +294,7 @@ def test_rigol_check_errors_raises_on_nonzero(rigol: RigolDP800, rigol_visa: Mag
     with pytest.raises(RuntimeError, match="Rigol PSU reported error"):
         rigol.set_voltage(1.0, channel=1)
 
+
 # --- InstroPSU composition ---
 
 


### PR DESCRIPTION
## Summary

This implements OVP, OCP, and Remote Sense for the TDK Genesys series of power supplies. It also stubs support for Keysight N5700 series supplies that are white labelled TDK Genesys supplies. This _does not_ include newer Genesys+ models. This closes INSTRO-9.

## Type of change

- [ ] Bug fix (`fix`)
- [X] New feature (`feat`)
- [ ] Breaking change (`feat!` / `fix!`)
- [ ] Refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] Chore / tooling (`chore`)

## Verification

======================================================================== test session starts ========================================================================
platform darwin -- Python 3.12.12, pytest-8.4.2, pluggy-1.6.0 -- /Users/william/Projects/instro/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/william/Projects/instro
configfile: pyproject.toml
collected 48 items                                                                                                                                                  

tests/psu/tdk/test_tdk_lambda_genesys_hardware.py::test_set_voltage[lan] PASSED                                                                               [  2%]
tests/psu/tdk/test_tdk_lambda_genesys_hardware.py::test_set_voltage_rejects_negative_value[lan] PASSED                                                        [  4%]
tests/psu/tdk/test_tdk_lambda_genesys_hardware.py::test_set_voltage_rejects_value_at_ovp_limit[lan] PASSED                                                    [  6%]
tests/psu/tdk/test_tdk_lambda_genesys_hardware.py::test_get_voltage[lan] PASSED                                                                               [  8%]
tests/psu/tdk/test_tdk_lambda_genesys_hardware.py::test_set_current_limit[lan] PASSED                                                                         [ 10%]
tests/psu/tdk/test_tdk_lambda_genesys_hardware.py::test_set_current_limit_rejects_negative_value[lan] PASSED                                                  [ 12%]
tests/psu/tdk/test_tdk_lambda_genesys_hardware.py::test_get_current[lan] PASSED                                                                               [ 14%]
tests/psu/tdk/test_tdk_lambda_genesys_hardware.py::test_output_enable[lan] PASSED                                                                             [ 16%]
tests/psu/tdk/test_tdk_lambda_genesys_hardware.py::test_get_output_status[lan] PASSED                                                                         [ 18%]
tests/psu/tdk/test_tdk_lambda_genesys_hardware.py::test_set_overvoltage_protection_level[lan] PASSED                                                          [ 20%]
tests/psu/tdk/test_tdk_lambda_genesys_hardware.py::test_set_overvoltage_protection_level_rejects_value_at_programmed_voltage[lan] PASSED                      [ 22%]
tests/psu/tdk/test_tdk_lambda_genesys_hardware.py::test_get_overvoltage_protection_level[lan] PASSED                                                          [ 25%]
tests/psu/tdk/test_tdk_lambda_genesys_hardware.py::test_set_overvoltage_protection_enabled_unsupported[lan] PASSED                                            [ 27%]
tests/psu/tdk/test_tdk_lambda_genesys_hardware.py::test_get_overvoltage_protection_enabled_unsupported[lan] PASSED                                            [ 29%]
tests/psu/tdk/test_tdk_lambda_genesys_hardware.py::test_set_overvoltage_protection_delay_unsupported[lan] PASSED                                              [ 31%]
tests/psu/tdk/test_tdk_lambda_genesys_hardware.py::test_get_overvoltage_protection_delay_unsupported[lan] PASSED                                              [ 33%]
tests/psu/tdk/test_tdk_lambda_genesys_hardware.py::test_set_overcurrent_protection_level_unsupported[lan] PASSED                                              [ 35%]
tests/psu/tdk/test_tdk_lambda_genesys_hardware.py::test_get_overcurrent_protection_level_unsupported[lan] PASSED                                              [ 37%]
tests/psu/tdk/test_tdk_lambda_genesys_hardware.py::test_set_overcurrent_protection_enabled[lan] PASSED                                                        [ 39%]
tests/psu/tdk/test_tdk_lambda_genesys_hardware.py::test_get_overcurrent_protection_enabled[lan] PASSED                                                        [ 41%]
tests/psu/tdk/test_tdk_lambda_genesys_hardware.py::test_set_remote_sense_enabled_unsupported[lan] PASSED                                                      [ 43%]
tests/psu/tdk/test_tdk_lambda_genesys_hardware.py::test_get_remote_sense_enabled_unsupported[lan] PASSED                                                      [ 45%]
tests/psu/tdk/test_tdk_lambda_genesys_hardware.py::test_invalid_channel_raises[lan] PASSED                                                                    [ 47%]
tests/psu/tdk/test_tdk_lambda_genesys_hardware.py::test_check_errors_raises_after_instrument_error[lan] PASSED                                                [ 50%]
tests/psu/tdk/test_tdk_lambda_genesys_hardware.py::test_set_voltage[usb] PASSED                                                                               [ 52%]
tests/psu/tdk/test_tdk_lambda_genesys_hardware.py::test_set_voltage_rejects_negative_value[usb] PASSED                                                        [ 54%]
tests/psu/tdk/test_tdk_lambda_genesys_hardware.py::test_set_voltage_rejects_value_at_ovp_limit[usb] PASSED                                                    [ 56%]
tests/psu/tdk/test_tdk_lambda_genesys_hardware.py::test_get_voltage[usb] PASSED                                                                               [ 58%]
tests/psu/tdk/test_tdk_lambda_genesys_hardware.py::test_set_current_limit[usb] PASSED                                                                         [ 60%]
tests/psu/tdk/test_tdk_lambda_genesys_hardware.py::test_set_current_limit_rejects_negative_value[usb] PASSED                                                  [ 62%]
tests/psu/tdk/test_tdk_lambda_genesys_hardware.py::test_get_current[usb] PASSED                                                                               [ 64%]
tests/psu/tdk/test_tdk_lambda_genesys_hardware.py::test_output_enable[usb] PASSED                                                                             [ 66%]
tests/psu/tdk/test_tdk_lambda_genesys_hardware.py::test_get_output_status[usb] PASSED                                                                         [ 68%]
tests/psu/tdk/test_tdk_lambda_genesys_hardware.py::test_set_overvoltage_protection_level[usb] PASSED                                                          [ 70%]
tests/psu/tdk/test_tdk_lambda_genesys_hardware.py::test_set_overvoltage_protection_level_rejects_value_at_programmed_voltage[usb] PASSED                      [ 72%]
tests/psu/tdk/test_tdk_lambda_genesys_hardware.py::test_get_overvoltage_protection_level[usb] PASSED                                                          [ 75%]
tests/psu/tdk/test_tdk_lambda_genesys_hardware.py::test_set_overvoltage_protection_enabled_unsupported[usb] PASSED                                            [ 77%]
tests/psu/tdk/test_tdk_lambda_genesys_hardware.py::test_get_overvoltage_protection_enabled_unsupported[usb] PASSED                                            [ 79%]
tests/psu/tdk/test_tdk_lambda_genesys_hardware.py::test_set_overvoltage_protection_delay_unsupported[usb] PASSED                                              [ 81%]
tests/psu/tdk/test_tdk_lambda_genesys_hardware.py::test_get_overvoltage_protection_delay_unsupported[usb] PASSED                                              [ 83%]
tests/psu/tdk/test_tdk_lambda_genesys_hardware.py::test_set_overcurrent_protection_level_unsupported[usb] PASSED                                              [ 85%]
tests/psu/tdk/test_tdk_lambda_genesys_hardware.py::test_get_overcurrent_protection_level_unsupported[usb] PASSED                                              [ 87%]
tests/psu/tdk/test_tdk_lambda_genesys_hardware.py::test_set_overcurrent_protection_enabled[usb] PASSED                                                        [ 89%]
tests/psu/tdk/test_tdk_lambda_genesys_hardware.py::test_get_overcurrent_protection_enabled[usb] PASSED                                                        [ 91%]
tests/psu/tdk/test_tdk_lambda_genesys_hardware.py::test_set_remote_sense_enabled_unsupported[usb] PASSED                                                      [ 93%]
tests/psu/tdk/test_tdk_lambda_genesys_hardware.py::test_get_remote_sense_enabled_unsupported[usb] PASSED                                                      [ 95%]
tests/psu/tdk/test_tdk_lambda_genesys_hardware.py::test_invalid_channel_raises[usb] PASSED                                                                    [ 97%]
tests/psu/tdk/test_tdk_lambda_genesys_hardware.py::test_check_errors_raises_after_instrument_error[usb] PASSED                                                [100%]

======================================================================== 48 passed in 30.80s ========================================================================

## Tests

- [X] Unit tests added or updated
- [ ] Existing tests cover this change
- [ ] No tests — explain why:

## Checklist

- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(driver): add support for Keysight E36300`)
- [X] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [X] Documentation updated if user-facing behavior changed
- [X] Code follows the style/conventions of the surrounding code

## Notes for reviewers

