### PR TITLE
docs: lead with instrument control, introduce Nominal publishing later

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ with InstroPSU(
     print(psu.get_voltage(channel=1))  # Measurement(channel_data={'my-psu.ch1.voltage': [3.31...]}, ...)
 ```
 
-For the full walkthrough (including publishing to Nominal Core and the background polling daemon), see the [official documentation](https://instro.nominal.io).
+That's the whole loop: construct, `open()`, configure, measure, `close()`. When you want to capture the data, attach a publisher to stream it to a file, a custom destination, or [Nominal](https://nominal.io). For the full walkthrough (including the background polling daemon and publishers), see the [official documentation](https://instro.nominal.io).
 
 ## Supported devices
 

--- a/docs/guides/index.mdx
+++ b/docs/guides/index.mdx
@@ -3,7 +3,7 @@ title: "instro"
 description: "A Python library for interfacing with hardware test equipment"
 ---
 
-`instro` is a Python library for scripting and automating test equipment, with first-class integration into [Nominal Core](https://nominal.io) and [Nominal Connect](https://nominal.io). Write your test once, swap vendors with a single configuration change, and stream data to Nominal automatically.
+`instro` is a Python library for scripting and automating test equipment (power supplies, multimeters, electronic loads, DAQs, and more) from one unified, typed API. Code against an instrument category once, then swap vendors with a single configuration change. When you want to capture the data, attach a publisher to stream it to a file, [Nominal](https://nominal.io), or a destination of your own.
 
 ## Start here
 
@@ -27,7 +27,7 @@ description: "A Python library for interfacing with hardware test equipment"
     icon="download"
     href="/instrumentation/installation"
   >
-    Install the library via Nominal Connect or directly from the private PyPI.
+    Install from PyPI with `pip` or `uv`, plus the optional vendor extras you need.
   </Card>
   <Card
     title="Examples"

--- a/docs/guides/instrumentation/overview.mdx
+++ b/docs/guides/instrumentation/overview.mdx
@@ -6,18 +6,18 @@ description: A Python library/framework for interfacing with hardware
 `instro` is a Python library with the following objectives:
 
 1. Accelerate the authoring of tests which rely on hardware instruments.
-2. Provide low-code integration with Nominal tools like Connect and Core.
+2. Provide abstractions that allow code reuse across various instrument models, so you can swap vendors without rewriting your test.
 3. Define entry points for creating instrument interfaces and drivers that integrate with the library.
-4. Provide abstractions that allow code reuse across various instrument models.
+4. When you want to capture the data, offer low-code publishing to a file, a custom destination, or Nominal tools like Connect and Core.
 
 It is a Python forward framework that should be accessible to engineers new to Python but
 also extensible and useable by engineers who are Python savvy.
 
 # Problem Space: Before and After
 
-## Before: DAQ to Nominal Core
+## Before: a different SDK for every vendor
 
-Here's what is required to read data from various DAQ devices and stream data to Nominal Core.
+Here's what's required to read analog data from two different DAQ vendors using their native SDKs. Each device has its own API, configuration sequence, and data-handling quirks, and the acquisition logic is tangled together with the code that ships the samples somewhere.
 
 <AccordionGroup>
     <Accordion title="LabJack T-Series Devices">
@@ -113,9 +113,9 @@ Here's what is required to read data from various DAQ devices and stream data to
 
 </AccordionGroup>
 
-## After: InstroDAQ
+## After: one API across vendors
 
-Here's the same workflow using `instro`'s `InstroDAQ`.
+Here's the same workflow using `instro`'s `InstroDAQ`. The acquisition code is identical across vendors: change the driver and the rest stays the same. Capturing the data is one optional line (`add_publisher(...)`); drop it and the same script just reads into your process.
 
 ```python
 from instro.daq.drivers.labjack import LabJackTSeriesDriver
@@ -155,16 +155,16 @@ daq.close()
 # Key Concepts of instro
 
 - **Code to an interface**, not the specific instrument in use.
-- **Automatic data publishing** to Nominal Core and Nominal Connect out of the box by way of a customizable `Publisher` interface.
-- **Configurable background daemons** read and expose measurements to your script and your publishers.
+- **Configurable background daemons** read and expose measurements to your script.
+- **Optional data publishing** to a file, a custom destination, or Nominal Core and Nominal Connect, by way of a customizable `Publisher` interface. Attach one when you want to capture data; skip it and `instro` is just an instrument-control library.
 
 ## Two ways to get data
 
-You can get measurements into your script in two ways. **Both options publish data** whenever a measurement is produced. The difference is who triggers the reads and how often.
+You can get measurements into your script in two ways. If a publisher is attached, **both options publish data** whenever a measurement is produced. The difference is who triggers the reads and how often.
 
 |              | Background acquisition | On-demand acquisition |
 | ------------ | ---------------------- | --------------------- |
-| **How**      | Call `start()`. A background daemon reads from the instrument at a fixed, configurable rate. Pull the latest N values with `get_channel()` when you need them. | Skip `start()`. Call read methods (`read_analog()`, `get_voltage()`, …) only when you want a measurement. Each call reads the device and publishes the result. |
+| **How**      | Call `start()`. A background daemon reads from the instrument at a fixed, configurable rate. Pull the latest N values with `get_channel()` when you need them. | Skip `start()`. Call read methods (`read_analog()`, `get_voltage()`, …) only when you want a measurement. Each call reads the device, and publishes the result if a publisher is attached. |
 | **Best for** | Apps where data should always be available and publishing. | Apps that need measurements only at specific times; lower system and bus load. DMMs are a good example. |
 
 <Note>


### PR DESCRIPTION
## What

Reframes the introductory surfaces so `instro`'s headline is the unified, typed instrument-control API across vendors, and publishing (file / custom / Nominal) is introduced afterward as an optional step.

## Why

The docs landing page and overview previously led with "first-class integration into Nominal Core and Nominal Connect." For someone who just wants to control an instrument, that reads as ceremony and possible lock-in before they see the core value. Publishing is a real strength but belongs after the instrument-control story.

## Changes

- **`docs/guides/index.mdx`**: open with the vendor-unification value prop; demote Nominal to one of several publish destinations. Fixed a stale install card ("via Nominal Connect or the private PyPI" → install from public PyPI).
- **`docs/guides/instrumentation/overview.mdx`**: reordered objectives (code-reuse up, Nominal down); re-headlined Before/After from "DAQ to Nominal Core" to "a different SDK for every vendor" / "one API across vendors"; made publishing optional in key concepts and "two ways to get data."
- **`README.md`**: softened the one Nominal-forward pointer so publishing reads as optional.

No links or nav entries changed.

## Out of scope

The publisher deep-dive page and per-category pages still reference Nominal as later-stage detail, which is appropriate. Can sweep those in a follow-up if wanted.

Closes #120