### PR TITLE
fix(daq): make close() tolerant of double-close and failed open

### DIFF
--- a/docs/guides/instrumentation/exceptions.mdx
+++ b/docs/guides/instrumentation/exceptions.mdx
@@ -55,6 +55,8 @@ with daq:
     daq.read_analog()
 ```
 
+`close()` and `stop()` are tolerant teardown and never raise `InstrumentNotOpenError`. Closing an instrument that never opened, closing twice, or calling `close()` from a `finally` after a failed `open()` is safe and leaves the original error free to surface.
+
 Because it inherits from `InstroError`, `except InstroError` catches it.
 
 ## NotImplementedError

--- a/instro/daq/daq.py
+++ b/instro/daq/daq.py
@@ -453,7 +453,7 @@ class InstroDAQ(Instrument):
         logger.info("Opened DAQ '%s'", self.name)
 
     def close(self):
-        """Close the underlying driver and stop the daemon."""
+        """Run full teardown unconditionally: daemon, then publishers, then the driver, which owns its idempotency."""
         logger.info("Closing DAQ '%s'", self.name)
         super().close()
         self._driver.close()
@@ -561,9 +561,13 @@ class InstroDAQ(Instrument):
             super().start()
 
     def stop(self, **kwargs):
-        """Stop the DAQ device."""
-        self._require_open()
+        """Stop hardware acquisition and the background daemon; tolerant teardown when not open."""
         super().stop()
+        # Skip the device stop when not open: some drivers' stop() issues a transport
+        # command (e.g. Keysight's ABORt) that raises if the session isn't open. close()
+        # routes through here, so this gate keeps close-before-open from raising.
+        if not self._is_open:
+            return
         channel_type = kwargs.pop("channel_type", None)
         self._driver.stop(channel_type=channel_type, **kwargs)
 

--- a/tests/daq/test_daq_drivers.py
+++ b/tests/daq/test_daq_drivers.py
@@ -341,7 +341,6 @@ def test_read_digital_port_unconfigured_channel():
 
 _GUARDED_METHODS = [
     ("start", lambda daq: daq.start()),
-    ("stop", lambda daq: daq.stop()),
     ("read_analog", lambda daq: daq.read_analog()),
     ("write_analog_value", lambda daq: daq.write_analog_value("ch", 1.0)),
     ("write_digital_line", lambda daq: daq.write_digital_line("ch", 1)),
@@ -394,7 +393,7 @@ def test_method_after_open_does_not_raise_not_open():
     daq = InstroDAQ(name="ut", driver=_make_mock_driver())
     daq.open()
 
-    daq.stop()  # would raise InstrumentNotOpenError before open()
+    daq.get_points_in_buffer()  # would raise InstrumentNotOpenError before open()
 
 
 def test_method_after_close_raises_not_open_again():
@@ -405,6 +404,42 @@ def test_method_after_close_raises_not_open_again():
 
     with pytest.raises(InstrumentNotOpenError, match="ut"):
         daq.read_analog()
+
+
+def test_close_without_open_runs_full_teardown():
+    """close() before open() does not raise and still runs every teardown step: driver close and publisher close."""
+    pub = Mock(name="publisher")
+    daq = InstroDAQ(name="ut", driver=_make_mock_driver(), publishers=[pub])
+
+    daq.close()  # must not raise InstrumentNotOpenError
+
+    daq._driver.close.assert_called_once()
+    pub.close.assert_called_once()
+
+
+def test_double_close_does_not_raise_and_always_closes_driver():
+    """close() never gates the driver close on state: a second close() re-runs it (the driver owns idempotency)."""
+    daq = InstroDAQ(name="ut", driver=_make_mock_driver())
+    daq.open()
+
+    daq.close()
+    daq.close()  # must not raise InstrumentNotOpenError
+
+    assert daq._driver.close.call_count == 2
+
+
+def test_close_after_failed_open_propagates_original_error():
+    """A failed open() must not poison the finally: close() runs teardown without masking the real error."""
+    daq = InstroDAQ(name="ut", driver=_make_mock_driver())
+    daq._driver.open.side_effect = RuntimeError("device unreachable")
+
+    with pytest.raises(RuntimeError, match="device unreachable"):
+        try:
+            daq.open()
+        finally:
+            daq.close()  # must not raise InstrumentNotOpenError and mask the open failure
+
+    daq._driver.close.assert_called_once()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

`InstroDAQ.stop()` called `self._require_open()` first, and `Instrument.close()` routes through `self.stop()`. So `close()` raised `InstrumentNotOpenError` in three cases that should be tolerant:

- `close()` without `open()`
- double `close()` (the first close clears `_is_open`)
- `try: open() ... finally: close()` after a failed `open()` — the guard raised out of the `finally`, masking the original error and skipping publisher cleanup in `Instrument.close()`

Regression from #97, which added the open-guard to every DAQ method including `stop()`.

## Fix

- `stop()` always tears down the background daemon, then skips only the **device** stop when not open. That gate stays deliberately: some drivers' `stop()` issues a transport command (e.g. Keysight's `ABORt`) that raises before the session is open, and `close()` routes through `stop()`.
- `close()` now runs full teardown unconditionally — daemon, publishers, then `driver.close()` — and relies on each driver's already-idempotent `close()` (VISA returns early when no session, NI loops empty task dicts, LabJack guards the handle, MCC swallows release errors) rather than gating on the HAL's `_is_open` flag.

## Tests

Adds regression tests for close-before-open, double-close, and close-after-failed-open (verified to fail against the pre-fix source), and repoints the open-guard "after open" probe at a method that is still guarded. `just check` and `just test` pass (866 passed).

## Docs

Notes in `docs/guides/instrumentation/exceptions.mdx` that `close()`/`stop()` are tolerant teardown and never raise `InstrumentNotOpenError`.

Closes #107
