### PR TITLE
fix(build): resolve Git Bash for just recipes on Windows

### DIFF
--- a/justfile
+++ b/justfile
@@ -2,6 +2,10 @@ set positional-arguments := true
 
 export CARGO_TERM_COLOR := "always"
 
+# On Windows, ensure shebang recipes use Git Bash, not the WSL `bash` in System32 (see #109).
+# Git Bash's dir is derived from wherever `git` resolves on PATH, not a hardcoded install path.
+export PATH := if os() == "windows" { (parent_directory(parent_directory(require("git.exe"))) / "bin") + ";" + env_var("PATH") } else { env_var("PATH") }
+
 # Default command is no subcommand given to list available commands
 default:
     @just --list


### PR DESCRIPTION
## What

On Windows, `just test` / `just install` / `just eip-wheel-smoke-test` failed with exit 127:

```
/bin/bash: C:UsersjohnAppDataLocalTempjust-XXXXinstall: No such file or directory
```

These are shebang recipes (`#!/usr/bin/env bash`). `just` writes the body to a Windows temp file and runs `bash <path>`, but `bash` resolved to the **WSL launcher** (`C:\Windows\System32\bash.exe`), which expects `/mnt/c/...` and treats the backslashes as escapes — mangling the path so the script can't be found.

## Fix

Prepend Git Bash to `PATH` on Windows so plain `bash` resolves to Git Bash. The directory is **derived from where `git` resolves on `PATH`** (not a hardcoded install path), so it works regardless of which drive/folder Git is installed to:

```just
export PATH := if os() == "windows" { (parent_directory(parent_directory(require("git.exe"))) / "bin") + ";" + env_var("PATH") } else { env_var("PATH") }
```

`just` only evaluates the taken `if` branch, so `require("git.exe")` (which would fail on Linux/macOS) never runs off-Windows; the `else` re-exports `PATH` unchanged.

## Verification

`just test` passes end-to-end on Windows: 892 tests + Rust suite (23 unit, 3 doctests) + EtherNet/IP wheel smoke test, no manual `PATH` tweaking.

## Notes

- Prerequisite for adding Windows + macOS CI.
- Remaining assumption: the standard Git-for-Windows layout (official installer / winget / Chocolatey). A bare scoop shim wouldn't resolve.

Closes #109