### PR TITLE
fix(daq): guard NI fetch_analog against fetch before start()

### DIFF
--- a/packages/instro-daq-ni/instro/daq/drivers/ni/nidaq.py
+++ b/packages/instro-daq-ni/instro/daq/drivers/ni/nidaq.py
@@ -381,6 +381,8 @@ class NIDAQDriver(DAQDriverBase):
         return DAQmxData(data=data, timestamp=timestamp, dt=None)
 
     def fetch_analog(self) -> DAQmxData:
+        if ChannelType.ANALOG_INPUT not in self._running_channel_types:
+            raise RuntimeError("No active scan. Call start() before fetch_analog().")
         if self._ai_hw_timing_config is None:
             raise RuntimeError("configure_ai_sample_rate() must be called before fetching analog data.")
         task = self._tasks[ChannelType.ANALOG_INPUT]


### PR DESCRIPTION
## Summary

`NIDAQDriver.fetch_analog()` on a configured-but-not-started continuous AI task silently corrupted published data. DAQmx auto-starts a task on `task.read(n)`, so the call returned `samples_per_channel` real samples even though `start()` was never run — but `_actual_sample_period` is only set in `start()`, so it stayed `None`. `fetch_analog()` then returned `DAQmxData(..., dt=None)`, and `_read_to_measurements` took the single-timestamp branch, producing a `Measurement` with N channel values and exactly **1** timestamp. No error was raised.

This PR adds a start-guard at the top of `fetch_analog()`:

```python
if ChannelType.ANALOG_INPUT not in self._running_channel_types:
    raise RuntimeError("No active scan. Call start() before fetch_analog().")
```

The guard raises **before** `task.read()` can auto-start the task, fixing both reported problems:

- **Primary (silent corruption):** the auto-start never happens, so we never reach `_read_to_measurements` with `dt=None` and N samples.
- **Secondary (untracked task):** since the task is never silently auto-started, a later `start()` still sees `ANALOG_INPUT` absent from `_running_channel_types` and takes the normal path instead of hitting a raw DAQmx error.

The message mirrors MCC's `fetch_analog()` so NI now fails loudly like MCC and LabJack, which both already reject this ordering.

## Test plan

- `just check` passes (ruff format, mypy, ruff lint).
- NI unit tests are deferred (none exist in the repo today; the NI package isn't installed under the default `uv sync`/CI env). Tracked on INSTRO-386.

Closes INSTRO-386