### PR TITLE
feat(psu): add Rigol DP800 ovp, ocp, and remote sense

### DIFF
--- a/docs/guides/instrumentation/psu.mdx
+++ b/docs/guides/instrumentation/psu.mdx
@@ -11,7 +11,7 @@ description: Using InstroPSU for SCPI-based programmable power supplies
 
 - **B&K Precision**: 9115-series and 914X-series via SCPI/VISA (`BK9115`, `BK914X`)
 - **Keysight**: E36100-series single-channel via SCPI/VISA (`KeysightE36100`)
-- **Rigol**: DP-series via SCPI/VISA (`RigolDP800`)
+- **Rigol**: DP-series via SCPI/VISA (`RigolDP800`), including OVP/OCP controls and remote sense on supported DP800 channels
 - **Siglent**: SPD-series via SCPI/VISA (`SiglentSPD3303`)
 - **TDK Lambda**: Genesys family via SCPI/VISA (`TDKLambdaGenesys`), including white-label Agilent/Keysight N5700-series supplies
 - **Simulated**: `SimulatedPSU` for use with the bundled SCPI simulator

--- a/instro/psu/drivers/rigol_dp800.py
+++ b/instro/psu/drivers/rigol_dp800.py
@@ -1,29 +1,54 @@
 """Rigol DP800-series PSU driver. Covers DP811, DP821, DP831, DP832."""
 
+from dataclasses import dataclass
+
+from instro.lib.exceptions import FeatureNotSupportedError
 from instro.lib.transports.visa import VisaConfig, VisaDriver
 from instro.psu import PSUDriverBase
+
+
+@dataclass(frozen=True)
+class _Range:
+    minimum: float
+    maximum: float
+
+
+@dataclass(frozen=True)
+class _ChannelLimits:
+    voltage: _Range
+    current: _Range
+    ovp: _Range
+    ocp: _Range
 
 
 class RigolDP800(PSUDriverBase):
     """Rigol DP800-series multi-channel PSU (DP811/DP821/DP831/DP832)."""
 
+    FRIENDLY_NAME = "Rigol DP800-series PSU"
+
     def __init__(self, visa_resource: str | VisaConfig) -> None:
         self._visa = VisaDriver(visa_resource)
         self.idn = ""
+        self._limits: dict[int, _ChannelLimits] = {}
 
     def open(self) -> None:
         self._visa.open()
+        self._load_limits()
 
     def close(self) -> None:
         self._visa.close()
 
     def set_voltage(self, voltage: float, channel: int) -> None:
+        if (limits := self._limits.get(channel)) is not None:
+            self._validate_in_range(voltage, limits.voltage, channel, "voltage")
         self._write_checked(f":SOUR{channel}:VOLT {voltage:.3f}")
 
     def get_voltage(self, channel: int) -> float:
         return self._query_checked_float(f":MEAS:VOLT? CH{channel}")
 
     def set_current_limit(self, current_limit: float, channel: int) -> None:
+        if (limits := self._limits.get(channel)) is not None:
+            self._validate_in_range(current_limit, limits.current, channel, "current limit")
         self._write_checked(f":SOUR{channel}:CURR {current_limit:.3f}")
 
     def get_current(self, channel: int) -> float:
@@ -34,28 +59,72 @@ class RigolDP800(PSUDriverBase):
         self._write_checked(cmd)
 
     def get_output_status(self, channel: int) -> bool:
-        with self._visa.lock():
-            resp = self._visa.query(f":OUTP? CH{channel}")
-            self._check_errors()
-        return resp == "ON"
+        return self._query_checked_bool(f":OUTP? CH{channel}")
+
+    def set_overvoltage_protection_level(self, voltage: float, channel: int) -> None:
+        if (limits := self._limits.get(channel)) is not None:
+            self._validate_in_range(voltage, limits.ovp, channel, "overvoltage protection level")
+        self._write_checked(f":SOUR{channel}:VOLT:PROT {voltage:.3f}")
+
+    def get_overvoltage_protection_level(self, channel: int) -> float:
+        return self._query_checked_float(f":SOUR{channel}:VOLT:PROT:LEV?")
+
+    def set_overvoltage_protection_enabled(self, enabled: bool, channel: int) -> None:
+        self._write_checked(f":SOUR{channel}:VOLT:PROT:STAT {'ON' if enabled else 'OFF'}")
+
+    def get_overvoltage_protection_enabled(self, channel: int) -> bool:
+        return self._query_checked_bool(f":SOUR{channel}:VOLT:PROT:STAT?")
+
+    def set_overvoltage_protection_delay(self, delay: float, channel: int) -> None:
+        raise FeatureNotSupportedError(
+            f"set_overvoltage_protection_delay is not supported by the {self.FRIENDLY_NAME}; "
+            "the DP800 programming guide does not define an OVP delay command"
+        )
+
+    def get_overvoltage_protection_delay(self, channel: int) -> float:
+        raise FeatureNotSupportedError(
+            f"get_overvoltage_protection_delay is not supported by the {self.FRIENDLY_NAME}; "
+            "the DP800 programming guide does not define an OVP delay query"
+        )
+
+    def set_overcurrent_protection_level(self, current: float, channel: int) -> None:
+        if (limits := self._limits.get(channel)) is not None:
+            self._validate_in_range(current, limits.ocp, channel, "overcurrent protection level")
+        self._write_checked(f":SOUR{channel}:CURR:PROT {current:.3f}")
+
+    def get_overcurrent_protection_level(self, channel: int) -> float:
+        return self._query_checked_float(f":SOUR{channel}:CURR:PROT:LEV?")
+
+    def set_overcurrent_protection_enabled(self, enabled: bool, channel: int) -> None:
+        self._write_checked(f":SOUR{channel}:CURR:PROT:STAT {'ON' if enabled else 'OFF'}")
+
+    def get_overcurrent_protection_enabled(self, channel: int) -> bool:
+        return self._query_checked_bool(f":SOUR{channel}:CURR:PROT:STAT?")
+
+    def set_remote_sense_enabled(self, enabled: bool, channel: int) -> None:
+        self._write_checked(f":OUTP:SENS CH{channel},{'ON' if enabled else 'OFF'}")
+
+    def get_remote_sense_enabled(self, channel: int) -> bool:
+        state = self._query_checked(f":OUTP:SENS? CH{channel}").strip().upper()
+
+        match state:
+            case "ON" | "1":
+                return True
+            case "OFF" | "0":
+                return False
+            case "NONE":
+                raise FeatureNotSupportedError(
+                    f"remote sense is not supported by {self.FRIENDLY_NAME} channel {channel}"
+                )
+            case _:
+                raise RuntimeError(f"Unexpected Rigol remote-sense state for channel {channel}: {state}")
 
     def query_status(self) -> dict:
         """Query the status of the PSU (output enable, regulation mode, OVP/OCP flags)."""
         status: dict = {}
 
         with self._visa.lock():
-            if not self.idn:
-                self.idn = self._visa.query("*IDN?")
-                self._check_errors()
-
-            if "DP832" in self.idn or "DP831" in self.idn:
-                num_channels = 3
-            elif "DP821" in self.idn:
-                num_channels = 2
-            elif "DP811" in self.idn:
-                num_channels = 1
-            else:
-                raise RuntimeError(f"Unrecognized Rigol PSU model: {self.idn}")
+            num_channels = self._channel_count()
 
             for channel in range(1, num_channels + 1):
                 channel_dict: dict = {}
@@ -89,18 +158,63 @@ class RigolDP800(PSUDriverBase):
             "OCP": bool(cond_code & 8),
         }
 
+    def _channel_count(self) -> int:
+        if not self.idn:
+            self.idn = self._query_checked("*IDN?")
+
+        if "DP832" in self.idn or "DP831" in self.idn:
+            return 3
+        if "DP821" in self.idn:
+            return 2
+        if "DP811" in self.idn or "DP813" in self.idn:
+            return 1
+        raise RuntimeError(f"Unrecognized Rigol PSU model: {self.idn}")
+
+    def _load_limits(self) -> None:
+        self._limits = {
+            channel: _ChannelLimits(
+                voltage=self._query_range(f":SOUR{channel}:VOLT?"),
+                current=self._query_range(f":SOUR{channel}:CURR?"),
+                ovp=self._query_range(f":SOUR{channel}:VOLT:PROT:LEV?"),
+                ocp=self._query_range(f":SOUR{channel}:CURR:PROT:LEV?"),
+            )
+            for channel in range(1, self._channel_count() + 1)
+        }
+
+    def _query_range(self, command: str) -> _Range:
+        return _Range(
+            minimum=self._query_checked_float(f"{command} MIN"),
+            maximum=self._query_checked_float(f"{command} MAX"),
+        )
+
+    def _validate_in_range(self, value: float, limit: _Range, channel: int, label: str) -> None:
+        if limit.minimum <= value <= limit.maximum:
+            return
+
+        raise ValueError(
+            f"{label} {value} is out of range for {self.FRIENDLY_NAME} channel {channel}: "
+            f"{limit.minimum} to {limit.maximum}"
+        )
+
     def _write_checked(self, command: str) -> None:
         with self._visa.lock():
             self._visa.write(command)
             self._check_errors()
 
-    def _query_checked_float(self, command: str) -> float:
+    def _query_checked(self, command: str) -> str:
         with self._visa.lock():
             value = self._visa.query(command)
             self._check_errors()
-            return float(value)
+            return value
+
+    def _query_checked_float(self, command: str) -> float:
+        return float(self._query_checked(command))
+
+    def _query_checked_bool(self, command: str) -> bool:
+        return self._query_checked(command).strip().upper() in {"1", "ON"}
 
     def _check_errors(self) -> None:
         err = self._visa.query(":SYST:ERR?")
-        if not err.startswith("0"):
-            raise RuntimeError(f"Rigol PSU reported error: {err}")
+        code = err.strip().split(",", 1)[0].lstrip("+")
+        if code != "0":
+            raise RuntimeError(f"The {self.FRIENDLY_NAME} reported error: {err.strip()}")

--- a/tests/psu/rigol/test_rigol_dp800_hardware.py
+++ b/tests/psu/rigol/test_rigol_dp800_hardware.py
@@ -1,0 +1,373 @@
+"""Optional Rigol DP800-series hardware smoke tests."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Iterator
+from dataclasses import dataclass
+
+import pytest
+
+from instro.lib.exceptions import FeatureNotSupportedError
+from instro.lib.transports import VisaConfig
+from instro.psu.drivers.rigol_dp800 import RigolDP800
+
+pytestmark = pytest.mark.hardware
+
+# HARDWARE TEST SETUP - EDIT THESE VALUES BEFORE RUNNING THIS FILE.
+# Set VISA_RESOURCE to the bench unit's VISA resource string. Set VISA_BACKEND to
+# "@ivi" or "" for the system VISA library, or "@py" for pyvisa-py.
+# Keep the programmed values comfortably inside the specific unit's ratings.
+# For DP811/DP813, set CHANNELS to one channel with supports_remote_sense=True.
+# For DP821/DP822, keep channel 2 supports_remote_sense=True and remove channel 3.
+VISA_RESOURCE = "TCPIP0::IP_ADDRESS::INSTR"
+VISA_BACKEND = "@ivi"
+INVALID_CHANNEL = 4
+
+
+@dataclass(frozen=True)
+class ChannelConfig:
+    channel: int
+    programmed_voltage: float
+    programmed_current_limit: float
+    ovp_level: float
+    ocp_level: float
+    voltage_readback_tolerance: float
+    current_readback_tolerance: float
+    supports_remote_sense: bool
+
+
+CHANNELS = [
+    ChannelConfig(
+        channel=1,
+        programmed_voltage=1.0,
+        programmed_current_limit=0.1,
+        ovp_level=5.0,
+        ocp_level=0.5,
+        voltage_readback_tolerance=0.15,
+        current_readback_tolerance=0.02,
+        supports_remote_sense=False,
+    ),
+    ChannelConfig(
+        channel=2,
+        programmed_voltage=1.0,
+        programmed_current_limit=0.1,
+        ovp_level=5.0,
+        ocp_level=0.5,
+        voltage_readback_tolerance=0.15,
+        current_readback_tolerance=0.02,
+        supports_remote_sense=False,
+    ),
+    ChannelConfig(
+        channel=3,
+        programmed_voltage=1.0,
+        programmed_current_limit=0.1,
+        ovp_level=5.0,
+        ocp_level=0.5,
+        voltage_readback_tolerance=0.15,
+        current_readback_tolerance=0.02,
+        supports_remote_sense=False,
+    ),
+]
+
+
+def _shutdown_outputs(driver: RigolDP800) -> None:
+    for channel_config in CHANNELS:
+        driver.output_enable(False, channel=channel_config.channel)
+
+
+def _reset_driver(driver: RigolDP800) -> None:
+    driver._visa.write("*CLS")
+    driver._visa.write("*RST")
+    time.sleep(0.25)
+    driver._visa.write("*CLS")
+    driver._check_errors()
+
+
+@pytest.fixture(scope="module")
+def driver() -> Iterator[RigolDP800]:
+    psu_driver = RigolDP800(
+        VisaConfig(
+            visa_resource=VISA_RESOURCE,
+            visa_backend=VISA_BACKEND,
+        )
+    )
+    opened = False
+    try:
+        psu_driver.open()
+        opened = True
+        yield psu_driver
+    finally:
+        if opened:
+            _shutdown_outputs(psu_driver)
+        psu_driver.close()
+
+
+@pytest.fixture(autouse=True)
+def reset_before_each_test(driver: RigolDP800) -> None:
+    _reset_driver(driver)
+
+
+def test_query_status(driver: RigolDP800) -> None:
+    status = driver.query_status()
+
+    assert set(status) == {f"ch{channel_config.channel}" for channel_config in CHANNELS}
+    for channel_config in CHANNELS:
+        channel_status = status[f"ch{channel_config.channel}"]
+        assert channel_status["enable"] is False
+        assert channel_status["mode"] in {"off", "CC", "CV", "UNREGULATED"}
+        assert isinstance(channel_status["OVP"], bool)
+        assert isinstance(channel_status["OCP"], bool)
+
+
+@pytest.mark.parametrize("channel_config", CHANNELS, ids=lambda config: f"channel_{config.channel}")
+def test_set_voltage(driver: RigolDP800, channel_config: ChannelConfig) -> None:
+    driver.set_current_limit(channel_config.programmed_current_limit, channel=channel_config.channel)
+    driver.set_voltage(channel_config.programmed_voltage, channel=channel_config.channel)
+    try:
+        driver.output_enable(True, channel=channel_config.channel)
+        time.sleep(1)
+
+        assert driver.get_voltage(channel=channel_config.channel) == pytest.approx(
+            channel_config.programmed_voltage,
+            abs=channel_config.voltage_readback_tolerance,
+        )
+    finally:
+        driver.output_enable(False, channel=channel_config.channel)
+
+
+@pytest.mark.parametrize("channel_config", CHANNELS, ids=lambda config: f"channel_{config.channel}")
+def test_get_voltage(driver: RigolDP800, channel_config: ChannelConfig) -> None:
+    driver.set_current_limit(channel_config.programmed_current_limit, channel=channel_config.channel)
+    driver.set_voltage(channel_config.programmed_voltage, channel=channel_config.channel)
+    try:
+        driver.output_enable(True, channel=channel_config.channel)
+        time.sleep(1)
+
+        voltage = driver.get_voltage(channel=channel_config.channel)
+
+        assert voltage == pytest.approx(
+            channel_config.programmed_voltage,
+            abs=channel_config.voltage_readback_tolerance,
+        )
+    finally:
+        driver.output_enable(False, channel=channel_config.channel)
+
+
+@pytest.mark.parametrize("channel_config", CHANNELS, ids=lambda config: f"channel_{config.channel}")
+def test_set_current_limit(driver: RigolDP800, channel_config: ChannelConfig) -> None:
+    driver.set_current_limit(channel_config.programmed_current_limit, channel=channel_config.channel)
+    driver.set_voltage(channel_config.programmed_voltage, channel=channel_config.channel)
+    try:
+        driver.output_enable(True, channel=channel_config.channel)
+        time.sleep(1)
+
+        assert driver.get_current(channel=channel_config.channel) == pytest.approx(
+            0.0,
+            abs=channel_config.current_readback_tolerance,
+        )
+    finally:
+        driver.output_enable(False, channel=channel_config.channel)
+
+
+@pytest.mark.parametrize("channel_config", CHANNELS, ids=lambda config: f"channel_{config.channel}")
+def test_get_current(driver: RigolDP800, channel_config: ChannelConfig) -> None:
+    driver.set_current_limit(channel_config.programmed_current_limit, channel=channel_config.channel)
+    driver.set_voltage(channel_config.programmed_voltage, channel=channel_config.channel)
+    try:
+        driver.output_enable(True, channel=channel_config.channel)
+        time.sleep(1)
+
+        current = driver.get_current(channel=channel_config.channel)
+
+        assert current == pytest.approx(
+            0.0,
+            abs=channel_config.current_readback_tolerance,
+        )
+    finally:
+        driver.output_enable(False, channel=channel_config.channel)
+
+
+@pytest.mark.parametrize("channel_config", CHANNELS, ids=lambda config: f"channel_{config.channel}")
+def test_output_enable(driver: RigolDP800, channel_config: ChannelConfig) -> None:
+    driver.set_current_limit(channel_config.programmed_current_limit, channel=channel_config.channel)
+    driver.set_voltage(channel_config.programmed_voltage, channel=channel_config.channel)
+    try:
+        driver.output_enable(True, channel=channel_config.channel)
+        assert driver.get_output_status(channel=channel_config.channel) is True
+
+        driver.output_enable(False, channel=channel_config.channel)
+        assert driver.get_output_status(channel=channel_config.channel) is False
+    finally:
+        driver.output_enable(False, channel=channel_config.channel)
+
+
+@pytest.mark.parametrize("channel_config", CHANNELS, ids=lambda config: f"channel_{config.channel}")
+def test_get_output_status(driver: RigolDP800, channel_config: ChannelConfig) -> None:
+    assert driver.get_output_status(channel=channel_config.channel) is False
+
+    driver.set_current_limit(channel_config.programmed_current_limit, channel=channel_config.channel)
+    driver.set_voltage(channel_config.programmed_voltage, channel=channel_config.channel)
+    try:
+        driver.output_enable(True, channel=channel_config.channel)
+
+        assert driver.get_output_status(channel=channel_config.channel) is True
+    finally:
+        driver.output_enable(False, channel=channel_config.channel)
+
+
+@pytest.mark.parametrize("channel_config", CHANNELS, ids=lambda config: f"channel_{config.channel}")
+def test_set_overvoltage_protection_level(driver: RigolDP800, channel_config: ChannelConfig) -> None:
+    driver.set_overvoltage_protection_level(channel_config.ovp_level, channel=channel_config.channel)
+
+    assert driver.get_overvoltage_protection_level(channel=channel_config.channel) == pytest.approx(
+        channel_config.ovp_level
+    )
+
+
+@pytest.mark.parametrize("channel_config", CHANNELS, ids=lambda config: f"channel_{config.channel}")
+def test_get_overvoltage_protection_level(driver: RigolDP800, channel_config: ChannelConfig) -> None:
+    driver.set_overvoltage_protection_level(channel_config.ovp_level, channel=channel_config.channel)
+
+    level = driver.get_overvoltage_protection_level(channel=channel_config.channel)
+
+    assert level == pytest.approx(channel_config.ovp_level)
+
+
+@pytest.mark.parametrize("channel_config", CHANNELS, ids=lambda config: f"channel_{config.channel}")
+def test_set_overvoltage_protection_enabled(driver: RigolDP800, channel_config: ChannelConfig) -> None:
+    driver.set_overvoltage_protection_level(channel_config.ovp_level, channel=channel_config.channel)
+    driver.set_overvoltage_protection_enabled(True, channel=channel_config.channel)
+    assert driver.get_overvoltage_protection_enabled(channel=channel_config.channel) is True
+
+    driver.set_overvoltage_protection_enabled(False, channel=channel_config.channel)
+    assert driver.get_overvoltage_protection_enabled(channel=channel_config.channel) is False
+
+
+@pytest.mark.parametrize("channel_config", CHANNELS, ids=lambda config: f"channel_{config.channel}")
+def test_get_overvoltage_protection_enabled(driver: RigolDP800, channel_config: ChannelConfig) -> None:
+    driver.set_overvoltage_protection_level(channel_config.ovp_level, channel=channel_config.channel)
+    driver.set_overvoltage_protection_enabled(False, channel=channel_config.channel)
+    assert driver.get_overvoltage_protection_enabled(channel=channel_config.channel) is False
+
+    driver.set_overvoltage_protection_enabled(True, channel=channel_config.channel)
+
+    assert driver.get_overvoltage_protection_enabled(channel=channel_config.channel) is True
+
+
+@pytest.mark.parametrize("channel_config", CHANNELS, ids=lambda config: f"channel_{config.channel}")
+def test_set_overcurrent_protection_level(driver: RigolDP800, channel_config: ChannelConfig) -> None:
+    driver.set_overcurrent_protection_level(channel_config.ocp_level, channel=channel_config.channel)
+
+    assert driver.get_overcurrent_protection_level(channel=channel_config.channel) == pytest.approx(
+        channel_config.ocp_level
+    )
+
+
+@pytest.mark.parametrize("channel_config", CHANNELS, ids=lambda config: f"channel_{config.channel}")
+def test_get_overcurrent_protection_level(driver: RigolDP800, channel_config: ChannelConfig) -> None:
+    driver.set_overcurrent_protection_level(channel_config.ocp_level, channel=channel_config.channel)
+
+    level = driver.get_overcurrent_protection_level(channel=channel_config.channel)
+
+    assert level == pytest.approx(channel_config.ocp_level)
+
+
+@pytest.mark.parametrize("channel_config", CHANNELS, ids=lambda config: f"channel_{config.channel}")
+def test_set_overcurrent_protection_enabled(driver: RigolDP800, channel_config: ChannelConfig) -> None:
+    driver.set_overcurrent_protection_level(channel_config.ocp_level, channel=channel_config.channel)
+    driver.set_overcurrent_protection_enabled(True, channel=channel_config.channel)
+    assert driver.get_overcurrent_protection_enabled(channel=channel_config.channel) is True
+
+    driver.set_overcurrent_protection_enabled(False, channel=channel_config.channel)
+    assert driver.get_overcurrent_protection_enabled(channel=channel_config.channel) is False
+
+
+@pytest.mark.parametrize("channel_config", CHANNELS, ids=lambda config: f"channel_{config.channel}")
+def test_get_overcurrent_protection_enabled(driver: RigolDP800, channel_config: ChannelConfig) -> None:
+    driver.set_overcurrent_protection_level(channel_config.ocp_level, channel=channel_config.channel)
+    driver.set_overcurrent_protection_enabled(False, channel=channel_config.channel)
+    assert driver.get_overcurrent_protection_enabled(channel=channel_config.channel) is False
+
+    driver.set_overcurrent_protection_enabled(True, channel=channel_config.channel)
+
+    assert driver.get_overcurrent_protection_enabled(channel=channel_config.channel) is True
+
+
+def test_set_overvoltage_protection_delay_unsupported(driver: RigolDP800) -> None:
+    with pytest.raises(FeatureNotSupportedError, match="OVP delay command"):
+        driver.set_overvoltage_protection_delay(0.1, channel=CHANNELS[0].channel)
+
+
+def test_get_overvoltage_protection_delay_unsupported(driver: RigolDP800) -> None:
+    with pytest.raises(FeatureNotSupportedError, match="OVP delay query"):
+        driver.get_overvoltage_protection_delay(channel=CHANNELS[0].channel)
+
+
+@pytest.mark.parametrize("channel_config", CHANNELS, ids=lambda config: f"channel_{config.channel}")
+def test_set_remote_sense_enabled(driver: RigolDP800, channel_config: ChannelConfig) -> None:
+    if not channel_config.supports_remote_sense:
+        with pytest.raises(RuntimeError, match="Rigol DP800-series PSU reported error"):
+            driver.set_remote_sense_enabled(True, channel=channel_config.channel)
+        return
+
+    try:
+        driver.set_remote_sense_enabled(True, channel=channel_config.channel)
+        assert driver.get_remote_sense_enabled(channel=channel_config.channel) is True
+    finally:
+        driver.set_remote_sense_enabled(False, channel=channel_config.channel)
+
+    assert driver.get_remote_sense_enabled(channel=channel_config.channel) is False
+
+
+@pytest.mark.parametrize("channel_config", CHANNELS, ids=lambda config: f"channel_{config.channel}")
+def test_get_remote_sense_enabled(driver: RigolDP800, channel_config: ChannelConfig) -> None:
+    if not channel_config.supports_remote_sense:
+        with pytest.raises(FeatureNotSupportedError, match="remote sense is not supported"):
+            driver.get_remote_sense_enabled(channel=channel_config.channel)
+        return
+
+    driver.set_remote_sense_enabled(False, channel=channel_config.channel)
+    assert driver.get_remote_sense_enabled(channel=channel_config.channel) is False
+
+    try:
+        driver.set_remote_sense_enabled(True, channel=channel_config.channel)
+
+        assert driver.get_remote_sense_enabled(channel=channel_config.channel) is True
+    finally:
+        driver.set_remote_sense_enabled(False, channel=channel_config.channel)
+
+
+def test_check_errors_raises_after_instrument_error(driver: RigolDP800) -> None:
+    driver._visa.write("INSTRO:INVALID")
+
+    with pytest.raises(RuntimeError, match="Rigol DP800-series PSU reported error"):
+        driver._check_errors()
+
+
+def test_set_voltage_out_of_range_raises_value_error(driver: RigolDP800) -> None:
+    with pytest.raises(ValueError, match="out of range"):
+        driver.set_voltage(10_000.0, channel=CHANNELS[0].channel)
+
+
+def test_set_current_limit_out_of_range_raises_value_error(driver: RigolDP800) -> None:
+    with pytest.raises(ValueError, match="out of range"):
+        driver.set_current_limit(10_000.0, channel=CHANNELS[0].channel)
+
+
+def test_set_overvoltage_protection_level_out_of_range_raises_value_error(driver: RigolDP800) -> None:
+    with pytest.raises(ValueError, match="out of range"):
+        driver.set_overvoltage_protection_level(10_000.0, channel=CHANNELS[0].channel)
+
+
+def test_set_overcurrent_protection_level_out_of_range_raises_value_error(driver: RigolDP800) -> None:
+    with pytest.raises(ValueError, match="out of range"):
+        driver.set_overcurrent_protection_level(10_000.0, channel=CHANNELS[0].channel)
+
+
+def test_invalid_channel_raises_instrument_error(driver: RigolDP800) -> None:
+    try:
+        with pytest.raises(RuntimeError, match="Rigol DP800-series PSU reported error"):
+            driver.set_voltage(1.0, channel=INVALID_CHANNEL)
+    finally:
+        driver._visa.write("*CLS")

--- a/tests/psu/rigol/test_rigol_dp800_software.py
+++ b/tests/psu/rigol/test_rigol_dp800_software.py
@@ -1,0 +1,412 @@
+"""Software tests for the Rigol DP800-series PSU driver."""
+
+from collections.abc import Iterator
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from instro.lib.exceptions import FeatureNotSupportedError
+from instro.lib.transports import VisaConfig
+from instro.psu.drivers import RigolDP800
+
+_NO_ERROR = '0,"No error"'
+
+
+@pytest.fixture
+def rigol_visa_cls() -> Iterator[MagicMock]:
+    with patch("instro.psu.drivers.rigol_dp800.VisaDriver", autospec=True) as cls:
+        yield cls
+
+
+@pytest.fixture
+def rigol_visa(rigol_visa_cls: MagicMock) -> MagicMock:
+    visa = rigol_visa_cls.return_value
+    visa.query.return_value = _NO_ERROR
+    return visa
+
+
+@pytest.fixture
+def rigol(rigol_visa_cls: MagicMock) -> RigolDP800:
+    return RigolDP800("TCPIP0::rigol::INSTR")
+
+
+def _open_with_dp832_limits(rigol: RigolDP800, rigol_visa: MagicMock, reset_mock: bool = True) -> None:
+    responses = ["RIGOL TECHNOLOGIES,DP832A,DP8B26AM00234,00.01.19", _NO_ERROR]
+    for _ in range(3):
+        responses.extend(
+            [
+                "0.000",
+                _NO_ERROR,
+                "32.000",
+                _NO_ERROR,
+                "0.000",
+                _NO_ERROR,
+                "3.200",
+                _NO_ERROR,
+                "0.001",
+                _NO_ERROR,
+                "33.000",
+                _NO_ERROR,
+                "0.001",
+                _NO_ERROR,
+                "3.300",
+                _NO_ERROR,
+            ]
+        )
+
+    rigol_visa.query.side_effect = responses
+    rigol.open()
+    if reset_mock:
+        rigol_visa.reset_mock()
+        rigol_visa.query.side_effect = None
+        rigol_visa.query.return_value = _NO_ERROR
+
+
+def test_rigol_init_builds_visa_driver_from_resource(rigol_visa_cls: MagicMock) -> None:
+    RigolDP800("TCPIP0::rigol::INSTR")
+
+    rigol_visa_cls.assert_called_once_with("TCPIP0::rigol::INSTR")
+
+
+def test_rigol_init_accepts_prebuilt_connection_config(rigol_visa_cls: MagicMock) -> None:
+    config = VisaConfig(visa_resource="TCPIP0::rigol::INSTR")
+    RigolDP800(config)
+
+    rigol_visa_cls.assert_called_once_with(config)
+
+
+def test_rigol_open_close_delegate_to_visa(rigol: RigolDP800, rigol_visa: MagicMock) -> None:
+    _open_with_dp832_limits(rigol, rigol_visa, reset_mock=False)
+    rigol.close()
+
+    rigol_visa.open.assert_called_once()
+    rigol_visa.close.assert_called_once()
+
+
+def test_rigol_open_caches_channel_limits(rigol: RigolDP800, rigol_visa: MagicMock) -> None:
+    _open_with_dp832_limits(rigol, rigol_visa, reset_mock=False)
+
+    assert rigol_visa.query.call_args_list[:18] == [
+        call("*IDN?"),
+        call(":SYST:ERR?"),
+        call(":SOUR1:VOLT? MIN"),
+        call(":SYST:ERR?"),
+        call(":SOUR1:VOLT? MAX"),
+        call(":SYST:ERR?"),
+        call(":SOUR1:CURR? MIN"),
+        call(":SYST:ERR?"),
+        call(":SOUR1:CURR? MAX"),
+        call(":SYST:ERR?"),
+        call(":SOUR1:VOLT:PROT:LEV? MIN"),
+        call(":SYST:ERR?"),
+        call(":SOUR1:VOLT:PROT:LEV? MAX"),
+        call(":SYST:ERR?"),
+        call(":SOUR1:CURR:PROT:LEV? MIN"),
+        call(":SYST:ERR?"),
+        call(":SOUR1:CURR:PROT:LEV? MAX"),
+        call(":SYST:ERR?"),
+    ]
+
+
+def test_rigol_set_voltage_writes_per_channel(rigol: RigolDP800, rigol_visa: MagicMock) -> None:
+    rigol.set_voltage(5.0, channel=2)
+
+    rigol_visa.write.assert_called_once_with(":SOUR2:VOLT 5.000")
+    rigol_visa.query.assert_called_once_with(":SYST:ERR?")
+
+
+def test_rigol_get_voltage_uses_meas_command(rigol: RigolDP800, rigol_visa: MagicMock) -> None:
+    rigol_visa.query.side_effect = ["12.000", '0,"No error"']
+
+    assert rigol.get_voltage(channel=3) == pytest.approx(12.0)
+    assert rigol_visa.query.call_args_list == [call(":MEAS:VOLT? CH3"), call(":SYST:ERR?")]
+
+
+def test_rigol_set_current_limit_writes_per_channel(rigol: RigolDP800, rigol_visa: MagicMock) -> None:
+    rigol.set_current_limit(0.5, channel=2)
+
+    rigol_visa.write.assert_called_once_with(":SOUR2:CURR 0.500")
+    rigol_visa.query.assert_called_once_with(":SYST:ERR?")
+
+
+def test_rigol_get_current_uses_meas_command(rigol: RigolDP800, rigol_visa: MagicMock) -> None:
+    rigol_visa.query.side_effect = ["0.250", '0,"No error"']
+
+    assert rigol.get_current(channel=1) == pytest.approx(0.25)
+    assert rigol_visa.query.call_args_list == [call(":MEAS:CURR? CH1"), call(":SYST:ERR?")]
+
+
+def test_rigol_output_enable_formats_per_channel(rigol: RigolDP800, rigol_visa: MagicMock) -> None:
+    rigol.output_enable(True, channel=1)
+    rigol.output_enable(False, channel=2)
+
+    assert rigol_visa.write.call_args_list == [call(":OUTP CH1,ON"), call(":OUTP CH2,OFF")]
+    assert rigol_visa.query.call_args_list == [call(":SYST:ERR?"), call(":SYST:ERR?")]
+
+
+def test_rigol_get_output_status_parses_state(rigol: RigolDP800, rigol_visa: MagicMock) -> None:
+    rigol_visa.query.side_effect = ["ON", '0,"No error"']
+    assert rigol.get_output_status(channel=1) is True
+
+    rigol_visa.query.side_effect = ["OFF", '0,"No error"']
+    assert rigol.get_output_status(channel=1) is False
+
+
+def test_rigol_set_overvoltage_protection_level_writes_channel_command(
+    rigol: RigolDP800,
+    rigol_visa: MagicMock,
+) -> None:
+    rigol.set_overvoltage_protection_level(12.0, channel=2)
+
+    rigol_visa.write.assert_called_once_with(":SOUR2:VOLT:PROT 12.000")
+    rigol_visa.query.assert_called_once_with(":SYST:ERR?")
+
+
+def test_rigol_get_overvoltage_protection_level_queries_channel_command(
+    rigol: RigolDP800,
+    rigol_visa: MagicMock,
+) -> None:
+    rigol_visa.query.side_effect = ["12.000", '0,"No error"']
+
+    assert rigol.get_overvoltage_protection_level(channel=2) == pytest.approx(12.0)
+    assert rigol_visa.query.call_args_list == [call(":SOUR2:VOLT:PROT:LEV?"), call(":SYST:ERR?")]
+
+
+def test_rigol_set_overvoltage_protection_enabled_writes_state(
+    rigol: RigolDP800,
+    rigol_visa: MagicMock,
+) -> None:
+    rigol.set_overvoltage_protection_enabled(True, channel=2)
+    rigol.set_overvoltage_protection_enabled(False, channel=2)
+
+    assert rigol_visa.write.call_args_list == [
+        call(":SOUR2:VOLT:PROT:STAT ON"),
+        call(":SOUR2:VOLT:PROT:STAT OFF"),
+    ]
+    assert rigol_visa.query.call_args_list == [call(":SYST:ERR?"), call(":SYST:ERR?")]
+
+
+def test_rigol_get_overvoltage_protection_enabled_parses_state(
+    rigol: RigolDP800,
+    rigol_visa: MagicMock,
+) -> None:
+    rigol_visa.query.side_effect = ["ON", '0,"No error"']
+    assert rigol.get_overvoltage_protection_enabled(channel=1) is True
+
+    rigol_visa.query.side_effect = ["OFF", '0,"No error"']
+    assert rigol.get_overvoltage_protection_enabled(channel=1) is False
+
+
+def test_rigol_overvoltage_protection_delay_raises_unsupported(
+    rigol: RigolDP800,
+    rigol_visa: MagicMock,
+) -> None:
+    with pytest.raises(FeatureNotSupportedError, match="OVP delay command"):
+        rigol.set_overvoltage_protection_delay(0.25, channel=1)
+
+    with pytest.raises(FeatureNotSupportedError, match="OVP delay query"):
+        rigol.get_overvoltage_protection_delay(channel=1)
+
+    rigol_visa.write.assert_not_called()
+    rigol_visa.query.assert_not_called()
+
+
+def test_rigol_set_overcurrent_protection_level_writes_channel_command(
+    rigol: RigolDP800,
+    rigol_visa: MagicMock,
+) -> None:
+    rigol.set_overcurrent_protection_level(2.0, channel=3)
+
+    rigol_visa.write.assert_called_once_with(":SOUR3:CURR:PROT 2.000")
+    rigol_visa.query.assert_called_once_with(":SYST:ERR?")
+
+
+@pytest.mark.parametrize(
+    ("method_name", "value"),
+    [
+        ("set_voltage", -0.001),
+        ("set_voltage", 32.001),
+        ("set_current_limit", -0.001),
+        ("set_current_limit", 3.201),
+        ("set_overvoltage_protection_level", 0.000),
+        ("set_overvoltage_protection_level", 33.001),
+        ("set_overcurrent_protection_level", 0.000),
+        ("set_overcurrent_protection_level", 3.301),
+    ],
+)
+def test_rigol_setters_reject_cached_out_of_range_values(
+    rigol: RigolDP800,
+    rigol_visa: MagicMock,
+    method_name: str,
+    value: float,
+) -> None:
+    _open_with_dp832_limits(rigol, rigol_visa)
+
+    with pytest.raises(ValueError, match="out of range"):
+        getattr(rigol, method_name)(value, channel=1)
+
+    rigol_visa.write.assert_not_called()
+    rigol_visa.query.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("method_name", "value", "expected_command"),
+    [
+        ("set_voltage", 32.0, ":SOUR1:VOLT 32.000"),
+        ("set_current_limit", 3.2, ":SOUR1:CURR 3.200"),
+        ("set_overvoltage_protection_level", 33.0, ":SOUR1:VOLT:PROT 33.000"),
+        ("set_overcurrent_protection_level", 3.3, ":SOUR1:CURR:PROT 3.300"),
+    ],
+)
+def test_rigol_setters_accept_cached_maximum_values(
+    rigol: RigolDP800,
+    rigol_visa: MagicMock,
+    method_name: str,
+    value: float,
+    expected_command: str,
+) -> None:
+    _open_with_dp832_limits(rigol, rigol_visa)
+
+    getattr(rigol, method_name)(value, channel=1)
+
+    rigol_visa.write.assert_called_once_with(expected_command)
+    rigol_visa.query.assert_called_once_with(":SYST:ERR?")
+
+
+def test_rigol_invalid_cached_channel_surfaces_instrument_parameter_error(
+    rigol: RigolDP800,
+    rigol_visa: MagicMock,
+) -> None:
+    _open_with_dp832_limits(rigol, rigol_visa)
+    rigol_visa.query.return_value = '-220,"Parameter error"'
+
+    with pytest.raises(RuntimeError, match="Parameter error"):
+        rigol.set_voltage(1.0, channel=4)
+
+    rigol_visa.write.assert_called_once_with(":SOUR4:VOLT 1.000")
+    rigol_visa.query.assert_called_once_with(":SYST:ERR?")
+
+
+def test_rigol_set_remote_sense_enabled_surfaces_instrument_parameter_error(
+    rigol: RigolDP800,
+    rigol_visa: MagicMock,
+) -> None:
+    rigol_visa.query.return_value = '-220,"Parameter error"'
+
+    with pytest.raises(RuntimeError, match="Parameter error"):
+        rigol.set_remote_sense_enabled(True, channel=1)
+
+    rigol_visa.write.assert_called_once_with(":OUTP:SENS CH1,ON")
+    rigol_visa.query.assert_called_once_with(":SYST:ERR?")
+
+
+def test_rigol_get_overcurrent_protection_level_queries_channel_command(
+    rigol: RigolDP800,
+    rigol_visa: MagicMock,
+) -> None:
+    rigol_visa.query.side_effect = ["2.000", '0,"No error"']
+
+    assert rigol.get_overcurrent_protection_level(channel=3) == pytest.approx(2.0)
+    assert rigol_visa.query.call_args_list == [call(":SOUR3:CURR:PROT:LEV?"), call(":SYST:ERR?")]
+
+
+def test_rigol_set_overcurrent_protection_enabled_writes_state(
+    rigol: RigolDP800,
+    rigol_visa: MagicMock,
+) -> None:
+    rigol.set_overcurrent_protection_enabled(True, channel=3)
+    rigol.set_overcurrent_protection_enabled(False, channel=3)
+
+    assert rigol_visa.write.call_args_list == [
+        call(":SOUR3:CURR:PROT:STAT ON"),
+        call(":SOUR3:CURR:PROT:STAT OFF"),
+    ]
+    assert rigol_visa.query.call_args_list == [call(":SYST:ERR?"), call(":SYST:ERR?")]
+
+
+def test_rigol_get_overcurrent_protection_enabled_parses_state(
+    rigol: RigolDP800,
+    rigol_visa: MagicMock,
+) -> None:
+    rigol_visa.query.side_effect = ["1", '0,"No error"']
+    assert rigol.get_overcurrent_protection_enabled(channel=1) is True
+
+    rigol_visa.query.side_effect = ["0", '0,"No error"']
+    assert rigol.get_overcurrent_protection_enabled(channel=1) is False
+
+
+def test_rigol_set_remote_sense_enabled_writes_state(rigol: RigolDP800, rigol_visa: MagicMock) -> None:
+    rigol.set_remote_sense_enabled(True, channel=2)
+    rigol.set_remote_sense_enabled(False, channel=2)
+
+    assert rigol_visa.write.call_args_list == [
+        call(":OUTP:SENS CH2,ON"),
+        call(":OUTP:SENS CH2,OFF"),
+    ]
+    assert rigol_visa.query.call_args_list == [call(":SYST:ERR?"), call(":SYST:ERR?")]
+
+
+def test_rigol_get_remote_sense_enabled_parses_state(rigol: RigolDP800, rigol_visa: MagicMock) -> None:
+    rigol_visa.query.side_effect = ["ON", '0,"No error"']
+    assert rigol.get_remote_sense_enabled(channel=2) is True
+
+    rigol_visa.query.side_effect = ["OFF", '0,"No error"']
+    assert rigol.get_remote_sense_enabled(channel=2) is False
+
+
+def test_rigol_get_remote_sense_enabled_raises_unsupported_on_none(
+    rigol: RigolDP800,
+    rigol_visa: MagicMock,
+) -> None:
+    rigol_visa.query.side_effect = ["NONE", '0,"No error"']
+
+    with pytest.raises(FeatureNotSupportedError, match="remote sense is not supported"):
+        rigol.get_remote_sense_enabled(channel=1)
+
+
+def test_rigol_check_errors_accepts_unsigned_zero(rigol: RigolDP800, rigol_visa: MagicMock) -> None:
+    rigol_visa.query.return_value = '0,"No error"'
+
+    rigol.set_voltage(1.0, channel=1)
+
+    rigol_visa.query.assert_called_once_with(":SYST:ERR?")
+
+
+def test_rigol_check_errors_accepts_signed_zero(rigol: RigolDP800, rigol_visa: MagicMock) -> None:
+    rigol_visa.query.return_value = '+0,"No error"'
+
+    rigol.set_voltage(1.0, channel=1)
+
+    rigol_visa.query.assert_called_once_with(":SYST:ERR?")
+
+
+def test_rigol_check_errors_raises_on_nonzero(rigol: RigolDP800, rigol_visa: MagicMock) -> None:
+    rigol_visa.query.return_value = '-100,"Command error"'
+
+    with pytest.raises(RuntimeError, match="Rigol DP800-series PSU reported error"):
+        rigol.set_voltage(1.0, channel=1)
+
+
+def test_rigol_write_checked_surfaces_documented_command_error(
+    rigol: RigolDP800,
+    rigol_visa: MagicMock,
+) -> None:
+    rigol_visa.query.return_value = '-113,"Undefined header; keyword cannot be found"'
+
+    with pytest.raises(RuntimeError, match="Undefined header"):
+        rigol.output_enable(True, channel=1)
+
+    rigol_visa.write.assert_called_once_with(":OUTP CH1,ON")
+    rigol_visa.query.assert_called_once_with(":SYST:ERR?")
+
+
+def test_rigol_query_checked_surfaces_documented_command_error(
+    rigol: RigolDP800,
+    rigol_visa: MagicMock,
+) -> None:
+    rigol_visa.query.side_effect = ["0.000", '-113,"Undefined header; keyword cannot be found"']
+
+    with pytest.raises(RuntimeError, match="Undefined header"):
+        rigol.get_voltage(channel=1)
+
+    assert rigol_visa.query.call_args_list == [call(":MEAS:VOLT? CH1"), call(":SYST:ERR?")]

--- a/tests/psu/test_psu_drivers.py
+++ b/tests/psu/test_psu_drivers.py
@@ -1,14 +1,10 @@
 """Tests for PSU drivers (driver-owned VisaDriver transport) and InstroPSU composition."""
 
-from collections.abc import Iterator
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock
 
 import pytest
 
 from instro.psu import InstroPSU, PSUDriverBase
-from instro.psu.drivers import (
-    BK9115,
-)
 
 # --- PSUDriverBase ---
 
@@ -96,88 +92,6 @@ def test_psu_driver_base_remote_sense_methods_raise_not_implemented(
 ) -> None:
     with pytest.raises(NotImplementedError, match=f"{method_name} is not implemented for _BaseOnlyPSUDriver"):
         getattr(base_only_psu_driver, method_name)(*args, channel=1)
-
-
-# --- BK9115 ---
-
-
-@pytest.fixture
-def bk_single_visa_cls() -> Iterator[MagicMock]:
-    with patch("instro.psu.drivers.bk_9115.VisaDriver", autospec=True) as cls:
-        yield cls
-
-
-@pytest.fixture
-def bk_single_visa(bk_single_visa_cls: MagicMock) -> MagicMock:
-    visa = bk_single_visa_cls.return_value
-    visa.query.return_value = '0,"No error"'
-    return visa
-
-
-@pytest.fixture
-def bk_single(bk_single_visa_cls: MagicMock) -> BK9115:
-    return BK9115("USB0::0xFFFF::0x9115::SN::INSTR")
-
-
-def test_bk_single_init_builds_visa_driver_from_resource(bk_single_visa_cls: MagicMock) -> None:
-    BK9115("USB0::0xFFFF::0x9115::SN::INSTR")
-    bk_single_visa_cls.assert_called_once_with("USB0::0xFFFF::0x9115::SN::INSTR")
-
-
-def test_bk_single_init_accepts_prebuilt_connection_config(bk_single_visa_cls: MagicMock) -> None:
-    config = VisaConfig(visa_resource="USB0::example::INSTR")
-    BK9115(config)
-    bk_single_visa_cls.assert_called_once_with(config)
-
-
-def test_bk_single_open_close_delegate_to_visa(bk_single: BK9115, bk_single_visa: MagicMock) -> None:
-    bk_single.open()
-    bk_single_visa.open.assert_called_once()
-    bk_single.close()
-    bk_single_visa.close.assert_called_once()
-
-
-def test_bk_single_set_voltage_writes_checked(bk_single: BK9115, bk_single_visa: MagicMock) -> None:
-    bk_single.set_voltage(5.0, channel=1)
-    bk_single_visa.write.assert_called_once_with("VOLT 5.000")
-    bk_single_visa.query.assert_called_once_with("SYST:ERR?")
-
-
-def test_bk_single_get_voltage_parses_response(bk_single: BK9115, bk_single_visa: MagicMock) -> None:
-    bk_single_visa.query.side_effect = ["12.345", '0,"No error"']
-    assert bk_single.get_voltage(channel=1) == pytest.approx(12.345)
-    assert bk_single_visa.query.call_args_list == [call("MEAS:VOLT?"), call("SYST:ERR?")]
-
-
-def test_bk_single_set_current_limit_writes_checked(bk_single: BK9115, bk_single_visa: MagicMock) -> None:
-    bk_single.set_current_limit(1.25, channel=1)
-    bk_single_visa.write.assert_called_once_with("CURR 1.250")
-    bk_single_visa.query.assert_called_once_with("SYST:ERR?")
-
-
-def test_bk_single_get_current_parses_response(bk_single: BK9115, bk_single_visa: MagicMock) -> None:
-    bk_single_visa.query.side_effect = ["0.500", '0,"No error"']
-    assert bk_single.get_current(channel=1) == pytest.approx(0.5)
-
-
-def test_bk_single_output_enable_writes_checked(bk_single: BK9115, bk_single_visa: MagicMock) -> None:
-    bk_single.output_enable(True, channel=1)
-    bk_single_visa.write.assert_called_once_with("OUTP:STAT ON")
-    bk_single.output_enable(False, channel=1)
-    assert bk_single_visa.write.call_args_list[-1] == call("OUTP:STAT OFF")
-
-
-def test_bk_single_get_output_status_parses(bk_single: BK9115, bk_single_visa: MagicMock) -> None:
-    bk_single_visa.query.side_effect = ["1", '0,"No error"']
-    assert bk_single.get_output_status(channel=1) is True
-    bk_single_visa.query.side_effect = ["0", '0,"No error"']
-    assert bk_single.get_output_status(channel=1) is False
-
-
-def test_bk_single_check_errors_raises_on_nonzero(bk_single: BK9115, bk_single_visa: MagicMock) -> None:
-    bk_single_visa.query.return_value = '-100,"Command error"'
-    with pytest.raises(RuntimeError, match="BK PSU reported error"):
-        bk_single.set_voltage(1.0, channel=1)
 
 
 # --- InstroPSU composition ---

--- a/tests/psu/test_psu_drivers.py
+++ b/tests/psu/test_psu_drivers.py
@@ -9,7 +9,6 @@ from instro.lib.transports import SerialConfig, VisaConfig
 from instro.psu import InstroPSU, PSUDriverBase
 from instro.psu.drivers import (
     BK9115,
-    RigolDP800,
     SiglentSPD3303,
 )
 
@@ -181,56 +180,6 @@ def test_bk_single_check_errors_raises_on_nonzero(bk_single: BK9115, bk_single_v
     bk_single_visa.query.return_value = '-100,"Command error"'
     with pytest.raises(RuntimeError, match="BK PSU reported error"):
         bk_single.set_voltage(1.0, channel=1)
-
-
-# --- RigolDP800 ---
-
-
-@pytest.fixture
-def rigol_visa_cls() -> Iterator[MagicMock]:
-    with patch("instro.psu.drivers.rigol_dp800.VisaDriver", autospec=True) as cls:
-        yield cls
-
-
-@pytest.fixture
-def rigol_visa(rigol_visa_cls: MagicMock) -> MagicMock:
-    visa = rigol_visa_cls.return_value
-    visa.query.return_value = '0,"No error"'
-    return visa
-
-
-@pytest.fixture
-def rigol(rigol_visa_cls: MagicMock) -> RigolDP800:
-    return RigolDP800("TCPIP0::rigol::INSTR")
-
-
-def test_rigol_set_voltage_writes_per_channel(rigol: RigolDP800, rigol_visa: MagicMock) -> None:
-    rigol.set_voltage(5.0, channel=2)
-    rigol_visa.write.assert_called_once_with(":SOUR2:VOLT 5.000")
-    rigol_visa.query.assert_called_once_with(":SYST:ERR?")
-
-
-def test_rigol_get_voltage_uses_meas_command(rigol: RigolDP800, rigol_visa: MagicMock) -> None:
-    rigol_visa.query.side_effect = ["12.000", '0,"No error"']
-    assert rigol.get_voltage(channel=3) == pytest.approx(12.0)
-    assert rigol_visa.query.call_args_list == [call(":MEAS:VOLT? CH3"), call(":SYST:ERR?")]
-
-
-def test_rigol_output_enable_formats_per_channel(rigol: RigolDP800, rigol_visa: MagicMock) -> None:
-    rigol.output_enable(True, channel=1)
-    rigol.output_enable(False, channel=2)
-    assert rigol_visa.write.call_args_list == [call(":OUTP CH1,ON"), call(":OUTP CH2,OFF")]
-
-
-def test_rigol_get_output_status_parses_on(rigol: RigolDP800, rigol_visa: MagicMock) -> None:
-    rigol_visa.query.side_effect = ["ON", '0,"No error"']
-    assert rigol.get_output_status(channel=1) is True
-
-
-def test_rigol_check_errors_raises_on_nonzero(rigol: RigolDP800, rigol_visa: MagicMock) -> None:
-    rigol_visa.query.return_value = '-100,"Command error"'
-    with pytest.raises(RuntimeError, match="Rigol PSU reported error"):
-        rigol.set_voltage(1.0, channel=1)
 
 
 # --- InstroPSU composition ---


### PR DESCRIPTION
## Summary

Add support for OVP, OCP, and remote sense to the Rigol DP800 driver. Closes INSTRO-3.

## Type of change

- [ ] Bug fix (`fix`)
- [X] New feature (`feat`)
- [ ] Breaking change (`feat!` / `fix!`)
- [ ] Refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] Chore / tooling (`chore`)

## Verification

========================================================== test session starts ===========================================================
platform darwin -- Python 3.12.12, pytest-8.4.2, pluggy-1.6.0 -- /Users/william/Projects/instro/.venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/william/Projects/instro
configfile: pyproject.toml
collected 57 items

tests/psu/rigol/test_rigol_dp800_hardware.py::test_query_status PASSED                                                             [  1%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_set_voltage[channel_1] PASSED                                                   [  3%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_set_voltage[channel_2] PASSED                                                   [  5%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_set_voltage[channel_3] PASSED                                                   [  7%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_get_voltage[channel_1] PASSED                                                   [  8%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_get_voltage[channel_2] PASSED                                                   [ 10%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_get_voltage[channel_3] PASSED                                                   [ 12%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_set_current_limit[channel_1] PASSED                                             [ 14%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_set_current_limit[channel_2] PASSED                                             [ 15%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_set_current_limit[channel_3] PASSED                                             [ 17%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_get_current[channel_1] PASSED                                                   [ 19%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_get_current[channel_2] PASSED                                                   [ 21%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_get_current[channel_3] PASSED                                                   [ 22%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_output_enable[channel_1] PASSED                                                 [ 24%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_output_enable[channel_2] PASSED                                                 [ 26%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_output_enable[channel_3] PASSED                                                 [ 28%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_get_output_status[channel_1] PASSED                                             [ 29%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_get_output_status[channel_2] PASSED                                             [ 31%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_get_output_status[channel_3] PASSED                                             [ 33%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_set_overvoltage_protection_level[channel_1] PASSED                              [ 35%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_set_overvoltage_protection_level[channel_2] PASSED                              [ 36%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_set_overvoltage_protection_level[channel_3] PASSED                              [ 38%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_get_overvoltage_protection_level[channel_1] PASSED                              [ 40%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_get_overvoltage_protection_level[channel_2] PASSED                              [ 42%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_get_overvoltage_protection_level[channel_3] PASSED                              [ 43%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_set_overvoltage_protection_enabled[channel_1] PASSED                            [ 45%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_set_overvoltage_protection_enabled[channel_2] PASSED                            [ 47%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_set_overvoltage_protection_enabled[channel_3] PASSED                            [ 49%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_get_overvoltage_protection_enabled[channel_1] PASSED                            [ 50%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_get_overvoltage_protection_enabled[channel_2] PASSED                            [ 52%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_get_overvoltage_protection_enabled[channel_3] PASSED                            [ 54%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_set_overcurrent_protection_level[channel_1] PASSED                              [ 56%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_set_overcurrent_protection_level[channel_2] PASSED                              [ 57%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_set_overcurrent_protection_level[channel_3] PASSED                              [ 59%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_get_overcurrent_protection_level[channel_1] PASSED                              [ 61%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_get_overcurrent_protection_level[channel_2] PASSED                              [ 63%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_get_overcurrent_protection_level[channel_3] PASSED                              [ 64%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_set_overcurrent_protection_enabled[channel_1] PASSED                            [ 66%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_set_overcurrent_protection_enabled[channel_2] PASSED                            [ 68%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_set_overcurrent_protection_enabled[channel_3] PASSED                            [ 70%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_get_overcurrent_protection_enabled[channel_1] PASSED                            [ 71%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_get_overcurrent_protection_enabled[channel_2] PASSED                            [ 73%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_get_overcurrent_protection_enabled[channel_3] PASSED                            [ 75%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_set_overvoltage_protection_delay_unsupported PASSED                             [ 77%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_get_overvoltage_protection_delay_unsupported PASSED                             [ 78%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_set_remote_sense_enabled[channel_1] PASSED                                      [ 80%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_set_remote_sense_enabled[channel_2] PASSED                                      [ 82%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_set_remote_sense_enabled[channel_3] PASSED                                      [ 84%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_get_remote_sense_enabled[channel_1] PASSED                                      [ 85%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_get_remote_sense_enabled[channel_2] PASSED                                      [ 87%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_get_remote_sense_enabled[channel_3] PASSED                                      [ 89%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_check_errors_raises_after_instrument_error PASSED                               [ 91%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_set_voltage_out_of_range_raises_value_error PASSED                              [ 92%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_set_current_limit_out_of_range_raises_value_error PASSED                        [ 94%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_set_overvoltage_protection_level_out_of_range_raises_value_error PASSED         [ 96%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_set_overcurrent_protection_level_out_of_range_raises_value_error PASSED         [ 98%]
tests/psu/rigol/test_rigol_dp800_hardware.py::test_invalid_channel_raises_instrument_error PASSED                                  [100%]

===================================================== 57 passed in 146.90s (0:02:26) =====================================================

## Tests

- [X] Unit tests added or updated
- [ ] Existing tests cover this change
- [ ] No tests — explain why:

## Checklist

- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(driver): add support for Keysight E36300`)
- [X] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [X] Documentation updated if user-facing behavior changed
- [X] Code follows the style/conventions of the surrounding code

## Notes for reviewers

I've done something different here given that apparently the supply we tested on silently swallows out of range values without raising an error. We are querying for the min and max values of every channel at open and then checking ourselves before sending a query.
