### PR TITLE
feat(daq): add Arduino Firmata DAQ driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ pip install "instro[nidaq,contrib]"
 | Multimeter | `InstroDMM` | Agilent 34401A, Keithley 2400, Keithley 2750 (unstable), simulated |
 | Electronic Load | `InstroELoad` | B&K Precision (85xxB-series) |
 | Oscilloscope | `InstroScope` | Keysight (1200X-series), Tektronix (2-series), Siglent (SDS1000X-E) |
-| DAQ | `InstroDAQ` | Keysight 34980A, NI-DAQmx, LabJack T-series, MCC USB-series |
+| DAQ | `InstroDAQ` | Keysight 34980A, NI-DAQmx, LabJack T-series, MCC USB-series, ArduinoFirmata |
 | I2C | `I2CInterface` | Total Phase Aardvark |
 | Modbus | `ModbusDevice` | Any Modbus TCP / RTU device |
 | EtherNet/IP | `EtherNetIPDevice` | Allen-Bradley / CompactLogix-class PLCs |

--- a/docs/guides/instrumentation/daq.mdx
+++ b/docs/guides/instrumentation/daq.mdx
@@ -111,9 +111,10 @@ daq = InstroDAQ(
 )
 
 # Arduino Uno (Serial Port Name)
+# sampling_rate_hz defaults to ~53 Hz (19 ms interval); maximum is 1000 Hz
 from instro.daq.drivers.arduino_firmata import ArduinoFirmata
 
-daq = InstroDAQ(name="arduino", driver=ArduinoFirmata(port="<PORT NAME>"))
+daq = InstroDAQ(name="arduino", driver=ArduinoFirmata(port="<PORT NAME>", sampling_rate_hz=100))
 
 ```
 
@@ -213,7 +214,7 @@ The `physical_channel` naming convention depends on your DAQ vendor:
 - **LabJack**: "DAC0", "DAC1", etc.
 - **MCC**: Integer channel index as a string, for example `"0"`, `"1"`.
 - **Keysight**: Depends on module slot and channel configuration
-- **Arduino**: Does not support analog output (use digital PWM pins for approximate output)
+- **Arduino**: PWM-capable digital pins only — "D3", "D5", "D6", "D9", "D10", "D11" on an Uno. This is **not true analog output**: the driver sets a PWM duty cycle via `analogWrite()`, not a DAC voltage. The `range_min`/`range_max` you configure map linearly to 0–100% duty cycle. Non-PWM pins will silently produce no output. PWM frequency is fixed by the Arduino's hardware timers and cannot be changed via StandardFirmata — D5/D6 run at ~980 Hz, all other PWM pins at ~490 Hz.
 
 Refer to your device's documentation for channel naming.
 </Note>
@@ -281,7 +282,7 @@ Different DAQ devices have different timing capabilities:
 - **Multiplexed DAQs** (e.g., LabJack T4/T7, most NI DAQ devices, most MCC devices): Maximum per-channel rate decreases with more channels
 - **Simultaneous DAQs** (e.g., LabJack T8): All channels sampled simultaneously
 - **Sample rate limits**: Check your device specifications
-- **Arduino (Firmata)**: Does not support hardware-timed acquisition; use software-timed `read_analog()` only.
+- **Arduino (Firmata)**: Does not support hardware-timed acquisition — do not call `configure_ai_sample_rate()`. The background daemon (`daq.start()`) is supported: the driver manages its own streaming-based timing config internally and routes daemon calls through a callback-populated queue. Maximum sampling rate is **1000 Hz** — this is a hard limit of the Firmata wire format, which encodes the interval as a whole-millisecond integer. Requests above 1000 Hz are clamped with a warning.
 </Warning>
 
 <Note>

--- a/docs/guides/instrumentation/daq.mdx
+++ b/docs/guides/instrumentation/daq.mdx
@@ -13,6 +13,7 @@ InstroDAQ is a hardware abstraction layer (HAL) that provides a unified interfac
 - **LabJack T-Series** - T4, T7, T8 models using LJM driver
 - **Measurement Computing (MCC)** - USB and Ethernet DAQ devices using the MCC Universal Library (`mcculw`)
 - **Keysight 34980A** - Multifunction switch/measure unit via SCPI/VISA
+- **Arduino (Firmata)** - Any Arduino running StandardFirmata via `pyfirmata2`
 
 ## Key Concepts
 
@@ -108,6 +109,12 @@ daq = InstroDAQ(
     name="keysightDAQ",
     driver=Keysight34980A("TCPIP0::<IP_ADDRESS>::INSTR"),
 )
+
+# Arduino Uno (Serial Port Name)
+from instro.daq.drivers.arduino_firmata import ArduinoFirmata
+
+daq = InstroDAQ(name="arduino", driver=ArduinoFirmata(port="<PORT NAME>"))
+
 ```
 
 ## Configuring Channels
@@ -134,6 +141,7 @@ The `physical_channel` naming convention depends on your DAQ vendor:
 - **LabJack**: "AIN0", "AIN1", etc.
 - **MCC**: Integer channel index as a string, for example `"0"`, `"1"`.
 - **Keysight**: Depends on module slot and channel configuration
+- **Arduino**: "A0", "A1", etc for analog. "D2", "D3", etc for digital.  
 
 Refer to your device's documentation for channel naming.
 </Note>
@@ -205,6 +213,7 @@ The `physical_channel` naming convention depends on your DAQ vendor:
 - **LabJack**: "DAC0", "DAC1", etc.
 - **MCC**: Integer channel index as a string, for example `"0"`, `"1"`.
 - **Keysight**: Depends on module slot and channel configuration
+- **Arduino**: Does not support analog output (use digital PWM pins for approximate output)
 
 Refer to your device's documentation for channel naming.
 </Note>
@@ -272,6 +281,7 @@ Different DAQ devices have different timing capabilities:
 - **Multiplexed DAQs** (e.g., LabJack T4/T7, most NI DAQ devices, most MCC devices): Maximum per-channel rate decreases with more channels
 - **Simultaneous DAQs** (e.g., LabJack T8): All channels sampled simultaneously
 - **Sample rate limits**: Check your device specifications
+- **Arduino (Firmata)**: Does not support hardware-timed acquisition; use software-timed `read_analog()` only.
 </Warning>
 
 <Note>
@@ -527,6 +537,7 @@ print(f"Port value: {int(measurement.latest)}")
 
 <Note>
 Port-based I/O is implemented for **MCC**, **NI DAQmx**, and **Keysight** devices. On **LabJack**, `write_digital_port()` and `read_digital_port()` raise `NotImplementedError`; use `write_digital_line()` / `read_digital_line()` to address individual lines instead. Keysight groups a single port into one channel of at most 32 bits, so `DigitalPortWidth.WIDTH_64` is rejected — configure a 64-bit span as two channels. On **NI DAQmx**, `port_width` is checked against the port's physical line count and a mismatch raises `ValueError` — pass the `DigitalPortWidth` that matches the hardware port.
+On **Arduino**, `ArduinoFirmata` raises `NotImplementedError` for port mode, same as LabJack.
 </Note>
 
 ## Complete Examples

--- a/instro/daq/drivers/__init__.py
+++ b/instro/daq/drivers/__init__.py
@@ -7,6 +7,7 @@ from pkgutil import extend_path
 __path__ = extend_path(__path__, __name__)
 
 from instro.daq import DAQDriverBase, HWTimestamper
+from instro.daq.drivers.arduino_firmata import ArduinoFirmata
 from instro.daq.drivers.keysight_34980a import Keysight34980A
 
-__all__ = ["DAQDriverBase", "HWTimestamper", "Keysight34980A"]
+__all__ = ["DAQDriverBase", "HWTimestamper", "Keysight34980A", "ArduinoFirmata"]

--- a/instro/daq/drivers/arduino_firmata.py
+++ b/instro/daq/drivers/arduino_firmata.py
@@ -34,7 +34,7 @@ class ArduinoFirmata(DAQDriverBase):
     Pin ranges depend on specific Arduino board.
     """
 
-    def __init__(self, port: str, sampling_rate_hz: float = 1000 / 19) -> None:
+    def __init__(self, port: str, sampling_rate_hz: float = 1000 / 19, buffer_size: int = 10_000) -> None:
         super().__init__()
         self._port = port
         if sampling_rate_hz > 1000:
@@ -49,10 +49,13 @@ class ArduinoFirmata(DAQDriverBase):
             raise ValueError(f"sampling_rate_hz must be > 0; got {sampling_rate_hz}Hz")
         else:
             self._sampling_interval_ms = int(1000 / sampling_rate_hz)
+
+        if buffer_size < 1:
+            raise ValueError(f"buffer_size must be >= 1; got {buffer_size}")
         self._board: pyfirmata2.Arduino | None = None
         self._pins: dict[str, Any] = {}
         self._latest_values: dict[str, float] = {}
-        self._sample_queue: queue.Queue[tuple[int, dict[str, float]]] = queue.Queue()
+        self._sample_queue: queue.Queue[tuple[int, dict[str, float]]] = queue.Queue(maxsize=buffer_size)
         self._pending_updates: set[str] = set()
         self._expected_ai_channels: frozenset[str] = frozenset()
 
@@ -89,6 +92,13 @@ class ArduinoFirmata(DAQDriverBase):
         self._sampling_interval_ms = int(1000 / rate_hz)
         if self._board is not None:
             self._board.setSamplingInterval(self._sampling_interval_ms)
+        if self._ai_hw_timing_config is not None:
+            sample_rate = 1000 / self._sampling_interval_ms
+            self._ai_hw_timing_config = HWTimingConfig(
+                sample_rate=sample_rate,
+                sample_period=round(1e9 / sample_rate),
+                samples_per_channel=1,
+            )
 
     def configure_ao_channel(self, channel: AnalogChannel) -> None:
         assert self._board is not None, "Call open() before configuring channels"
@@ -148,7 +158,16 @@ class ArduinoFirmata(DAQDriverBase):
         self._pending_updates.add(alias)
         if self._expected_ai_channels and self._pending_updates >= self._expected_ai_channels:
             timestamp = time.time_ns()
-            self._sample_queue.put((timestamp, dict(self._latest_values)))
+            if self._sample_queue.full():
+                warnings.warn(
+                    "ArduinoFirmata sample buffer is full; dropping oldest sample. "
+                    "Reduce sampling_rate_hz or increase buffer_size",
+                    UserWarning,
+                    stacklevel=2,
+                )
+                self._sample_queue.get_nowait()
+
+            self._sample_queue.put_nowait((timestamp, dict(self._latest_values)))
             self._pending_updates.clear()
 
     def read_analog(self) -> dict[str, float]:

--- a/instro/daq/drivers/arduino_firmata.py
+++ b/instro/daq/drivers/arduino_firmata.py
@@ -45,6 +45,8 @@ class ArduinoFirmata(DAQDriverBase):
             )
             self._sampling_interval_ms = 1
 
+        elif sampling_rate_hz <= 0:
+            raise ValueError(f"sampling_rate_hz must be > 0; got {sampling_rate_hz}Hz")
         else:
             self._sampling_interval_ms = int(1000 / sampling_rate_hz)
         self._board: pyfirmata2.Arduino | None = None
@@ -81,6 +83,9 @@ class ArduinoFirmata(DAQDriverBase):
                 stacklevel=2,
             )
             rate_hz = 1000
+
+        elif rate_hz <= 0:
+            raise ValueError(f"rate_hz must be > 0; got {rate_hz}Hz")
         self._sampling_interval_ms = int(1000 / rate_hz)
         if self._board is not None:
             self._board.setSamplingInterval(self._sampling_interval_ms)
@@ -151,7 +156,11 @@ class ArduinoFirmata(DAQDriverBase):
         return result
 
     def fetch_analog(self) -> dict[str, float]:
-        return self._sample_queue.get()
+        timeout = max(1.0, self._sampling_interval_ms / 1000 * 3)
+        try:
+            return self._sample_queue.get(timeout=timeout)
+        except queue.Empty:
+            return {}
 
     def _read_to_measurements(
         self,
@@ -161,6 +170,8 @@ class ArduinoFirmata(DAQDriverBase):
         default_tags: dict[str, str],
         **kwargs: Any,
     ) -> list[Measurement]:
+        if not response:
+            return []
         timestamp = time.time_ns()
         channel_data: dict[str, list[float]] = {}
         for alias, raw in response.items():

--- a/instro/daq/drivers/arduino_firmata.py
+++ b/instro/daq/drivers/arduino_firmata.py
@@ -22,18 +22,20 @@ if TYPE_CHECKING:
 class ArduinoFirmata(DAQDriverBase):
     """Arduino DAQ driver via Firmata protocol.
 
-    Arduino UNO:
-        Physical channel format - analog input: ''"A0"''-''"A5"'';
-        digital line: ''"D2"'' - ''"D13"''
+    Analog and digital I/O over StandardFirmata. The sampling rate controls how
+    often the Arduino sends analog readings back over serial. The Firmata default
+    is ~53 Hz (19ms interval). Rates above ~100 Hz may cause dropped messages at
+    the default 57600 baud; the actual ceiling depends on baud rate and the number
+    of configured channels.
 
+    Physical channel format: analog input "A0-A5"; digital line "D2"-"D13".
     Pin ranges depend on specific Arduino board.
-
     """
 
-    def __init__(self, port: str, sampling_interval_ms: int = 19) -> None:
+    def __init__(self, port: str, sampling_rate_hz: float = 1000 / 19) -> None:
         super().__init__()
         self._port = port
-        self._sampling_interval_ms = sampling_interval_ms
+        self._sampling_interval_ms = int(1000 / sampling_rate_hz)
         self._board: pyfirmata2.Arduino | None = None
         self._pins: dict[str, Any] = {}
         self._latest_values: dict[str, float] = {}
@@ -43,7 +45,7 @@ class ArduinoFirmata(DAQDriverBase):
             import pyfirmata2
         except ImportError as e:
             raise ImportError(
-                "pyfirmata2 is required for ArduinoFirmata.install it with: uv sync --extra arduino"
+                "pyfirmata2 is required for ArduinoFirmata. Install it with: uv sync --extra arduino"
             ) from e
         self._board = pyfirmata2.Arduino(self._port)
         it = pyfirmata2.util.Iterator(self._board)
@@ -56,16 +58,22 @@ class ArduinoFirmata(DAQDriverBase):
             self._board = None
         self._pins.clear()
 
+    def set_sampling_rate(self, rate_hz: float) -> None:
+        """Set the analog sampling rate. Rates above ~100Hz may cause dropped messages at the default 57600 baud."""
+        self._sampling_interval_ms = int(1000 / rate_hz)
+        if self._board is not None:
+            self._board.setSamplingInterval(self._sampling_interval_ms)
+
     def configure_ai_channel(self, channel: AnalogChannel) -> None:
         assert self._board is not None, "Call open() before configuring channels"
         alias_copy = channel.alias
-        pin_num = _parse_analog_pin(channel.physical_channel)  # turns A0 into 0, A3 into 3, etc
+        pin_num = _parse_analog_pin(channel.physical_channel)
         pin = self._board.get_pin(f"a:{pin_num}:i")
         pin.register_callback(
             lambda value, a=alias_copy: self._latest_values.__setitem__(a, value if value is not None else 0.0)
         )
-        pin.enable_reporting()  # tells arduino to continuously send readings of this pin
-        self._pins[channel.alias] = pin  # store pin object so read_analog can find by alias
+        pin.enable_reporting()
+        self._pins[channel.alias] = pin
         self._ai_channels[channel.alias] = channel
 
     def configure_ai_hw_timing(self, hw_timing_config: HWTimingConfig) -> None:
@@ -104,9 +112,7 @@ class ArduinoFirmata(DAQDriverBase):
             ch = channel_list.get(alias)
             if not isinstance(ch, AnalogChannel):
                 continue
-            voltage = ch.range_min + (
-                raw * (ch.range_max - ch.range_min)
-            )  # if raw is in range 0-1, else we must change
+            voltage = ch.range_min + (raw * (ch.range_max - ch.range_min))
 
             channel_data[f"{daq_name}.{alias}"] = [voltage]
         return [Measurement(channel_data=channel_data, timestamps=[timestamp], tags={**default_tags, **kwargs})]

--- a/instro/daq/drivers/arduino_firmata.py
+++ b/instro/daq/drivers/arduino_firmata.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import queue
 import time
+import warnings
 from typing import TYPE_CHECKING, Any, Mapping
 
 from instro.daq import DAQDriverBase
@@ -35,10 +37,22 @@ class ArduinoFirmata(DAQDriverBase):
     def __init__(self, port: str, sampling_rate_hz: float = 1000 / 19) -> None:
         super().__init__()
         self._port = port
-        self._sampling_interval_ms = int(1000 / sampling_rate_hz)
+        if sampling_rate_hz > 1000:
+            warnings.warn(
+                f"{sampling_rate_hz} Hz exceeds the Firmata protocol maximum of 1000Hz; clamping to 1000 Hz",
+                UserWarning,
+                stacklevel=2,
+            )
+            self._sampling_interval_ms = 1
+
+        else:
+            self._sampling_interval_ms = int(1000 / sampling_rate_hz)
         self._board: pyfirmata2.Arduino | None = None
         self._pins: dict[str, Any] = {}
         self._latest_values: dict[str, float] = {}
+        self._sample_queue: queue.Queue[dict[str, float]] = queue.Queue()
+        self._pending_updates: set[str] = set()
+        self._expected_ai_channels: frozenset[str] = frozenset()
 
     def open(self) -> None:
         try:
@@ -60,32 +74,75 @@ class ArduinoFirmata(DAQDriverBase):
 
     def set_sampling_rate(self, rate_hz: float) -> None:
         """Set the analog sampling rate. Rates above ~100Hz may cause dropped messages at the default 57600 baud."""
+        if rate_hz > 1000:
+            warnings.warn(
+                f"{rate_hz} Hz exceeds the Firmata protocol maximum of 1000 Hz; clamping to 1000 Hz",
+                UserWarning,
+                stacklevel=2,
+            )
+            rate_hz = 1000
         self._sampling_interval_ms = int(1000 / rate_hz)
         if self._board is not None:
             self._board.setSamplingInterval(self._sampling_interval_ms)
+
+    def configure_ao_channel(self, channel: AnalogChannel) -> None:
+        assert self._board is not None, "Call open() before configuring channels"
+        pin_num = _parse_digital_pin(channel.physical_channel)
+        pin = self._board.get_pin(f"d:{pin_num}:p")
+        self._pins[channel.alias] = pin
+        self._ao_channels[channel.alias] = channel
+
+    def write_analog_value(self, channel: AnalogChannel, value: float) -> None:
+        normalized = (value - channel.range_min) / (channel.range_max - channel.range_min)
+        self._pins[channel.alias].write(max(0.0, min(1.0, normalized)))
 
     def configure_ai_channel(self, channel: AnalogChannel) -> None:
         assert self._board is not None, "Call open() before configuring channels"
         alias_copy = channel.alias
         pin_num = _parse_analog_pin(channel.physical_channel)
         pin = self._board.get_pin(f"a:{pin_num}:i")
-        pin.register_callback(
-            lambda value, a=alias_copy: self._latest_values.__setitem__(a, value if value is not None else 0.0)
-        )
+        pin.register_callback(lambda value, a=alias_copy: self._on_analog_callback(a, value))
         pin.enable_reporting()
         self._pins[channel.alias] = pin
         self._ai_channels[channel.alias] = channel
 
     def configure_ai_hw_timing(self, hw_timing_config: HWTimingConfig) -> None:
+        # Firmata timing is managed internally in start()/stop(); do not call configure_ai_sampling_rate() on this driver.
         raise NotImplementedError("ArduinoFirmata does not support hardware-timed buffered acquisition")
 
     def start(self, **kwargs: Any) -> None:
         if self._board is not None:
+            # Set a synthetic timing config so InstroDAQ routes daemon calls through fetch_analog()
+            # rather than raising. samples_per_channel=1 because each fetch returns one snapshot.
+            # This bypasses the normal configure_ai_hw_timing() path intentionally - Firmata has no
+            # hardware timing; start()/stop() own the config lifecycle instead
+            sample_rate = 1000 / self._sampling_interval_ms
+            self._ai_hw_timing_config = HWTimingConfig(
+                sample_rate=sample_rate,
+                sample_period=round(1e9 / sample_rate),
+                samples_per_channel=1,
+            )
+            self._expected_ai_channels = frozenset(self._ai_channels.keys())
             self._board.samplingOn(self._sampling_interval_ms)
 
     def stop(self, **kwargs: Any) -> None:
         if self._board is not None:
             self._board.samplingOff()
+        self._ai_hw_timing_config = None
+        self._pending_updates.clear()
+        self._expected_ai_channels = frozenset()
+        while not self._sample_queue.empty():
+            try:
+                self._sample_queue.get_nowait()
+            except queue.Empty:
+                break
+
+    def _on_analog_callback(self, alias: str, value: float | None) -> None:
+        self._latest_values[alias] = value if value is not None else 0.0
+        self._pending_updates.add(alias)
+        if self._expected_ai_channels and self._pending_updates >= self._expected_ai_channels:
+            self._sample_queue.put(dict(self._latest_values))
+            self._pending_updates.clear()
 
     def read_analog(self) -> dict[str, float]:
         result: dict[str, float] = {}
@@ -93,10 +150,8 @@ class ArduinoFirmata(DAQDriverBase):
             result[alias] = self._latest_values.get(alias, 0.0)
         return result
 
-    def fetch_analog(self) -> Any:
-        raise NotImplementedError(
-            "ArduinoFirmata does not support hardware-timed buffered fetch; use software-timed read_analog()"
-        )
+    def fetch_analog(self) -> dict[str, float]:
+        return self._sample_queue.get()
 
     def _read_to_measurements(
         self,

--- a/instro/daq/drivers/arduino_firmata.py
+++ b/instro/daq/drivers/arduino_firmata.py
@@ -52,7 +52,7 @@ class ArduinoFirmata(DAQDriverBase):
         self._board: pyfirmata2.Arduino | None = None
         self._pins: dict[str, Any] = {}
         self._latest_values: dict[str, float] = {}
-        self._sample_queue: queue.Queue[dict[str, float]] = queue.Queue()
+        self._sample_queue: queue.Queue[tuple[int, dict[str, float]]] = queue.Queue()
         self._pending_updates: set[str] = set()
         self._expected_ai_channels: frozenset[str] = frozenset()
 
@@ -118,7 +118,8 @@ class ArduinoFirmata(DAQDriverBase):
     def start(self, **kwargs: Any) -> None:
         if self._board is not None:
             # Set a synthetic timing config so InstroDAQ routes daemon calls through fetch_analog()
-            # rather than raising. samples_per_channel=1 because each fetch returns one snapshot.
+            # rather than raising. samples_per_channel=1 because each fetch returns one snapshot per interval;
+            # fetch_analog drains the full queue and may return multiple snapshots as a batch.
             # This bypasses the normal configure_ai_hw_timing() path intentionally - Firmata has no
             # hardware timing; start()/stop() own the config lifecycle instead
             sample_rate = 1000 / self._sampling_interval_ms
@@ -146,7 +147,8 @@ class ArduinoFirmata(DAQDriverBase):
         self._latest_values[alias] = value if value is not None else 0.0
         self._pending_updates.add(alias)
         if self._expected_ai_channels and self._pending_updates >= self._expected_ai_channels:
-            self._sample_queue.put(dict(self._latest_values))
+            timestamp = time.time_ns()
+            self._sample_queue.put((timestamp, dict(self._latest_values)))
             self._pending_updates.clear()
 
     def read_analog(self) -> dict[str, float]:
@@ -155,33 +157,42 @@ class ArduinoFirmata(DAQDriverBase):
             result[alias] = self._latest_values.get(alias, 0.0)
         return result
 
-    def fetch_analog(self) -> dict[str, float]:
+    def fetch_analog(self) -> list[tuple[int, dict[str, float]]]:
         timeout = max(1.0, self._sampling_interval_ms / 1000 * 3)
+        result = []
         try:
-            return self._sample_queue.get(timeout=timeout)
+            result.append(self._sample_queue.get(timeout=timeout))
         except queue.Empty:
-            return {}
+            raise TimeoutError("fetch_analog timed out waiting for a sample")
+        while True:
+            try:
+                result.append(self._sample_queue.get_nowait())
+            except queue.Empty:
+                break
+        return result
 
     def _read_to_measurements(
         self,
-        response: dict[str, float],
+        response: list[tuple[int, dict[str, float]]],
         channel_list: Mapping[str, DAQChannel],
         daq_name: str,
         default_tags: dict[str, str],
         **kwargs: Any,
     ) -> list[Measurement]:
-        if not response:
-            return []
-        timestamp = time.time_ns()
-        channel_data: dict[str, list[float]] = {}
-        for alias, raw in response.items():
-            ch = channel_list.get(alias)
-            if not isinstance(ch, AnalogChannel):
-                continue
-            voltage = ch.range_min + (raw * (ch.range_max - ch.range_min))
+        measurements = []
+        for timestamp, values in response:
+            channel_data: dict[str, list[float]] = {}
+            for alias, raw in values.items():
+                ch = channel_list.get(alias)
+                if not isinstance(ch, AnalogChannel):
+                    continue
+                voltage = ch.range_min + (raw * (ch.range_max - ch.range_min))
 
-            channel_data[f"{daq_name}.{alias}"] = [voltage]
-        return [Measurement(channel_data=channel_data, timestamps=[timestamp], tags={**default_tags, **kwargs})]
+                channel_data[f"{daq_name}.{alias}"] = [voltage]
+            measurements.append(
+                Measurement(channel_data=channel_data, timestamps=[timestamp], tags={**default_tags, **kwargs})
+            )
+        return measurements
 
     def configure_di_line_channel(
         self, physical_channel: str, logic: Logic, logic_level: float | None = None, alias: str | None = None

--- a/instro/daq/drivers/arduino_firmata.py
+++ b/instro/daq/drivers/arduino_firmata.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING, Any, Mapping
+
+from instro.daq import DAQDriverBase
+from instro.daq.types import (
+    AnalogChannel,
+    DAQChannel,
+    DigitalChannel,
+    DigitalLineChannel,
+    Direction,
+    HWTimingConfig,
+    Logic,
+)
+from instro.lib.types import Measurement
+
+if TYPE_CHECKING:
+    import pyfirmata2
+
+
+class ArduinoFirmata(DAQDriverBase):
+    """Arduino DAQ driver via Firmata protocol.
+
+    Arduino UNO:
+        Physical channel format - analog input: ''"A0"''-''"A5"'';
+        digital line: ''"D2"'' - ''"D13"''
+
+    Pin ranges depend on specific Arduino board.
+
+    """
+
+    def __init__(self, port: str, sampling_interval_ms: int = 19) -> None:
+        super().__init__()
+        self._port = port
+        self._sampling_interval_ms = sampling_interval_ms
+        self._board: pyfirmata2.Arduino | None = None
+        self._pins: dict[str, Any] = {}
+        self._latest_values: dict[str, float] = {}
+
+    def open(self) -> None:
+        try:
+            import pyfirmata2
+        except ImportError as e:
+            raise ImportError(
+                "pyfirmata2 is required for ArduinoFirmata.install it with: uv sync --extra arduino"
+            ) from e
+        self._board = pyfirmata2.Arduino(self._port)
+        it = pyfirmata2.util.Iterator(self._board)
+        it.start()
+        time.sleep(0.1)  # allow the iterator to receive first handshake response
+
+    def close(self) -> None:
+        if self._board is not None:
+            self._board.exit()
+            self._board = None
+        self._pins.clear()
+
+    def configure_ai_channel(self, channel: AnalogChannel) -> None:
+        assert self._board is not None, "Call open() before configuring channels"
+        alias_copy = channel.alias
+        pin_num = _parse_analog_pin(channel.physical_channel)  # turns A0 into 0, A3 into 3, etc
+        pin = self._board.get_pin(f"a:{pin_num}:i")
+        pin.register_callback(
+            lambda value, a=alias_copy: self._latest_values.__setitem__(a, value if value is not None else 0.0)
+        )
+        pin.enable_reporting()  # tells arduino to continuously send readings of this pin
+        self._pins[channel.alias] = pin  # store pin object so read_analog can find by alias
+        self._ai_channels[channel.alias] = channel
+
+    def configure_ai_hw_timing(self, hw_timing_config: HWTimingConfig) -> None:
+        raise NotImplementedError("ArduinoFirmata does not support hardware-timed buffered acquisition")
+
+    def start(self, **kwargs: Any) -> None:
+        if self._board is not None:
+            self._board.samplingOn(self._sampling_interval_ms)
+
+    def stop(self, **kwargs: Any) -> None:
+        if self._board is not None:
+            self._board.samplingOff()
+
+    def read_analog(self) -> dict[str, float]:
+        result: dict[str, float] = {}
+        for alias in self._ai_channels:
+            result[alias] = self._latest_values.get(alias, 0.0)
+        return result
+
+    def fetch_analog(self) -> Any:
+        raise NotImplementedError(
+            "ArduinoFirmata does not support hardware-timed buffered fetch; use software-timed read_analog()"
+        )
+
+    def _read_to_measurements(
+        self,
+        response: dict[str, float],
+        channel_list: Mapping[str, DAQChannel],
+        daq_name: str,
+        default_tags: dict[str, str],
+        **kwargs: Any,
+    ) -> list[Measurement]:
+        timestamp = time.time_ns()
+        channel_data: dict[str, list[float]] = {}
+        for alias, raw in response.items():
+            ch = channel_list.get(alias)
+            if not isinstance(ch, AnalogChannel):
+                continue
+            voltage = ch.range_min + (
+                raw * (ch.range_max - ch.range_min)
+            )  # if raw is in range 0-1, else we must change
+
+            channel_data[f"{daq_name}.{alias}"] = [voltage]
+        return [Measurement(channel_data=channel_data, timestamps=[timestamp], tags={**default_tags, **kwargs})]
+
+    def configure_di_line_channel(
+        self, physical_channel: str, logic: Logic, logic_level: float | None = None, alias: str | None = None
+    ) -> None:
+        assert self._board is not None, "Call open() before configuring channels"
+        pin_num = _parse_digital_pin(physical_channel)
+        pin = self._board.get_pin(f"d:{pin_num}:i")
+        key = alias or physical_channel
+
+        alias_copy = key
+        pin.register_callback(
+            lambda value, a=alias_copy: self._latest_values.__setitem__(a, value if value is not None else 0)
+        )
+        pin.enable_reporting()
+        self._pins[key] = pin
+        self._di_channels[key] = DigitalLineChannel(
+            physical_channel=physical_channel,
+            alias=key,
+            direction=Direction.INPUT,
+            logic_level=logic_level,
+            logic=logic,
+            bit_position=pin_num,
+        )
+
+    def configure_do_line_channel(
+        self,
+        physical_channel: str,
+        logic: Logic,
+        logic_level: float | None = None,
+        alias: str | None = None,
+    ) -> None:
+        assert self._board is not None, "Call open() before configuring channels"
+        pin_num = _parse_digital_pin(physical_channel)
+        pin = self._board.get_pin(f"d:{pin_num}:o")
+        key = alias or physical_channel
+        self._pins[key] = pin
+        self._do_channels[key] = DigitalLineChannel(
+            physical_channel=physical_channel,
+            alias=key,
+            direction=Direction.OUTPUT,
+            logic_level=logic_level,
+            logic=logic,
+            bit_position=pin_num,
+        )
+
+    def write_digital_line(self, channel: DigitalChannel, data: int) -> None:
+        self._pins[channel.alias].write(data)
+
+    def read_digital_line(self, channel: DigitalChannel) -> int:
+        raw = self._latest_values.get(channel.alias, 0)
+        return int(bool(raw))
+
+    def write_digital_port(self, channel: DigitalChannel, data: int) -> None:
+        raise NotImplementedError("ArduinoFirmata does not support port-mode digital I/O")
+
+    def read_digital_port(self, channel: DigitalChannel) -> int:
+        raise NotImplementedError("ArduinoFirmata does not support port-mode digital I/O")
+
+
+def _parse_analog_pin(physical_channel: str) -> int:
+    """Parse A0-A5 (Range depends on board model)."""
+    return int(physical_channel.lstrip("Aa"))
+
+
+def _parse_digital_pin(physical_channel: str) -> int:
+    """Parse D2-D13 (Range depends on board model) to pyfirmata2 pin index."""
+    return int(physical_channel.lstrip("Dd"))

--- a/instro/daq/drivers/arduino_firmata.py
+++ b/instro/daq/drivers/arduino_firmata.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import contextlib
 import queue
 import time
 import warnings
@@ -48,7 +49,7 @@ class ArduinoFirmata(DAQDriverBase):
         elif sampling_rate_hz <= 0:
             raise ValueError(f"sampling_rate_hz must be > 0; got {sampling_rate_hz}Hz")
         else:
-            self._sampling_interval_ms = int(1000 / sampling_rate_hz)
+            self._sampling_interval_ms = max(1, round(1000 / sampling_rate_hz))
 
         if buffer_size < 1:
             raise ValueError(f"buffer_size must be >= 1; got {buffer_size}")
@@ -90,7 +91,7 @@ class ArduinoFirmata(DAQDriverBase):
 
         elif rate_hz <= 0:
             raise ValueError(f"rate_hz must be > 0; got {rate_hz}Hz")
-        self._sampling_interval_ms = int(1000 / rate_hz)
+        self._sampling_interval_ms = max(1, round(1000 / rate_hz))
         if self._board is not None:
             self._board.setSamplingInterval(self._sampling_interval_ms)
         if self._ai_hw_timing_config is not None:
@@ -159,20 +160,28 @@ class ArduinoFirmata(DAQDriverBase):
         self._pending_updates.add(alias)
         if self._expected_ai_channels and self._pending_updates >= self._expected_ai_channels:
             timestamp = time.time_ns()
-            if self._sample_queue.full():
+            try:
+                self._sample_queue.put_nowait((timestamp, dict(self._latest_values)))
+            except queue.Full:
                 warnings.warn(
                     "ArduinoFirmata sample buffer is full; dropping oldest sample. "
                     "Reduce sampling_rate_hz or increase buffer_size",
                     UserWarning,
                     stacklevel=2,
                 )
-                self._sample_queue.get_nowait()
-
-            self._sample_queue.put_nowait((timestamp, dict(self._latest_values)))
+                with contextlib.suppress(queue.Empty):
+                    self._sample_queue.get_nowait()
+                with contextlib.suppress(queue.Full):
+                    self._sample_queue.put_nowait((timestamp, dict(self._latest_values)))
             self._pending_updates.clear()
 
     def read_analog(self) -> list[tuple[int, dict[str, float]]]:
-        values = {alias: self._latest_values.get(alias, 0.0) for alias in self._ai_channels}
+        missing = [alias for alias in self._ai_channels if alias not in self._latest_values]
+        if missing:
+            raise RuntimeError(
+                f"No data received yet for analog channel(s) {missing}; the first Firmata report hasn't arrived yet."
+            )
+        values = {alias: self._latest_values[alias] for alias in self._ai_channels}
         return [(time.time_ns(), values)]
 
     def fetch_analog(self) -> list[tuple[int, dict[str, float]]]:
@@ -260,8 +269,11 @@ class ArduinoFirmata(DAQDriverBase):
             self._board.sp.flush()
 
     def read_digital_line(self, channel: DigitalChannel) -> int:
-        raw = self._latest_values.get(channel.alias, 0)
-        return int(bool(raw))
+        if channel.alias not in self._latest_values:
+            raise RuntimeError(
+                f"No data received yet for digital line '{channel.alias}'; the first Firmata report hasn't arrived yet."
+            )
+        return int(bool(self._latest_values[channel.alias]))
 
     def write_digital_port(self, channel: DigitalChannel, data: int) -> None:
         raise NotImplementedError("ArduinoFirmata does not support port-mode digital I/O")

--- a/instro/daq/drivers/arduino_firmata.py
+++ b/instro/daq/drivers/arduino_firmata.py
@@ -70,6 +70,7 @@ class ArduinoFirmata(DAQDriverBase):
         it = pyfirmata2.util.Iterator(self._board)
         it.start()
         time.sleep(0.1)  # allow the iterator to receive first handshake response
+        self._board.samplingOn(self._sampling_interval_ms)
 
     def close(self) -> None:
         if self._board is not None:
@@ -170,11 +171,9 @@ class ArduinoFirmata(DAQDriverBase):
             self._sample_queue.put_nowait((timestamp, dict(self._latest_values)))
             self._pending_updates.clear()
 
-    def read_analog(self) -> dict[str, float]:
-        result: dict[str, float] = {}
-        for alias in self._ai_channels:
-            result[alias] = self._latest_values.get(alias, 0.0)
-        return result
+    def read_analog(self) -> list[tuple[int, dict[str, float]]]:
+        values = {alias: self._latest_values.get(alias, 0.0) for alias in self._ai_channels}
+        return [(time.time_ns(), values)]
 
     def fetch_analog(self) -> list[tuple[int, dict[str, float]]]:
         timeout = max(1.0, self._sampling_interval_ms / 1000 * 3)
@@ -198,20 +197,18 @@ class ArduinoFirmata(DAQDriverBase):
         default_tags: dict[str, str],
         **kwargs: Any,
     ) -> list[Measurement]:
-        measurements = []
+        timestamps: list[int] = []
+        channel_data: dict[str, list[float]] = {}
         for timestamp, values in response:
-            channel_data: dict[str, list[float]] = {}
+            timestamps.append(timestamp)
             for alias, raw in values.items():
                 ch = channel_list.get(alias)
                 if not isinstance(ch, AnalogChannel):
                     continue
                 voltage = ch.range_min + (raw * (ch.range_max - ch.range_min))
+                channel_data.setdefault(f"{daq_name}.{alias}", []).append(voltage)
 
-                channel_data[f"{daq_name}.{alias}"] = [voltage]
-            measurements.append(
-                Measurement(channel_data=channel_data, timestamps=[timestamp], tags={**default_tags, **kwargs})
-            )
-        return measurements
+        return [Measurement(channel_data=channel_data, timestamps=timestamps, tags={**default_tags, **kwargs})]
 
     def configure_di_line_channel(
         self, physical_channel: str, logic: Logic, logic_level: float | None = None, alias: str | None = None
@@ -259,6 +256,8 @@ class ArduinoFirmata(DAQDriverBase):
 
     def write_digital_line(self, channel: DigitalChannel, data: int) -> None:
         self._pins[channel.alias].write(data)
+        if self._board is not None:
+            self._board.sp.flush()
 
     def read_digital_line(self, channel: DigitalChannel) -> int:
         raw = self._latest_values.get(channel.alias, 0)

--- a/instro/daq/drivers/arduino_firmata.py
+++ b/instro/daq/drivers/arduino_firmata.py
@@ -33,6 +33,11 @@ class ArduinoFirmata(DAQDriverBase):
 
     Physical channel format: analog input "A0-A5"; digital line "D2"-"D13".
     Pin ranges depend on specific Arduino board.
+
+    Known limitation: analog and digital-line channel data share one internal
+    dict keyed by alias. Configuring an AI channel and a DI channel with the
+    same alias is unsupported and will make ``read_analog()`` misidentify the
+    DI channel's report as analog data instead of raising.
     """
 
     def __init__(self, port: str, sampling_rate_hz: float = 1000 / 19, buffer_size: int = 10_000) -> None:
@@ -54,6 +59,7 @@ class ArduinoFirmata(DAQDriverBase):
         if buffer_size < 1:
             raise ValueError(f"buffer_size must be >= 1; got {buffer_size}")
         self._board: pyfirmata2.Arduino | None = None
+        self._iterator: pyfirmata2.util.Iterator | None = None
         self._pins: dict[str, Any] = {}
         self._latest_values: dict[str, float] = {}
         self._sample_queue: queue.Queue[tuple[int, dict[str, float]]] = queue.Queue(maxsize=buffer_size)
@@ -68,16 +74,27 @@ class ArduinoFirmata(DAQDriverBase):
                 "pyfirmata2 is required for ArduinoFirmata. Install it with: uv sync --extra arduino"
             ) from e
         self._board = pyfirmata2.Arduino(self._port)
-        it = pyfirmata2.util.Iterator(self._board)
-        it.start()
+        self._iterator = pyfirmata2.util.Iterator(self._board)
+        self._iterator.start()
         time.sleep(0.1)  # allow the iterator to receive first handshake response
         self._board.samplingOn(self._sampling_interval_ms)
 
     def close(self) -> None:
+        # Stop the reader thread before tearing down the board so it can't deliver a
+        # stale callback into this instance's state after close() returns (e.g. during
+        # a close()+open() reuse of the same driver).
+        if self._iterator is not None:
+            self._iterator.stop()
+            self._iterator.join(timeout=1.0)
+            self._iterator = None
         if self._board is not None:
             self._board.exit()
             self._board = None
         self._pins.clear()
+        self._latest_values.clear()
+        self._pending_updates.clear()
+        self._expected_ai_channels = frozenset()
+        self._drain_sample_queue()
 
     def set_sampling_rate(self, rate_hz: float) -> None:
         """Set the analog sampling rate. Rates above ~100Hz may cause dropped messages at the default 57600 baud."""
@@ -149,6 +166,9 @@ class ArduinoFirmata(DAQDriverBase):
         self._ai_hw_timing_config = None
         self._pending_updates.clear()
         self._expected_ai_channels = frozenset()
+        self._drain_sample_queue()
+
+    def _drain_sample_queue(self) -> None:
         while not self._sample_queue.empty():
             try:
                 self._sample_queue.get_nowait()

--- a/instro/daq/types.py
+++ b/instro/daq/types.py
@@ -11,6 +11,7 @@ class DAQVendor(Enum):
     LABJACK_T_SERIES = "LabJack T-Series"
     KEYSIGHT_34980 = "KEYSIGHT_34980"
     MCC = "MCC DAQ"
+    ARDUINO_FIRMATA = "Arduino Firmata"
     # Add other vendors as needed
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ aardvark = ["instro-i2c-aardvark"]
 ethernetip = ["instro-ethernetip"]
 contrib = ["instro-contrib"]
 unstable = ["instro-unstable"]
+arduino = ["pyfirmata2"]
 all = [
     "instro-daq-ni",
     "instro-daq-labjack",
@@ -43,6 +44,7 @@ all = [
     "instro-ethernetip",
     "instro-contrib",
     "instro-unstable",
+    "pyfirmata2",
 ]
 
 [project.urls]
@@ -150,6 +152,10 @@ mypy_path = [
     "packages/instro-contrib",
 ]
 packages = ["instro", "instro.ethernetip"]
+
+[[tool.mypy.overrides]]
+module = "pyfirmata2.*"
+ignore_missing_imports = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -166,7 +166,9 @@ testpaths = ["tests"]
 # --ignore=tests/i2c/totalphase: Aardvark tests depend on the optional `i2c` extra
 # (pyaardvark; hardware-only) and must be invoked explicitly (e.g.
 # `uv run --extra i2c python tests/i2c/totalphase/test_aardvark_hardware.py`).
-addopts = "-m 'not hardware' --ignore=tests/daq/mcc --ignore=tests/daq/labjack --ignore=tests/i2c/totalphase"
+# --ignore=tests/daq/arduino: arduino tests depend on the optional `arduino` extra
+# (pyfirmata2; hardware-only) and must be invoked explicitly (e.g. `pytest tests/daq/arduino`).
+addopts = "-m 'not hardware' --ignore=tests/daq/mcc --ignore=tests/daq/labjack --ignore=tests/i2c/totalphase --ignore=tests/daq/arduino"
 markers = [
     "hardware: tests that require a physical device and loopback wiring (deselected by default)",
 ]

--- a/tests/daq/arduino/test_arduino_firmata_hardware.py
+++ b/tests/daq/arduino/test_arduino_firmata_hardware.py
@@ -1,0 +1,476 @@
+"""Hardware integration test for the Arduino Firmata DAQ driver via InstroDAQ.
+
+This test requires a physical Arduino connected via USB running StandardFirmata.
+It exercises the ArduinoFirmata driver: analog input via background daemon,
+analog output (PWM), digital line read/write, sampling-rate change, and
+buffer-depth telemetry. Each test step is optionally recorded as an event on
+a Nominal Core asset.
+
+============================================================================
+WIRING
+============================================================================
+
+  No loopback is required for the basic tests. For loopback tests, wire:
+
+    Analog loopback  (D10 PWM out → A0 in):
+      D10 (PWM output, 0-5 V)  --->  A0 (analog input, 0-5 V)
+      Note: PWM is a square wave; the read value depends on sampling timing.
+      The loopback test only checks that A0 reads a finite value in [0, 5] V
+      — it does not assert a tight voltage match.
+
+    Digital loopback (D2 out → D3 in):
+      D2 (digital output)  --->  D3 (digital input)
+
+  Set LOOPBACK_WIRED = True once the wires are in place.
+
+============================================================================
+NOMINAL CORE CONFIGURATION
+============================================================================
+
+  Before running, configure:
+
+    PORT            — serial port of the Arduino (e.g. /dev/tty.usbmodem1101)
+    DATASET_RID     — dataset RID for the NominalCorePublisher (optional;
+                      leave None to publish nowhere)
+
+  Nominal event recording is skipped automatically when no auth profile is
+  found on disk (so the test suite still runs without Nominal credentials).
+
+============================================================================
+RUNNING
+============================================================================
+
+    pytest tests/daq/arduino/test_arduino_firmata_hardware.py -m hardware -v -s
+
+"""
+
+import math
+import time
+import unittest
+from datetime import timedelta
+
+import pytest
+from nominal.core import EventType, NominalClient
+
+from instro.daq import InstroDAQ
+from instro.daq.drivers.arduino_firmata import ArduinoFirmata
+from instro.daq.types import Direction, Logic
+from instro.lib.publishers import NominalCorePublisher
+
+# ---------------------------------------------------------------------------
+# Configuration — edit before running
+# ---------------------------------------------------------------------------
+PORT = "/dev/tty.usbmodem1101"
+NAME = "arduino_validate"
+
+# Set to a Nominal dataset RID to stream validation data via NominalCorePublisher;
+# leave None to publish nowhere.
+DATASET_RID = None
+
+# Analog channel mapping
+AI_CHANNEL_0, AI_ALIAS_0 = "A0", "voltage"
+AI_CHANNEL_1, AI_ALIAS_1 = "A1", "voltage2"
+AO_CHANNEL, AO_ALIAS = "D10", "pwm_out"
+
+# Digital channel mapping
+DO_LINE, DO_ALIAS = "D2", "do_line"
+DI_LINE, DI_ALIAS = "D3", "di_line"
+
+# Set True once D10→A0 and D2→D3 are physically looped back.
+LOOPBACK_WIRED = True
+
+SAMPLE_RATE_HZ = 100.0
+PWM_TEST_VOLTAGES = [0.0, 1.0, 2.5, 4.0, 5.0]
+
+
+# ---------------------------------------------------------------------------
+# Nominal Core event helpers
+# ---------------------------------------------------------------------------
+
+
+class _EventRecorder:
+    """Collects test events and uploads them to a Nominal asset on finish.
+
+    Gracefully disabled when no Nominal auth profile is found on disk.
+    """
+
+    def __init__(self) -> None:
+        self._client: NominalClient | None = None
+        self._events: list[dict] = []
+        self._enabled = False
+
+    def begin(self) -> None:
+        try:
+            self._client = NominalClient.from_profile("default")
+            self._enabled = True
+        except Exception as exc:
+            print(f"\nNominal Core unavailable; event recording disabled: {exc}")
+
+    def record_event(
+        self,
+        name: str,
+        start_ns: int,
+        end_ns: int,
+        passed: bool,
+        description: str = "",
+    ) -> None:
+        if not self._enabled:
+            return
+        self._events.append(
+            {
+                "name": name,
+                "start_ns": start_ns,
+                "end_ns": end_ns,
+                "passed": passed,
+                "description": description,
+            }
+        )
+
+    def finish(self) -> None:
+        if not self._enabled or not self._events:
+            return
+        assert self._client is not None
+        asset = self._client.get_or_create_asset_by_properties(
+            properties={"device_type": "Arduino", "purpose": "hardware-test"},
+            name="Arduino",
+            description="Arduino DAQ device under test",
+            labels=["arduino", "firmata", "hardware-test"],
+        )
+        for evt in self._events:
+            duration_ns = evt["end_ns"] - evt["start_ns"]
+            self._client.create_event(
+                name=evt["name"],
+                type=EventType.SUCCESS if evt["passed"] else EventType.ERROR,
+                start=evt["start_ns"],
+                duration=timedelta(microseconds=duration_ns / 1_000),
+                description=evt["description"],
+                assets=[asset],
+                properties={"status": "PASS" if evt["passed"] else "FAIL"},
+                labels=["arduino-firmata-test"],
+            )
+
+
+_recorder = _EventRecorder()
+
+
+# ---------------------------------------------------------------------------
+# Test suite
+# ---------------------------------------------------------------------------
+@pytest.mark.hardware
+class TestArduinoFirmataHardware(unittest.TestCase):
+    """Hardware integration tests for the Arduino Firmata driver via InstroDAQ.
+
+    Each test creates, opens, configures, and closes its own DAQ instance so
+    tests are independent.
+    """
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        _recorder.begin()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        try:
+            _recorder.finish()
+        except Exception as exc:
+            print(f"\n*** Failed to create Nominal events: {exc} ***")
+            raise
+
+    # -- helpers ----------------------------------------------------------
+
+    def _create_daq(self) -> InstroDAQ:
+        daq = InstroDAQ(
+            name=NAME,
+            driver=ArduinoFirmata(port=PORT, sampling_rate_hz=SAMPLE_RATE_HZ),
+        )
+        if DATASET_RID:
+            daq.add_publisher(NominalCorePublisher(dataset_rid=DATASET_RID))
+        daq.open()
+        return daq
+
+    def _configure_ai(self, daq: InstroDAQ) -> None:
+        daq.configure_analog_channel(
+            direction=Direction.INPUT,
+            physical_channel=AI_CHANNEL_0,
+            alias=AI_ALIAS_0,
+            range_min=0.0,
+            range_max=5.0,
+        )
+        daq.configure_analog_channel(
+            direction=Direction.INPUT,
+            physical_channel=AI_CHANNEL_1,
+            alias=AI_ALIAS_1,
+            range_min=0.0,
+            range_max=5.0,
+        )
+
+    def _configure_ao(self, daq: InstroDAQ) -> None:
+        daq.configure_analog_channel(
+            direction=Direction.OUTPUT,
+            physical_channel=AO_CHANNEL,
+            alias=AO_ALIAS,
+            range_min=0.0,
+            range_max=5.0,
+        )
+
+    def _configure_digital_lines(self, daq: InstroDAQ) -> None:
+        daq.configure_digital_line(
+            direction=Direction.OUTPUT,
+            physical_channel=DO_LINE,
+            logic=Logic.HIGH,
+            alias=DO_ALIAS,
+        )
+        daq.configure_digital_line(
+            direction=Direction.INPUT,
+            physical_channel=DI_LINE,
+            logic=Logic.HIGH,
+            alias=DI_ALIAS,
+        )
+
+    def _run_step(self, name: str, description: str, fn) -> None:
+        start_ns = time.time_ns()
+        try:
+            fn()
+            _recorder.record_event(name, start_ns, time.time_ns(), passed=True, description=description)
+        except Exception as exc:
+            _recorder.record_event(
+                name, start_ns, time.time_ns(), passed=False, description=f"{description}\n\nError: {exc}"
+            )
+            raise
+
+    # =====================================================================
+    # 1. Lifecycle
+    # =====================================================================
+    def test_01_lifecycle(self) -> None:
+        """Open and close the Arduino connection."""
+
+        def step() -> None:
+            daq = self._create_daq()
+            daq.close()
+
+        self._run_step(
+            "Lifecycle",
+            "Open the Arduino via Firmata and close it cleanly.",
+            step,
+        )
+
+    # =====================================================================
+    # 2. Analog input — background daemon
+    # =====================================================================
+    def test_02_analog_input_background(self) -> None:
+        """Read A0 and A1 via the background daemon."""
+
+        def step() -> None:
+            daq = self._create_daq()
+            try:
+                self._configure_ai(daq)
+                daq.start()
+                try:
+                    time.sleep(0.5)
+                    ch0 = daq.get_channel(f"{NAME}.{AI_ALIAS_0}", 1, wait_for_latest=True)
+                    ch1 = daq.get_channel(f"{NAME}.{AI_ALIAS_1}", 1, wait_for_latest=False)
+                    self.assertIsNotNone(ch0)
+                    self.assertIsNotNone(ch1)
+                    self.assertTrue(math.isfinite(ch0.latest), f"non-finite A0 read: {ch0.latest}")
+                    self.assertTrue(math.isfinite(ch1.latest), f"non-finite A1 read: {ch1.latest}")
+                    self.assertGreaterEqual(ch0.latest, 0.0)
+                    self.assertLessEqual(ch0.latest, 5.0)
+                    print(f"         A0={ch0.latest:.3f} V  A1={ch1.latest:.3f} V")
+                finally:
+                    daq.stop()
+            finally:
+                daq.close()
+
+        self._run_step(
+            "Analog input (background)",
+            "Configure A0 and A1, start the background daemon, and verify finite readings arrive.",
+            step,
+        )
+
+    # =====================================================================
+    # 3. Analog output — PWM write
+    # =====================================================================
+    def test_03_analog_output_pwm(self) -> None:
+        """Write a sweep of voltages to D10 (PWM)."""
+
+        def step() -> None:
+            daq = self._create_daq()
+            try:
+                self._configure_ao(daq)
+                for v in PWM_TEST_VOLTAGES:
+                    daq.write_analog_value(AO_ALIAS, v)
+                    time.sleep(0.2)
+                daq.write_analog_value(AO_ALIAS, 0.0)
+            finally:
+                daq.close()
+
+        self._run_step(
+            "Analog output (PWM)",
+            f"Configure D10 as PWM output and write a sweep: {PWM_TEST_VOLTAGES} V.",
+            step,
+        )
+
+    # =====================================================================
+    # 4. Analog loopback — D10 PWM → A0
+    # =====================================================================
+    def test_04_analog_loopback(self) -> None:
+        """Write D10 PWM and verify A0 reads a finite value in range (structural check only)."""
+
+        def step() -> None:
+            daq = self._create_daq()
+            try:
+                self._configure_ai(daq)
+                self._configure_ao(daq)
+                daq.write_analog_value(AO_ALIAS, 2.5)
+                daq.start()
+                try:
+                    time.sleep(0.5)
+                    ch0 = daq.get_channel(f"{NAME}.{AI_ALIAS_0}", 1, wait_for_latest=True)
+                    self.assertTrue(math.isfinite(ch0.latest), f"non-finite loopback read: {ch0.latest}")
+                    self.assertGreaterEqual(ch0.latest, 0.0)
+                    self.assertLessEqual(ch0.latest, 5.0)
+                    print(f"         D10 PWM (2.5 V duty) -> A0={ch0.latest:.3f} V")
+                    if not LOOPBACK_WIRED:
+                        self.skipTest("LOOPBACK_WIRED=False; structural check only")
+                finally:
+                    daq.stop()
+                    daq.write_analog_value(AO_ALIAS, 0.0)
+            finally:
+                daq.close()
+
+        self._run_step(
+            "Analog loopback",
+            "Write 2.5 V (50% duty) to D10, verify A0 reads a finite value in [0, 5] V. "
+            "No tight tolerance: PWM loopback without filtering returns an instantaneous sample.",
+            step,
+        )
+
+    # =====================================================================
+    # 5. Digital line loopback — D2 out → D3 in
+    # =====================================================================
+    def test_05_digital_line_loopback(self) -> None:
+        """Drive D2 and verify D3 reads back the same state."""
+
+        def step() -> None:
+            daq = self._create_daq()
+            try:
+                self._configure_digital_lines(daq)
+                errs = []
+                for state in (0, 1, 0, 1, 0):
+                    daq.write_digital_line(DO_ALIAS, state)
+                    time.sleep(0.05)
+                    read = int(daq.read_digital_line(DI_ALIAS).latest)
+                    flag = "" if (not LOOPBACK_WIRED or read == state) else "  <-- mismatch"
+                    print(f"         D2<-{state} | D3={read}{flag}")
+                    if LOOPBACK_WIRED and read != state:
+                        errs.append(f"drove D2={state}, read D3={read}")
+                daq.write_digital_line(DO_ALIAS, 0)
+                self.assertFalse(errs, "; ".join(errs))
+            finally:
+                daq.write_digital_line(DO_ALIAS, 0)
+                daq.close()
+
+        self._run_step(
+            "Digital line loopback",
+            "Drive D2 through a 0/1 sequence and verify D3 reads back the same state "
+            "(requires D2→D3 loopback wire when LOOPBACK_WIRED=True).",
+            step,
+        )
+
+    # =====================================================================
+    # 6. Sampling rate change
+    # =====================================================================
+    def test_06_sampling_rate_change(self) -> None:
+        """Change the sampling rate mid-run and verify data still arrives."""
+
+        def step() -> None:
+            daq = self._create_daq()
+            try:
+                self._configure_ai(daq)
+                daq.start()
+                try:
+                    time.sleep(0.3)
+                    ch = daq.get_channel(f"{NAME}.{AI_ALIAS_0}", 1, wait_for_latest=True)
+                    self.assertTrue(math.isfinite(ch.latest))
+                    print(f"         before rate change: A0={ch.latest:.3f} V")
+
+                    daq.driver.set_sampling_rate(50.0)
+                    time.sleep(0.5)
+
+                    ch = daq.get_channel(f"{NAME}.{AI_ALIAS_0}", 1, wait_for_latest=True)
+                    self.assertTrue(math.isfinite(ch.latest))
+                    print(f"         after rate change to 50 Hz: A0={ch.latest:.3f} V")
+                finally:
+                    daq.stop()
+            finally:
+                daq.close()
+
+        self._run_step(
+            "Sampling rate change",
+            f"Start at {SAMPLE_RATE_HZ} Hz, change to 50 Hz via set_sampling_rate(), and verify A0 data still arrives.",
+            step,
+        )
+
+    # =====================================================================
+    # 7. Buffer-depth telemetry
+    # =====================================================================
+    def test_07_buffer_depth_telemetry(self) -> None:
+        """Verify get_points_in_buffer reports a valid depth during acquisition."""
+
+        def step() -> None:
+            daq = self._create_daq()
+            try:
+                self._configure_ai(daq)
+                daq.start()
+                try:
+                    time.sleep(0.5)
+                    depth = daq.get_points_in_buffer().latest
+                    print(f"         points_in_buffer = {depth}")
+                    self.assertTrue(math.isfinite(depth) and depth >= 0, f"invalid buffer depth: {depth}")
+                finally:
+                    daq.stop()
+            finally:
+                daq.close()
+
+        self._run_step(
+            "Buffer-depth telemetry",
+            "Run the background daemon and verify get_points_in_buffer() reports a finite, non-negative value.",
+            step,
+        )
+
+    # =====================================================================
+    # 8. Clean shutdown — outputs to safe state
+    # =====================================================================
+    def test_08_clean_shutdown(self) -> None:
+        """Set all outputs to safe state."""
+
+        def step() -> None:
+            daq = self._create_daq()
+            try:
+                self._configure_ao(daq)
+                self._configure_digital_lines(daq)
+                daq.write_analog_value(AO_ALIAS, 0.0)
+                daq.write_digital_line(DO_ALIAS, 0)
+            finally:
+                daq.close()
+
+        self._run_step(
+            "Clean shutdown — safe state",
+            "Set D10 to 0 V (PWM off) and D2 to 0 as a final safety step.",
+            step,
+        )
+
+    # =====================================================================
+    # 9. Methods not implemented — reported as skipped
+    # =====================================================================
+    def test_09_hw_timing_unsupported(self) -> None:
+        """configure_ai_hw_timing raises NotImplementedError on ArduinoFirmata."""
+        self.skipTest("ArduinoFirmata has no hardware-timed buffered acquisition")
+
+    def test_10_port_width_digital_unsupported(self) -> None:
+        """write_digital_port / read_digital_port raise NotImplementedError."""
+        self.skipTest("ArduinoFirmata does not support port-mode digital I/O")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/daq/arduino/test_arduino_firmata_hardware.py
+++ b/tests/daq/arduino/test_arduino_firmata_hardware.py
@@ -183,7 +183,12 @@ class TestArduinoFirmataHardware(unittest.TestCase):
         """Poll read_digital_line until it matches expected or timeout expires. Returns the last read value."""
         deadline = time.time() + timeout
         while time.time() < deadline:
-            read = int(daq.read_digital_line(alias).latest)
+            try:
+                read = int(daq.read_digital_line(alias).latest)
+            except RuntimeError:
+                # No Firmata report has arrived yet for this channel; keep polling.
+                time.sleep(0.01)
+                continue
             if read == expected:
                 return read
             time.sleep(0.01)

--- a/tests/daq/arduino/test_arduino_firmata_hardware.py
+++ b/tests/daq/arduino/test_arduino_firmata_hardware.py
@@ -56,6 +56,7 @@ from instro.daq import InstroDAQ
 from instro.daq.drivers.arduino_firmata import ArduinoFirmata
 from instro.daq.types import Direction, Logic
 from instro.lib.publishers import NominalCorePublisher
+from instro.lib.types import Measurement
 
 # ---------------------------------------------------------------------------
 # Configuration — edit before running
@@ -178,6 +179,16 @@ class TestArduinoFirmataHardware(unittest.TestCase):
 
     # -- helpers ----------------------------------------------------------
 
+    def _wait_for_digital(self, daq: InstroDAQ, alias: str, expected: int, timeout: float = 2.0) -> int:
+        """Poll read_digital_line until it matches expected or timeout expires. Returns the last read value."""
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            read = int(daq.read_digital_line(alias).latest)
+            if read == expected:
+                return read
+            time.sleep(0.01)
+        return int(daq.read_digital_line(alias).latest)
+
     def _create_daq(self) -> InstroDAQ:
         daq = InstroDAQ(
             name=NAME,
@@ -267,8 +278,8 @@ class TestArduinoFirmataHardware(unittest.TestCase):
                 daq.start()
                 try:
                     time.sleep(0.5)
-                    ch0 = daq.get_channel(f"{NAME}.{AI_ALIAS_0}", 1, wait_for_latest=True)
-                    ch1 = daq.get_channel(f"{NAME}.{AI_ALIAS_1}", 1, wait_for_latest=False)
+                    ch0 = daq.get_channel(f"{NAME}.{AI_ALIAS_0}", 1, wait_for_new_samples=True)
+                    ch1 = daq.get_channel(f"{NAME}.{AI_ALIAS_1}", 1, wait_for_new_samples=False)
                     self.assertIsNotNone(ch0)
                     self.assertIsNotNone(ch1)
                     self.assertTrue(math.isfinite(ch0.latest), f"non-finite A0 read: {ch0.latest}")
@@ -325,7 +336,7 @@ class TestArduinoFirmataHardware(unittest.TestCase):
                 daq.start()
                 try:
                     time.sleep(0.5)
-                    ch0 = daq.get_channel(f"{NAME}.{AI_ALIAS_0}", 1, wait_for_latest=True)
+                    ch0 = daq.get_channel(f"{NAME}.{AI_ALIAS_0}", 1, wait_for_new_samples=True)
                     self.assertTrue(math.isfinite(ch0.latest), f"non-finite loopback read: {ch0.latest}")
                     self.assertGreaterEqual(ch0.latest, 0.0)
                     self.assertLessEqual(ch0.latest, 5.0)
@@ -356,9 +367,15 @@ class TestArduinoFirmataHardware(unittest.TestCase):
             try:
                 self._configure_digital_lines(daq)
                 errs = []
-                for state in (0, 1, 0, 1, 0):
+                for state in (
+                    0,
+                    1,
+                    0,
+                    1,
+                    0,
+                ):
                     daq.write_digital_line(DO_ALIAS, state)
-                    time.sleep(0.05)
+                    time.sleep(0.15)
                     read = int(daq.read_digital_line(DI_ALIAS).latest)
                     flag = "" if (not LOOPBACK_WIRED or read == state) else "  <-- mismatch"
                     print(f"         D2<-{state} | D3={read}{flag}")
@@ -390,14 +407,14 @@ class TestArduinoFirmataHardware(unittest.TestCase):
                 daq.start()
                 try:
                     time.sleep(0.3)
-                    ch = daq.get_channel(f"{NAME}.{AI_ALIAS_0}", 1, wait_for_latest=True)
+                    ch = daq.get_channel(f"{NAME}.{AI_ALIAS_0}", 1, wait_for_new_samples=True)
                     self.assertTrue(math.isfinite(ch.latest))
                     print(f"         before rate change: A0={ch.latest:.3f} V")
 
                     daq.driver.set_sampling_rate(50.0)
                     time.sleep(0.5)
 
-                    ch = daq.get_channel(f"{NAME}.{AI_ALIAS_0}", 1, wait_for_latest=True)
+                    ch = daq.get_channel(f"{NAME}.{AI_ALIAS_0}", 1, wait_for_new_samples=True)
                     self.assertTrue(math.isfinite(ch.latest))
                     print(f"         after rate change to 50 Hz: A0={ch.latest:.3f} V")
                 finally:
@@ -461,13 +478,112 @@ class TestArduinoFirmataHardware(unittest.TestCase):
         )
 
     # =====================================================================
-    # 9. Methods not implemented — reported as skipped
+    # 9. Analog input — software-timed (no daemon)
     # =====================================================================
-    def test_09_hw_timing_unsupported(self) -> None:
+    def test_09_analog_input_software_timed(self) -> None:
+        """Read A0 via software-timed read_analog() without starting the daemon."""
+
+        def step() -> None:
+            daq = self._create_daq()
+            try:
+                self._configure_ai(daq)
+                time.sleep(0.3)  # allow callbacks to populate _latest_values
+                result = daq.read_analog()
+                self.assertIsInstance(result, Measurement)
+                self.assertEqual(len(result.timestamps), 1)
+                voltage = result.channel_data[f"{NAME}.{AI_ALIAS_0}"][0]
+                self.assertTrue(math.isfinite(voltage), f"non-finite A0 read: {voltage}")
+                self.assertGreaterEqual(voltage, 0.0)
+                self.assertLessEqual(voltage, 5.0)
+                print(f"         A0 (software-timed)={voltage:.3f} V")
+            finally:
+                daq.close()
+
+        self._run_step(
+            "Analog input (software-timed)",
+            "Configure A0 and A1, wait for callbacks, and verify read_analog() returns a finite value without starting the daemon.",
+            step,
+        )
+
+    # =====================================================================
+    # 10. Analog input — start(background=False)
+    # =====================================================================
+    def test_10_analog_input_no_daemon(self) -> None:
+        """Read A0 via fetch_analog with start(background=False)."""
+
+        def step() -> None:
+            daq = self._create_daq()
+            try:
+                self._configure_ai(daq)
+                daq.start(background=False)
+                try:
+                    result = daq.read_analog()
+                    self.assertIsInstance(result, Measurement)
+                    voltage = result.channel_data[f"{NAME}.{AI_ALIAS_0}"][0]
+                    self.assertTrue(math.isfinite(voltage), f"non-finite A0 read: {voltage}")
+                    self.assertGreaterEqual(voltage, 0.0)
+                    self.assertLessEqual(voltage, 5.0)
+                    print(f"         A0 (no daemon)={voltage:.3f} V")
+                finally:
+                    daq.stop()
+            finally:
+                daq.close()
+
+        self._run_step(
+            "Analog input (no daemon)",
+            "Configure A0 and A1, start(background=False), and verify read_analog() returns a finite value via fetch_analog.",
+            step,
+        )
+
+    # =====================================================================
+    # 11. Digital write while daemon running
+    # =====================================================================
+    def test_11_digital_write_while_daemon_running(self) -> None:
+        """Drive D2 while the background analog daemon is active."""
+
+        def step() -> None:
+            daq = self._create_daq()
+            try:
+                self._configure_ai(daq)
+                self._configure_digital_lines(daq)
+                daq.start()
+                try:
+                    time.sleep(0.3)
+                    errs = []
+                    for state in (0, 1, 0, 1, 0):
+                        daq.write_digital_line(DO_ALIAS, state)
+                        time.sleep(0.15)
+                        read = self._wait_for_digital(daq, DI_ALIAS, state)
+                        flag = "" if (not LOOPBACK_WIRED or read == state) else "  <-- mismatch"
+                        print(f"         D2<-{state} | D3={read}{flag}")
+                        if LOOPBACK_WIRED and read != state:
+                            errs.append(f"drove D2={state}, read D3={read}")
+                    ch0 = daq.get_channel(f"{NAME}.{AI_ALIAS_0}", 1, wait_for_new_samples=True)
+                    self.assertTrue(math.isfinite(ch0.latest), f"analog stopped during digital writes: {ch0.latest}")
+                    print(f"         A0 during digital writes={ch0.latest:.3f} V")
+                    daq.write_digital_line(DO_ALIAS, 0)
+                    self.assertFalse(errs, "; ".join(errs))
+                finally:
+                    daq.stop()
+            finally:
+                daq.write_digital_line(DO_ALIAS, 0)
+                daq.close()
+
+        self._run_step(
+            "Digital write while daemon running",
+            "Start the background analog daemon, then drive D2 through a 0/1 sequence and verify "
+            "D3 reads back correctly and A0 analog data keeps flowing.",
+            step,
+        )
+
+    # =====================================================================
+    # 12. Methods not implemented — reported as skipped
+    # =====================================================================
+    def test_12_hw_timing_unsupported(self) -> None:
         """configure_ai_hw_timing raises NotImplementedError on ArduinoFirmata."""
         self.skipTest("ArduinoFirmata has no hardware-timed buffered acquisition")
 
-    def test_10_port_width_digital_unsupported(self) -> None:
+    def test_13_port_width_digital_unsupported(self) -> None:
         """write_digital_port / read_digital_port raise NotImplementedError."""
         self.skipTest("ArduinoFirmata does not support port-mode digital I/O")
 

--- a/tests/daq/test_arduino_firmata.py
+++ b/tests/daq/test_arduino_firmata.py
@@ -117,3 +117,16 @@ def test_close(arduino_driver, mock_board):
 def test_configure_ai_hw_timing_raises(arduino_driver):
     with pytest.raises(NotImplementedError):
         arduino_driver.configure_ai_hw_timing(hw_timing_config=HWTimingConfig(30.0, 1, 40))
+
+
+def test_set_sampling_rate_before_open():
+    driver = ArduinoFirmata("/dev/ttyACM0")
+    driver.set_sampling_rate(100)
+    assert driver._sampling_interval_ms == 10
+    assert driver._board is None
+
+
+def test_set_sampling_rate_after_open_calls_board(arduino_driver, mock_board):
+    arduino_driver.set_sampling_rate(50)
+    assert arduino_driver._sampling_interval_ms == 20
+    mock_board.setSamplingInterval.assert_called_with(20)

--- a/tests/daq/test_arduino_firmata.py
+++ b/tests/daq/test_arduino_firmata.py
@@ -1,0 +1,119 @@
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from instro.daq.drivers.arduino_firmata import ArduinoFirmata
+from instro.daq.types import AnalogChannel, Direction, HWTimingConfig, Logic
+
+
+@pytest.fixture
+def mock_board():
+    return MagicMock()
+
+
+@pytest.fixture
+def arduino_driver(mock_board):
+    mock_pyfirmata2 = MagicMock()
+    mock_pyfirmata2.Arduino.return_value = mock_board
+    with patch.dict(sys.modules, {"pyfirmata2": mock_pyfirmata2}):
+        driver = ArduinoFirmata("/dev/ttyACM0")
+        with patch("time.sleep"):
+            driver.open()
+        yield driver
+
+
+def test_configure_ai_channel(arduino_driver, mock_board):
+    channel = AnalogChannel(
+        physical_channel="A0",
+        alias="voltage",
+        direction=Direction.INPUT,
+        range_min=0.0,
+        range_max=5.0,
+        scaler=None,
+    )
+    arduino_driver.configure_ai_channel(channel)
+
+    mock_board.get_pin.assert_called_once_with("a:0:i")
+    assert arduino_driver._ai_channels["voltage"] == channel
+
+
+def test_read_analog_input(arduino_driver, mock_board):
+    channel = AnalogChannel(
+        physical_channel="A0",
+        alias="voltage",
+        direction=Direction.INPUT,
+        range_min=0.0,
+        range_max=5.0,
+        scaler=None,
+    )
+    arduino_driver.configure_ai_channel(channel)
+    mock_pin = mock_board.get_pin.return_value
+
+    # get the registered callback
+    callback = mock_pin.register_callback.call_args[0][0]
+    callback(0.5)
+    result = arduino_driver.read_analog()
+    assert result == {"voltage": 0.5}
+
+
+def test_read_analog_input_none(arduino_driver, mock_board):
+    channel = AnalogChannel(
+        physical_channel="A0",
+        alias="voltage",
+        direction=Direction.INPUT,
+        range_min=0.0,
+        range_max=5.0,
+        scaler=None,
+    )
+    arduino_driver.configure_ai_channel(channel)
+    mock_pin = mock_board.get_pin.return_value
+
+    # get the registered callback
+    callback = mock_pin.register_callback.call_args[0][0]
+    callback(None)
+    result = arduino_driver.read_analog()
+    assert result == {"voltage": 0.0}
+
+
+def test_write_digital_line(arduino_driver, mock_board):
+    arduino_driver.configure_do_line_channel(
+        physical_channel="D13",
+        logic=Logic.HIGH,
+        alias="led",
+    )
+    channel = arduino_driver._do_channels["led"]
+    mock_pin = mock_board.get_pin.return_value
+
+    arduino_driver.write_digital_line(channel, 1)
+    mock_pin.write.assert_called_once_with(1)
+
+
+def test_read_digital_line(arduino_driver, mock_board):
+    arduino_driver.configure_di_line_channel(
+        physical_channel="D13",
+        logic=Logic.HIGH,
+        alias="button",
+    )
+
+    # get callback registered on pin
+    mock_pin = mock_board.get_pin.return_value
+    callback = mock_pin.register_callback.call_args[0][0]
+
+    # sim pyfirmata2 pushing a value
+    callback(1)
+
+    channel = arduino_driver._di_channels["button"]
+    result = arduino_driver.read_digital_line(channel)
+    assert result == 1
+
+
+def test_close(arduino_driver, mock_board):
+    arduino_driver.close()
+    mock_board.exit.assert_called_once()
+    assert not arduino_driver._pins
+
+
+def test_configure_ai_hw_timing_raises(arduino_driver):
+    with pytest.raises(NotImplementedError):
+        arduino_driver.configure_ai_hw_timing(hw_timing_config=HWTimingConfig(30.0, 1, 40))

--- a/tests/daq/test_arduino_firmata.py
+++ b/tests/daq/test_arduino_firmata.py
@@ -83,6 +83,21 @@ def test_read_analog_input_none(arduino_driver, mock_board):
     assert values == {"voltage": 0.0}
 
 
+def test_read_analog_input_before_first_report_raises(arduino_driver, mock_board):
+    channel = AnalogChannel(
+        physical_channel="A0",
+        alias="voltage",
+        direction=Direction.INPUT,
+        range_min=0.0,
+        range_max=5.0,
+        scaler=None,
+    )
+    arduino_driver.configure_ai_channel(channel)
+
+    with pytest.raises(RuntimeError, match="voltage"):
+        arduino_driver.read_analog()
+
+
 def test_write_digital_line(arduino_driver, mock_board):
     arduino_driver.configure_do_line_channel(
         physical_channel="D13",
@@ -113,6 +128,18 @@ def test_read_digital_line(arduino_driver, mock_board):
     channel = arduino_driver._di_channels["button"]
     result = arduino_driver.read_digital_line(channel)
     assert result == 1
+
+
+def test_read_digital_line_before_first_report_raises(arduino_driver, mock_board):
+    arduino_driver.configure_di_line_channel(
+        physical_channel="D13",
+        logic=Logic.HIGH,
+        alias="button",
+    )
+    channel = arduino_driver._di_channels["button"]
+
+    with pytest.raises(RuntimeError, match="button"):
+        arduino_driver.read_digital_line(channel)
 
 
 def test_close(arduino_driver, mock_board):

--- a/tests/daq/test_arduino_firmata.py
+++ b/tests/daq/test_arduino_firmata.py
@@ -148,6 +148,43 @@ def test_close(arduino_driver, mock_board):
     assert not arduino_driver._pins
 
 
+def test_close_stops_iterator_thread(mock_board):
+    mock_pyfirmata2 = MagicMock()
+    mock_pyfirmata2.Arduino.return_value = mock_board
+    with patch.dict(sys.modules, {"pyfirmata2": mock_pyfirmata2}):
+        driver = ArduinoFirmata("/dev/ttyACM0")
+        with patch("time.sleep"):
+            driver.open()
+        mock_iterator = mock_pyfirmata2.util.Iterator.return_value
+
+        driver.close()
+
+        mock_iterator.stop.assert_called_once()
+        mock_iterator.join.assert_called_once_with(timeout=1.0)
+
+
+def test_close_resets_latest_values_so_reopen_starts_clean(arduino_driver, mock_board):
+    channel = AnalogChannel(
+        physical_channel="A0",
+        alias="voltage",
+        direction=Direction.INPUT,
+        range_min=0.0,
+        range_max=5.0,
+        scaler=None,
+    )
+    arduino_driver.configure_ai_channel(channel)
+    mock_pin = mock_board.get_pin.return_value
+    callback = mock_pin.register_callback.call_args[0][0]
+    callback(0.5)
+    arduino_driver.read_analog()  # sanity: data is present before close()
+
+    arduino_driver.close()
+
+    assert arduino_driver._latest_values == {}
+    with pytest.raises(RuntimeError):
+        arduino_driver.read_analog()
+
+
 def test_configure_ai_hw_timing_raises(arduino_driver):
     with pytest.raises(NotImplementedError):
         arduino_driver.configure_ai_hw_timing(hw_timing_config=HWTimingConfig(30.0, 1, 40))

--- a/tests/daq/test_arduino_firmata.py
+++ b/tests/daq/test_arduino_firmata.py
@@ -5,6 +5,7 @@ import pytest
 
 from instro.daq.drivers.arduino_firmata import ArduinoFirmata
 from instro.daq.types import AnalogChannel, Direction, HWTimingConfig, Logic
+from instro.lib.types import Measurement
 
 
 @pytest.fixture
@@ -54,7 +55,10 @@ def test_read_analog_input(arduino_driver, mock_board):
     callback = mock_pin.register_callback.call_args[0][0]
     callback(0.5)
     result = arduino_driver.read_analog()
-    assert result == {"voltage": 0.5}
+    assert len(result) == 1
+    timestamp, values = result[0]
+    assert isinstance(timestamp, int)
+    assert values == {"voltage": 0.5}
 
 
 def test_read_analog_input_none(arduino_driver, mock_board):
@@ -73,7 +77,10 @@ def test_read_analog_input_none(arduino_driver, mock_board):
     callback = mock_pin.register_callback.call_args[0][0]
     callback(None)
     result = arduino_driver.read_analog()
-    assert result == {"voltage": 0.0}
+    assert len(result) == 1
+    timestamp, values = result[0]
+    assert isinstance(timestamp, int)
+    assert values == {"voltage": 0.0}
 
 
 def test_write_digital_line(arduino_driver, mock_board):
@@ -130,3 +137,102 @@ def test_set_sampling_rate_after_open_calls_board(arduino_driver, mock_board):
     arduino_driver.set_sampling_rate(50)
     assert arduino_driver._sampling_interval_ms == 20
     mock_board.setSamplingInterval.assert_called_with(20)
+
+
+# ---------------------------------------------------------------------------
+# _read_to_measurements
+# ---------------------------------------------------------------------------
+
+_VOLTAGE_CHANNEL = AnalogChannel(
+    physical_channel="A0",
+    alias="voltage",
+    direction=Direction.INPUT,
+    range_min=0.0,
+    range_max=5.0,
+    scaler=None,
+)
+
+
+def test_read_to_measurements_single_point(arduino_driver):
+    response = [(1_000_000, {"voltage": 0.5})]
+    result = arduino_driver._read_to_measurements(
+        response=response,
+        channel_list={"voltage": _VOLTAGE_CHANNEL},
+        daq_name="arduino",
+        default_tags={},
+    )
+    assert len(result) == 1
+    m = result[0]
+    assert m.timestamps == [1_000_000]
+    assert len(m.channel_data["arduino.voltage"]) == 1
+    assert abs(m.channel_data["arduino.voltage"][0] - 2.5) < 0.001  # 0.5 * 5.0V
+
+
+def test_read_to_measurements_multi_point(arduino_driver):
+    response = [(1000, {"voltage": 0.0}), (2000, {"voltage": 0.5}), (3000, {"voltage": 1.0})]
+    result = arduino_driver._read_to_measurements(
+        response=response,
+        channel_list={"voltage": _VOLTAGE_CHANNEL},
+        daq_name="arduino",
+        default_tags={},
+    )
+    assert len(result) == 1
+    m = result[0]
+    assert m.timestamps == [1000, 2000, 3000]
+    assert len(m.channel_data["arduino.voltage"]) == 3
+    assert abs(m.channel_data["arduino.voltage"][0] - 0.0) < 0.001
+    assert abs(m.channel_data["arduino.voltage"][1] - 2.5) < 0.001
+    assert abs(m.channel_data["arduino.voltage"][2] - 5.0) < 0.001
+
+
+# ---------------------------------------------------------------------------
+# InstroDAQ analog read routing
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def daq(arduino_driver):
+    from instro.daq import InstroDAQ
+
+    d = InstroDAQ(name="arduino", driver=arduino_driver)
+    d._is_open = True
+    return d
+
+
+def test_daq_read_analog_no_start(daq, arduino_driver):
+    """No start(): routes to _software_timed_read -> driver.read_analog() -> one Measurement."""
+    daq.configure_analog_channel(
+        direction=Direction.INPUT, physical_channel="A0", alias="voltage", range_min=0.0, range_max=5.0
+    )
+    arduino_driver._on_analog_callback("voltage", 0.6)
+    result = daq.read_analog()
+    assert isinstance(result, Measurement)
+    assert len(result.timestamps) == 1
+    assert abs(result.channel_data["arduino.voltage"][0] - 3.0) < 0.001  # 0.6 * 5.0V
+
+
+def test_daq_read_analog_daemon_running_raises(daq, arduino_driver):
+    """Daemon running: read_analog() raises RuntimeError."""
+    daq.configure_analog_channel(
+        direction=Direction.INPUT, physical_channel="A0", alias="voltage", range_min=0.0, range_max=5.0
+    )
+    arduino_driver._ai_hw_timing_config = HWTimingConfig(
+        sample_rate=100.0, sample_period=10_000_000, samples_per_channel=1
+    )
+    daq._background_thread = MagicMock()
+    daq._background_thread.is_alive.return_value = True
+    with pytest.raises(RuntimeError, match="background acquisition daemon"):
+        daq.read_analog()
+
+
+def test_daq_read_analog_start_no_background(daq, arduino_driver):
+    """start(background=False): routes to _fetch_analog -> driver.fetch_analog() -> one Measurement."""
+    daq.configure_analog_channel(
+        direction=Direction.INPUT, physical_channel="A0", alias="voltage", range_min=0.0, range_max=5.0
+    )
+    daq.start(background=False)
+    arduino_driver._on_analog_callback("voltage", 0.4)  # populates queue now that _expected_ai_channels is set
+    result = daq.read_analog()
+    assert isinstance(result, Measurement)
+    assert len(result.timestamps) == 1
+    assert abs(result.channel_data["arduino.voltage"][0] - 2.0) < 0.001  # 0.4 * 5.0V

--- a/uv.lock
+++ b/uv.lock
@@ -362,7 +362,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -554,6 +554,10 @@ all = [
     { name = "instro-ethernetip" },
     { name = "instro-i2c-aardvark" },
     { name = "instro-unstable" },
+    { name = "pyfirmata2" },
+]
+arduino = [
+    { name = "pyfirmata2" },
 ]
 contrib = [
     { name = "instro-contrib" },
@@ -625,6 +629,8 @@ requires-dist = [
     { name = "instro-unstable", marker = "extra == 'unstable'", editable = "packages/instro-unstable" },
     { name = "nominal", specifier = ">=1.99.0,<2.0.0" },
     { name = "pydantic", specifier = ">=2.0" },
+    { name = "pyfirmata2", marker = "extra == 'all'" },
+    { name = "pyfirmata2", marker = "extra == 'arduino'" },
     { name = "pymodbus", specifier = ">=3.10,<3.13" },
     { name = "pyserial", specifier = ">=3.5" },
     { name = "pyvisa", specifier = ">=1.15" },
@@ -633,7 +639,7 @@ requires-dist = [
     { name = "thermocouples", specifier = ">=2.1.2" },
     { name = "typer", specifier = ">=0.12" },
 ]
-provides-extras = ["daq", "labjack", "nidaq", "mccdaq", "i2c", "aardvark", "ethernetip", "contrib", "unstable", "all"]
+provides-extras = ["daq", "labjack", "nidaq", "mccdaq", "i2c", "aardvark", "ethernetip", "contrib", "unstable", "arduino", "all"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -1707,6 +1713,18 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/92/61/edbf7aea71052d410347846a2ea43394f74651bf6822b8fad8703ca00575/pydantic_core-2.46.0-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:909a7327b83ca93b372f7d48df0ebc7a975a5191eb0b6e024f503f4902c24124", size = 2327716, upload-time = "2026-04-13T09:06:31.681Z" },
     { url = "https://files.pythonhosted.org/packages/a4/11/aa5089b941e85294b1d5d526840b18f0d4464f842d43d8999ce50ef881c1/pydantic_core-2.46.0-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:2f7e6a3752378a69fadf3f5ee8bc5fa082f623703eec0f4e854b12c548322de0", size = 2365925, upload-time = "2026-04-13T09:05:38.338Z" },
     { url = "https://files.pythonhosted.org/packages/0c/75/e187b0ea247f71f2009d156df88b7d8449c52a38810c9a1bd55dd4871206/pydantic_core-2.46.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:ef47ee0a3ac4c2bb25a083b3acafb171f65be4a0ac1e84edef79dd0016e25eaa", size = 2193856, upload-time = "2026-04-13T09:05:03.114Z" },
+]
+
+[[package]]
+name = "pyfirmata2"
+version = "2.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyserial" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/16/60f33d9b37dccffeeabdc46c4ea751ddeb585fc72ac47243eecfdf718079/pyFirmata2-2.5.1.tar.gz", hash = "sha256:5ef8fc5caec084e72c6b7f199362a743854c9bd63a93cacbaa0c7bbb99efef75", size = 15523, upload-time = "2024-11-27T08:15:25.179Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/3b/fca22decea624feffb82f5feb3e898a167b0b0e9f93614faec86a2a13e66/pyFirmata2-2.5.1-py3-none-any.whl", hash = "sha256:0b5479b152afb6902b5c7c458d4fd496957776db98287e4b317c21269ebe908e", size = 14640, upload-time = "2024-11-27T08:15:09.752Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes INSTRO-324. Fixes #49 

## Summary
- Adds ArduinoFirmata driver implementing DAQDriverBase via pyfirmata2 
- Supports analog input/pwm output, digital input/output
- Uses callback-based value streaming (pyfirmata2 does not support polling); daemon supported through callback-populated queue
- Hardware-timed acquisition not supported; 
- Sampling rate capped at 1000Hz (Firmata wire format limit)
- Adds 'arduino' optional extra to pyproject.toml

## Test plan
- [x] Manually validated on Mac, Linux, and Windows with real Arduino hardware