### PR TITLE
fix(ethernetip): rename published package

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -57,7 +57,7 @@
     },
     "packages/instro-ethernetip-python": {
       "release-type": "python",
-      "component": "instro-ethernetip-python"
+      "component": "instro-ethernetip"
     },
     "packages/instro-contrib": {
       "release-type": "python",

--- a/.github/workflows/release-please-publish.yml
+++ b/.github/workflows/release-please-publish.yml
@@ -115,9 +115,9 @@ jobs:
           from pathlib import Path
           import tarfile
 
-          sdists = list(Path("dist").glob("instro_ethernetip_python-*.tar.gz"))
+          sdists = list(Path("dist").glob("instro_ethernetip-*.tar.gz"))
           if not sdists:
-              raise SystemExit("No instro-ethernetip-python sdist found")
+              raise SystemExit("No instro-ethernetip sdist found")
 
           required = [
               "packages/instro-ethernetip-python/src/lib.rs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -229,7 +229,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "instro-ethernetip-python"
+name = "instro-ethernetip"
 version = "0.1.0"
 dependencies = [
  "instro-ethernetip-rs",

--- a/docs/guides/migration/v1.mdx
+++ b/docs/guides/migration/v1.mdx
@@ -41,7 +41,7 @@ Two classes intentionally **keep** the `Nominal` prefix because the prefix refer
 | `nominal-instro-daq-mcc`      | `instro-daq-mcc`      |
 | `nominal-instro-i2c-aardvark` | `instro-i2c-aardvark` |
 | `nominal-instro-unstable`     | `instro-unstable`     |
-| `nominal-instro-ethernetip-python` | `instro-ethernetip-python` |
+| `nominal-instro-ethernetip-python` | `instro-ethernetip` |
 
 Extras (`pip install nominal-instro[daq]`) keep the same extras names, just on the new package: `pip install instro[daq]`.
 

--- a/justfile
+++ b/justfile
@@ -99,9 +99,9 @@ eip-rs-test:
 # clean build of the unstable EtherNet/IP Python bindings (sdist + wheel)
 # uv selects the workspace package via --package, then uses that package's
 
-# [build-system] backend; for instro-ethernetip-python that backend is maturin.
+# [build-system] backend; for instro-ethernetip that backend is maturin.
 eip-build:
-    uv build --package instro-ethernetip-python
+    uv build --package instro-ethernetip
 
 # install the built wheel into an isolated environment and verify the private native module
 eip-wheel-smoke-test:
@@ -112,10 +112,10 @@ eip-wheel-smoke-test:
     trap 'rm -rf "$wheel_dir"' EXIT
     # Build the platform-specific native extension wheel. This wheel provides
     # instro.unstable._ethernetip, the private PyO3 module loaded at import time.
-    uv build --wheel --package instro-ethernetip-python --out-dir "$wheel_dir"
-    wheel="$(find "$wheel_dir" -maxdepth 1 -name 'instro_ethernetip_python-*.whl' -print -quit)"
+    uv build --wheel --package instro-ethernetip --out-dir "$wheel_dir"
+    wheel="$(find "$wheel_dir" -maxdepth 1 -name 'instro_ethernetip-*.whl' -print -quit)"
     if [ -z "$wheel" ]; then
-        echo "No instro-ethernetip-python wheel found in $wheel_dir" >&2
+        echo "No instro-ethernetip wheel found in $wheel_dir" >&2
         exit 1
     fi
     uv_run_args=(
@@ -130,4 +130,4 @@ eip-wheel-smoke-test:
 
 # Full EIP test suite: wheel smoke test, Rust/Python bindings, and cpppo integration
 eip-test: eip-wheel-smoke-test rust eip-rs-test
-    uv run --no-cache --reinstall-package instro-ethernetip-python --with-editable . pytest tests/test_ethernetip_bindings.py -q
+    uv run --no-cache --reinstall-package instro-ethernetip --with-editable . pytest tests/test_ethernetip_bindings.py -q

--- a/packages/instro-ethernetip-python/Cargo.toml
+++ b/packages/instro-ethernetip-python/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "instro-ethernetip-python"
+name = "instro-ethernetip"
 version = "0.1.0"
 edition = "2024"
 rust-version = "1.88.0"

--- a/packages/instro-ethernetip-python/README.md
+++ b/packages/instro-ethernetip-python/README.md
@@ -1,4 +1,4 @@
-# instro-ethernetip-python
+# instro-ethernetip
 
 Python binding layer for the Rust EtherNet/IP client.
 
@@ -7,7 +7,7 @@ This is surfaced through the workspace dev environment as the private native mod
 It exists separately from `instro-ethernetip-rs` on purpose:
 
 - `instro-ethernetip-rs` is the core Rust library and should stay usable from pure Rust code without pulling in PyO3 or Python packaging concerns.
-- `instro-ethernetip-python` is the optional Python-facing wrapper built with PyO3 and `maturin`.
+- `instro-ethernetip` is the optional Python-facing wrapper built with PyO3 and `maturin`.
 
 That split keeps the Rust crate focused on its transport and value API while allowing Python packaging, type stubs, and extension-module details to evolve independently.
 
@@ -64,7 +64,7 @@ When the PyO3 API changes, keep the Rust exports and `_ethernetip.pyi` in sync.
 
 ## Build, CI, and packaging
 
-`instro-ethernetip-python` is a PyO3 extension crate packaged by `maturin`.
+`instro-ethernetip` is a PyO3 extension crate packaged by `maturin`.
 
 - `pyo3` exposes Rust types and functions as Python classes in the private `instro.unstable._ethernetip` module
 - `maturin` drives the Python packaging step and turns the Rust crate into a Python wheel
@@ -94,8 +94,8 @@ EtherNet/IP support is exposed as the optional `ethernetip` extra on `instro-uns
 Bare `instro-unstable` installs remain pure Python, so other unstable modules can import
 without resolving a native wheel.
 
-- `instro-unstable[ethernetip]` depends on `instro-ethernetip-python`
-- the root dev dependency group includes `instro-ethernetip-python`, so `uv sync` builds and installs the local PyO3 package for development
+- `instro-unstable[ethernetip]` depends on `instro-ethernetip`
+- the root dev dependency group includes `instro-ethernetip`, so `uv sync` builds and installs the local PyO3 package for development
 - `just eip-wheel-smoke-test` can still build a local wheel and verify the private native module against that wheel
 
 The release workflow builds platform-specific wheels for:
@@ -105,7 +105,7 @@ The release workflow builds platform-specific wheels for:
 - Windows `x86_64`
 
 The release workflow also publishes a source distribution. The sdist includes the Rust
-source for both `instro-ethernetip-python` and `instro-ethernetip-rs`, plus the Cargo
+source for both `instro-ethernetip` and `instro-ethernetip-rs`, plus the Cargo
 manifests and lockfile, so source builds do not depend on unpublished repository files.
 
 Development setup:

--- a/packages/instro-ethernetip-python/pyproject.toml
+++ b/packages/instro-ethernetip-python/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "instro-ethernetip-python"
+name = "instro-ethernetip"
 version = "0.2.0"
 description = "PyO3 bindings for the instro EtherNet/IP session API"
 license = "Apache-2.0"

--- a/packages/instro-unstable/instro/unstable/ethernetip/ethernetip.py
+++ b/packages/instro-unstable/instro/unstable/ethernetip/ethernetip.py
@@ -29,7 +29,7 @@ def _load_native_ethernetip() -> SimpleNamespace:
         from instro.unstable._ethernetip import EtherNetIpSession, PlcKind, PlcValue
     except ImportError as exc:
         raise RuntimeError(
-            "EtherNet/IP support requires the native package 'instro-ethernetip-python'. "
+            "EtherNet/IP support requires the native package 'instro-ethernetip'. "
             'Install it with `pip install "instro-unstable[ethernetip]"` or '
             '`uv add "instro-unstable[ethernetip]"`.'
         ) from exc

--- a/packages/instro-unstable/pyproject.toml
+++ b/packages/instro-unstable/pyproject.toml
@@ -10,8 +10,8 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-ethernetip = ["instro-ethernetip-python>=0.1.0,<0.2.0"]
-all = ["instro-ethernetip-python>=0.1.0,<0.2.0"]
+ethernetip = ["instro-ethernetip>=0.2.0,<0.3.0"]
+all = ["instro-ethernetip>=0.2.0,<0.3.0"]
 
 [build-system]
 requires = ["hatchling"]
@@ -19,7 +19,7 @@ build-backend = "hatchling.build"
 
 [tool.uv.sources]
 instro = { workspace = true }
-instro-ethernetip-python = { workspace = true }
+instro-ethernetip = { workspace = true }
 
 [tool.hatch.build.targets.wheel]
 packages = ["instro"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ dev = [
     "mkdocstrings>=0.30.1",
     "mkdocstrings-python>=1.19.0",
     "types-requests>=2.32.4.20250913",
-    "instro-ethernetip-python",
+    "instro-ethernetip",
     "instro-unstable",
     "instro-contrib",
 ]
@@ -78,7 +78,7 @@ instro-daq-ni = { workspace = true }
 instro-daq-labjack = { workspace = true }
 instro-daq-mcc = { workspace = true }
 instro-i2c-aardvark = { workspace = true }
-instro-ethernetip-python = { workspace = true }
+instro-ethernetip = { workspace = true }
 instro-unstable = { workspace = true }
 instro-contrib = { workspace = true }
 

--- a/tests/ethernetip_wheel_smoke.py
+++ b/tests/ethernetip_wheel_smoke.py
@@ -36,7 +36,7 @@ def _assert_wheel_contains_expected_files(wheel_path: Path) -> None:
 
     for filename in ("METADATA", "WHEEL", "RECORD"):
         if not any(
-            name.startswith("instro_ethernetip_python-") and name.endswith(f".dist-info/{filename}") for name in names
+            name.startswith("instro_ethernetip-") and name.endswith(f".dist-info/{filename}") for name in names
         ):
             raise AssertionError(f"{wheel_path.name} is missing dist-info/{filename}")
 
@@ -72,7 +72,7 @@ def _assert_installed_wheel_types() -> None:
 def main() -> None:
     wheel = os.environ.get("INSTRO_EIP_WHEEL")
     if not wheel:
-        raise AssertionError("INSTRO_EIP_WHEEL must point to the built instro-ethernetip-python wheel")
+        raise AssertionError("INSTRO_EIP_WHEEL must point to the built instro-ethernetip wheel")
 
     _assert_wheel_contains_expected_files(Path(wheel))
 

--- a/tests/test_ethernetip_optional_native.py
+++ b/tests/test_ethernetip_optional_native.py
@@ -40,5 +40,5 @@ def test_open_reports_extra_when_native_ethernetip_is_missing(monkeypatch: pytes
     # The failure should tell users which package is missing and the preferred
     # `instro-unstable` extra that installs it.
     message = str(exc_info.value)
-    assert "instro-ethernetip-python" in message
+    assert "instro-ethernetip" in message
     assert "instro-unstable[ethernetip]" in message

--- a/uv.lock
+++ b/uv.lock
@@ -15,7 +15,7 @@ members = [
     "instro-daq-labjack",
     "instro-daq-mcc",
     "instro-daq-ni",
-    "instro-ethernetip-python",
+    "instro-ethernetip",
     "instro-i2c-aardvark",
     "instro-unstable",
 ]
@@ -465,7 +465,7 @@ wheels = [
 
 [[package]]
 name = "instro"
-version = "0.10.0"
+version = "0.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastavro", extra = ["snappy"] },
@@ -514,7 +514,7 @@ nidaq = [
 [package.dev-dependencies]
 dev = [
     { name = "instro-contrib" },
-    { name = "instro-ethernetip-python" },
+    { name = "instro-ethernetip" },
     { name = "instro-unstable" },
     { name = "mkdocs" },
     { name = "mkdocs-material" },
@@ -560,7 +560,7 @@ provides-extras = ["daq", "labjack", "nidaq", "mccdaq", "i2c", "aardvark", "cont
 [package.metadata.requires-dev]
 dev = [
     { name = "instro-contrib", editable = "packages/instro-contrib" },
-    { name = "instro-ethernetip-python", editable = "packages/instro-ethernetip-python" },
+    { name = "instro-ethernetip", editable = "packages/instro-ethernetip-python" },
     { name = "instro-unstable", editable = "packages/instro-unstable" },
     { name = "mkdocs", specifier = ">=1.6.1" },
     { name = "mkdocs-material", specifier = ">=9.7.0" },
@@ -577,7 +577,7 @@ test = [
 
 [[package]]
 name = "instro-contrib"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "packages/instro-contrib" }
 dependencies = [
     { name = "instro" },
@@ -588,7 +588,7 @@ requires-dist = [{ name = "instro", editable = "." }]
 
 [[package]]
 name = "instro-daq-labjack"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "packages/instro-daq-labjack" }
 dependencies = [
     { name = "instro" },
@@ -603,7 +603,7 @@ requires-dist = [
 
 [[package]]
 name = "instro-daq-mcc"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "packages/instro-daq-mcc" }
 dependencies = [
     { name = "instro" },
@@ -618,7 +618,7 @@ requires-dist = [
 
 [[package]]
 name = "instro-daq-ni"
-version = "0.7.0"
+version = "0.7.1"
 source = { editable = "packages/instro-daq-ni" }
 dependencies = [
     { name = "instro" },
@@ -632,8 +632,8 @@ requires-dist = [
 ]
 
 [[package]]
-name = "instro-ethernetip-python"
-version = "0.1.0"
+name = "instro-ethernetip"
+version = "0.2.0"
 source = { editable = "packages/instro-ethernetip-python" }
 dependencies = [
     { name = "instro" },
@@ -644,7 +644,7 @@ requires-dist = [{ name = "instro", editable = "." }]
 
 [[package]]
 name = "instro-i2c-aardvark"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "packages/instro-i2c-aardvark" }
 dependencies = [
     { name = "instro" },
@@ -659,7 +659,7 @@ requires-dist = [
 
 [[package]]
 name = "instro-unstable"
-version = "0.0.1"
+version = "0.1.0"
 source = { editable = "packages/instro-unstable" }
 dependencies = [
     { name = "instro" },
@@ -667,17 +667,17 @@ dependencies = [
 
 [package.optional-dependencies]
 all = [
-    { name = "instro-ethernetip-python" },
+    { name = "instro-ethernetip" },
 ]
 ethernetip = [
-    { name = "instro-ethernetip-python" },
+    { name = "instro-ethernetip" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "instro", editable = "." },
-    { name = "instro-ethernetip-python", marker = "extra == 'all'", editable = "packages/instro-ethernetip-python" },
-    { name = "instro-ethernetip-python", marker = "extra == 'ethernetip'", editable = "packages/instro-ethernetip-python" },
+    { name = "instro-ethernetip", marker = "extra == 'all'", editable = "packages/instro-ethernetip-python" },
+    { name = "instro-ethernetip", marker = "extra == 'ethernetip'", editable = "packages/instro-ethernetip-python" },
 ]
 provides-extras = ["ethernetip", "all"]
 


### PR DESCRIPTION
Fixes INSTRO-394: https://linear.app/nominal-io/issue/INSTRO-394/rename-instro-ethernetip-python-instro-ethernetip

## Summary
- rename the published EtherNet/IP Python distribution to `instro-ethernetip`
- update `instro-unstable[ethernetip]`, workspace metadata, release checks, docs, and tests
- keep the existing source directory path unchanged

## Verification
- `uv build --wheel --package instro-ethernetip --out-dir /tmp/instro-eip-dist`
- `uv run pytest tests/test_ethernetip_optional_native.py -q`
- `cargo check -p instro-ethernetip`
- `just eip-wheel-smoke-test`