### PR TITLE
chore(contrib): publish instro-contrib to PyPI

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -58,6 +58,10 @@
     "packages/instro-ethernetip-python": {
       "release-type": "python",
       "component": "instro-ethernetip-python"
+    },
+    "packages/instro-contrib": {
+      "release-type": "python",
+      "component": "instro-contrib"
     }
   },
   "groups": [
@@ -70,7 +74,8 @@
         "packages/instro-daq-ni",
         "packages/instro-i2c-aardvark",
         "packages/instro-unstable",
-        "packages/instro-ethernetip-python"
+        "packages/instro-ethernetip-python",
+        "packages/instro-contrib"
       ]
     }
   ]

--- a/.github/release-please-manifest.json
+++ b/.github/release-please-manifest.json
@@ -5,5 +5,6 @@
   "packages/instro-daq-ni": "0.7.0",
   "packages/instro-i2c-aardvark": "0.2.0",
   "packages/instro-unstable": "0.0.1",
-  "packages/instro-ethernetip-python": "0.1.0"
+  "packages/instro-ethernetip-python": "0.1.0",
+  "packages/instro-contrib": "0.1.0"
 }

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -117,7 +117,7 @@ If you're contributing a driver for a device the maintainers don't own, **start 
 
 The `instro-contrib` package (`packages/instro-contrib/`) hosts drivers the maintainers cannot verify directly against the device. Hardware verification is done by the contributor, not by the maintainers.
 
-The package is not yet published as its own distribution. A release flow will be wired up alongside `instro`'s PyPI publication. For now, consumers depend on the workspace member directly.
+The package is published to PyPI as `instro-contrib`, released alongside `instro` through the shared release-please flow.
 
 The bar is deliberately lower than core's because the maintainers can't independently test these drivers, but every contribution still passes review.
 

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ uv sync --extra all
 
 This creates a virtual environment with the core library, all optional vendor drivers, and dev dependencies. Run with `uv run python your_script.py` or activate via `source .venv/bin/activate` (Unix) / `.venv\Scripts\activate` (Windows).
 
-### Optional vendor extras
+### Optional extras
 
-Native-SDK drivers ship as separate workspace packages so the heavy dependencies stay optional. Install only what you need:
+Native-SDK drivers ship as separate workspace packages so the heavy dependencies stay optional, and community-contributed drivers ship in their own package. Install only what you need:
 
 | Extra | Pulls in |
 |---|---|
@@ -33,6 +33,7 @@ Native-SDK drivers ship as separate workspace packages so the heavy dependencies
 | `instro[mccdaq]` | MCC UL (Windows-only) |
 | `instro[daq]` | All three DAQ vendor SDKs |
 | `instro[aardvark]` | Total Phase Aardvark (I2C); alias: `instro[i2c]` |
+| `instro[contrib]` | Community-contributed drivers for devices the maintainers can't verify directly |
 | `instro[all]` | Everything above |
 
 ## Quickstart
@@ -72,7 +73,7 @@ For the full walkthrough (including publishing to Nominal Core and the backgroun
 | I2C | `I2CInterface` | Total Phase Aardvark |
 | Modbus | `ModbusDevice` | Any Modbus TCP / RTU device |
 
-Don't see your vendor? Drivers the maintainers can't verify directly against the device land in [`instro-contrib`](./packages/instro-contrib/) on contributor verification. See [`CONTRIBUTING.md`](./CONTRIBUTING.md) for the bar.
+Don't see your vendor? Drivers the maintainers can't verify directly against the device land in [`instro-contrib`](./packages/instro-contrib/) on contributor verification — install them with `instro[contrib]`. See [`CONTRIBUTING.md`](./CONTRIBUTING.md) for the bar.
 
 ## Experimental modules
 

--- a/docs/guides/instrumentation/installation.mdx
+++ b/docs/guides/instrumentation/installation.mdx
@@ -52,6 +52,9 @@ or with pip:
  - To install the TotalPhase Aardvark package, use `aardvark`.
  - To install all the aforementioned i2c packages, use `i2c`.
 
+### Community-contributed drivers
+ - To install community-contributed drivers for devices the maintainers can't verify directly, use `contrib`.
+
 ### Unstable modules
  - To install experimental modules, add `instro-unstable` as a separate package.
  - To install EtherNet/IP support, use `instro-unstable[ethernetip]`.

--- a/packages/instro-contrib/README.md
+++ b/packages/instro-contrib/README.md
@@ -1,0 +1,33 @@
+# instro-contrib
+
+Community-contributed drivers for [`instro`](https://github.com/nominal-io/instro).
+
+This package hosts drivers for devices the `instro` maintainers don't own and can't verify directly. Hardware verification is done by the contributor, so the support bar is lower than core's — but every driver still passes type checking, lint, and a mocked-transport unit test under review. The `contrib` namespace travels with every import as the disclaimer.
+
+## Installation
+
+```bash
+pip install 'instro[contrib]'   # with the instro core
+pip install instro-contrib       # standalone
+```
+
+## Usage
+
+Contrib drivers mirror the core `instro` layout with `contrib` inserted after the top-level package name, and run behind the same category HALs (`InstroPSU`, `InstroDMM`, …):
+
+```python
+from instro.psu import InstroPSU
+from instro.contrib.psu.drivers import SiglentSPDxxx
+
+psu = InstroPSU(name="bench", driver=SiglentSPDxxx("TCPIP::192.168.1.10::INSTR"), num_channels=1)
+```
+
+API stability is not guaranteed release-to-release; pin to a specific version if you need reproducibility.
+
+## Contributing
+
+New drivers are welcome. See [CONTRIBUTING.md](https://github.com/nominal-io/instro/blob/main/CONTRIBUTING.md#instro-contrib-community-contributed-drivers) for the contribution bar and layout.
+
+## License
+
+[Apache License 2.0](./LICENSE).

--- a/packages/instro-contrib/pyproject.toml
+++ b/packages/instro-contrib/pyproject.toml
@@ -1,13 +1,19 @@
 [project]
 name = "instro-contrib"
-version = "0.0.1"
-description = "Community-contributed drivers for instro, accepted on contributor testing where Nominal cannot verify against the device"
+version = "0.1.0"
+description = "Community-contributed instro drivers for devices the maintainers can't verify directly"
+readme = "README.md"
 license = "Apache-2.0"
 license-files = ["LICENSE"]
 requires-python = ">=3.10,<3.14"
 dependencies = [
     "instro",
 ]
+
+[project.urls]
+Homepage = "https://github.com/nominal-io/instro"
+Repository = "https://github.com/nominal-io/instro"
+Issues = "https://github.com/nominal-io/instro/issues"
 
 [build-system]
 requires = ["hatchling"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,11 +31,13 @@ nidaq = ["instro-daq-ni"]
 mccdaq = ["instro-daq-mcc"]
 i2c = ["instro-i2c-aardvark"]
 aardvark = ["instro-i2c-aardvark"]
+contrib = ["instro-contrib"]
 all = [
     "instro-daq-ni",
     "instro-daq-labjack",
     "instro-daq-mcc",
     "instro-i2c-aardvark",
+    "instro-contrib",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -484,10 +484,14 @@ aardvark = [
     { name = "instro-i2c-aardvark" },
 ]
 all = [
+    { name = "instro-contrib" },
     { name = "instro-daq-labjack" },
     { name = "instro-daq-mcc" },
     { name = "instro-daq-ni" },
     { name = "instro-i2c-aardvark" },
+]
+contrib = [
+    { name = "instro-contrib" },
 ]
 daq = [
     { name = "instro-daq-labjack" },
@@ -528,6 +532,8 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "fastavro", extras = ["snappy"], specifier = ">=1.12.1" },
+    { name = "instro-contrib", marker = "extra == 'all'", editable = "packages/instro-contrib" },
+    { name = "instro-contrib", marker = "extra == 'contrib'", editable = "packages/instro-contrib" },
     { name = "instro-daq-labjack", marker = "extra == 'all'", editable = "packages/instro-daq-labjack" },
     { name = "instro-daq-labjack", marker = "extra == 'daq'", editable = "packages/instro-daq-labjack" },
     { name = "instro-daq-labjack", marker = "extra == 'labjack'", editable = "packages/instro-daq-labjack" },
@@ -549,7 +555,7 @@ requires-dist = [
     { name = "textual", specifier = ">=0.80" },
     { name = "thermocouples", specifier = ">=2.1.2" },
 ]
-provides-extras = ["daq", "labjack", "nidaq", "mccdaq", "i2c", "aardvark", "all"]
+provides-extras = ["daq", "labjack", "nidaq", "mccdaq", "i2c", "aardvark", "contrib", "all"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -571,7 +577,7 @@ test = [
 
 [[package]]
 name = "instro-contrib"
-version = "0.0.1"
+version = "0.1.0"
 source = { editable = "packages/instro-contrib" }
 dependencies = [
     { name = "instro" },


### PR DESCRIPTION
## What

Wires `instro-contrib` into the shared release-please publish flow so it ships to PyPI alongside `instro`, exposes it as the `instro[contrib]` extra, and adds the README + metadata needed for a clean package page. Launches at `0.1.0`.

`instro-contrib` was the only workspace package absent from the release automation — it existed only as a workspace dev dependency and never reached PyPI.

## Changes

- **`.github/release-please-config.json` / `-manifest.json`** — register `instro-contrib` (component + unified `instro` group) at `0.1.0`.
- **`packages/instro-contrib/pyproject.toml`** — version `0.1.0`, add `readme`, tighten `description`, add `[project.urls]`.
- **`packages/instro-contrib/README.md`** — new; PyPI long description with install + usage.
- **`pyproject.toml`** (root) — add `contrib = ["instro-contrib"]` extra and include it in `all`. Kept in the `dev` group so CI's plain `uv sync` still installs it for the contrib smoke test.
- **`CONTRIBUTING.md`** — drop the stale "not yet published" note.
- **`uv.lock`** — refreshed (`0.0.1 -> 0.1.0`).

No publish-workflow YAML change needed: the generic `publish-python` job derives the package name from each released path's `basename` and runs `uv build --package <name>`, so contrib is picked up automatically once release-please knows about it.

## Verification

- `just check` green (ruff format, mypy, ruff lint).
- `just test` contrib smoke tests pass (10 passed).
- `uv lock --check` passes; `uv build --package instro-contrib` produces `instro_contrib-0.1.0` with the README + summary in metadata.

Closes #118