### PR TITLE
feat(visa): default to @ivi backend, fall back to @py

### DIFF
--- a/docs/guides/instrumentation/transports/visa.mdx
+++ b/docs/guides/instrumentation/transports/visa.mdx
@@ -106,7 +106,7 @@ When the VISA resource is an ASRL (RS-232 / RS-485) interface, `VisaDriver` appl
 
 ### Backends
 
-`VisaConfig.visa_backend` selects which pyvisa backend handles the resource. Most callers should let the default backend drive. The default is `"@ivi"` (the system IVI VISA implementation, e.g. NI-VISA or Keysight IO Libraries), which automatically falls back to the pure-Python `"@py"` backend when no IVI implementation is installed. Setting `visa_backend` to any non-default value (such as `"@py"` or `"@sim"`) uses that backend as-is, with no fallback.
+`VisaConfig.visa_backend` selects which pyvisa backend handles the resource. Most callers should leave it unset. When unset (`None`), `instro` uses the system IVI VISA implementation (`"@ivi"`, e.g. NI-VISA or Keysight IO Libraries) and automatically falls back to the pure-Python `"@py"` backend when no IVI implementation is installed. Setting `visa_backend` to any explicit value (such as `"@ivi"`, `"@py"`, or `"@sim"`) uses that backend as-is, with no fallback.
 
 ## Building a Custom Driver
 
@@ -239,7 +239,7 @@ Top-level connection parameters.
 | Field | Required | Default | Description |
 |-------|----------|---------|-------------|
 | `visa_resource` | Yes | | VISA resource string, e.g. `TCPIP0::host::5025::SOCKET` or `USB0::0x2A8D::0x0101::MY12345::INSTR` |
-| `visa_backend` | No | `"@ivi"` | pyvisa backend specifier; the default `"@ivi"` falls back to `"@py"` when no IVI implementation is installed |
+| `visa_backend` | No | `None` | pyvisa backend specifier; unset uses `"@ivi"` and falls back to `"@py"` when no IVI implementation is installed. An explicit value is used as-is, with no fallback |
 | `serial_config` | No | `SerialConfig()` | Serial settings, applied only when the resource is an ASRL interface |
 | `terminator` | No | `TerminatorConfig()` | Read and write terminators |
 | `timeout` | No | `TimeoutConfig()` | Operation timeouts |

--- a/docs/guides/instrumentation/transports/visa.mdx
+++ b/docs/guides/instrumentation/transports/visa.mdx
@@ -106,7 +106,7 @@ When the VISA resource is an ASRL (RS-232 / RS-485) interface, `VisaDriver` appl
 
 ### Backends
 
-`VisaConfig.visa_backend` selects which pyvisa backend handles the resource. Most callers should let the default backend drive.
+`VisaConfig.visa_backend` selects which pyvisa backend handles the resource. Most callers should let the default backend drive. The default is `"@ivi"` (the system IVI VISA implementation, e.g. NI-VISA or Keysight IO Libraries), which automatically falls back to the pure-Python `"@py"` backend when no IVI implementation is installed. Setting `visa_backend` to any non-default value (such as `"@py"` or `"@sim"`) uses that backend as-is, with no fallback.
 
 ## Building a Custom Driver
 
@@ -239,7 +239,7 @@ Top-level connection parameters.
 | Field | Required | Default | Description |
 |-------|----------|---------|-------------|
 | `visa_resource` | Yes | | VISA resource string, e.g. `TCPIP0::host::5025::SOCKET` or `USB0::0x2A8D::0x0101::MY12345::INSTR` |
-| `visa_backend` | No | `"@py"` | pyvisa backend specifier |
+| `visa_backend` | No | `"@ivi"` | pyvisa backend specifier; the default `"@ivi"` falls back to `"@py"` when no IVI implementation is installed |
 | `serial_config` | No | `SerialConfig()` | Serial settings, applied only when the resource is an ASRL interface |
 | `terminator` | No | `TerminatorConfig()` | Read and write terminators |
 | `timeout` | No | `TimeoutConfig()` | Operation timeouts |

--- a/instro/lib/transports/visa.py
+++ b/instro/lib/transports/visa.py
@@ -15,6 +15,9 @@ from pyvisa.constants import Parity as VisaParity
 
 logger = logging.getLogger(__name__)
 
+DEFAULT_VISA_BACKEND = "@ivi"
+FALLBACK_VISA_BACKEND = "@py"
+
 
 class StopBits(enum.Enum):
     ONE = 1
@@ -85,7 +88,9 @@ class VisaConfig:
     Attributes:
         visa_resource: VISA resource string, e.g. ``TCPIP0::host::5025::SOCKET``
             or ``USB0::0x2A8D::0x0101::MY12345::INSTR``.
-        visa_backend: pyvisa backend specifier. Defaults to ``@py``.
+        visa_backend: pyvisa backend specifier. Defaults to ``@ivi`` (the system
+            IVI VISA implementation), falling back to ``@py`` when no IVI backend
+            is installed. An explicitly set non-default backend is used as-is.
         serial_config: Serial settings applied when the VISA resource is an
             ASRL (RS-232/RS-485) interface.
         terminator: Read and write terminators.
@@ -93,7 +98,7 @@ class VisaConfig:
     """
 
     visa_resource: str
-    visa_backend: str = "@py"
+    visa_backend: str = DEFAULT_VISA_BACKEND
     serial_config: SerialConfig = dataclasses.field(default_factory=SerialConfig)
     terminator: TerminatorConfig = dataclasses.field(default_factory=TerminatorConfig)
     timeout: TimeoutConfig = dataclasses.field(default_factory=TimeoutConfig)
@@ -139,7 +144,7 @@ class VisaDriver:
             # pyvisa caches one ResourceManager per backend and shares it across every
             # driver in the process; closing it would kill all other drivers' sessions.
             # pyvisa closes it via its own atexit handler.
-            rm = pyvisa.ResourceManager(cfg.visa_backend)
+            rm = _open_resource_manager(cfg.visa_backend)
             inst: pyvisa.resources.MessageBasedResource | None = None
             try:
                 inst = typing.cast(
@@ -267,6 +272,22 @@ class VisaDriver:
                 f"VisaDriver is not open. Call open() first. Resource: {self._connection_config.visa_resource}"
             )
         return self._inst
+
+
+def _open_resource_manager(backend: str) -> pyvisa.ResourceManager:
+    """Open a ResourceManager for ``backend``; the default ``@ivi`` falls back to ``@py`` if no IVI library is found."""
+    try:
+        return pyvisa.ResourceManager(backend)
+    except OSError as exc:
+        if backend != DEFAULT_VISA_BACKEND:
+            raise
+        logger.warning(
+            "VISA backend %s unavailable (%s); falling back to %s",
+            DEFAULT_VISA_BACKEND,
+            exc,
+            FALLBACK_VISA_BACKEND,
+        )
+        return pyvisa.ResourceManager(FALLBACK_VISA_BACKEND)
 
 
 def _configure_resource(

--- a/instro/lib/transports/visa.py
+++ b/instro/lib/transports/visa.py
@@ -88,9 +88,10 @@ class VisaConfig:
     Attributes:
         visa_resource: VISA resource string, e.g. ``TCPIP0::host::5025::SOCKET``
             or ``USB0::0x2A8D::0x0101::MY12345::INSTR``.
-        visa_backend: pyvisa backend specifier. Defaults to ``@ivi`` (the system
-            IVI VISA implementation), falling back to ``@py`` when no IVI backend
-            is installed. An explicitly set non-default backend is used as-is.
+        visa_backend: pyvisa backend specifier. When unset (``None``), uses the
+            system IVI VISA implementation (``@ivi``) and falls back to ``@py``
+            when no IVI backend is installed. An explicitly set backend is used
+            as-is, with no fallback.
         serial_config: Serial settings applied when the VISA resource is an
             ASRL (RS-232/RS-485) interface.
         terminator: Read and write terminators.
@@ -98,7 +99,7 @@ class VisaConfig:
     """
 
     visa_resource: str
-    visa_backend: str = DEFAULT_VISA_BACKEND
+    visa_backend: str | None = None
     serial_config: SerialConfig = dataclasses.field(default_factory=SerialConfig)
     terminator: TerminatorConfig = dataclasses.field(default_factory=TerminatorConfig)
     timeout: TimeoutConfig = dataclasses.field(default_factory=TimeoutConfig)
@@ -139,7 +140,7 @@ class VisaDriver:
             logger.info(
                 "Opening VISA resource %s on backend %s",
                 cfg.visa_resource,
-                cfg.visa_backend,
+                cfg.visa_backend or DEFAULT_VISA_BACKEND,
             )
             # pyvisa caches one ResourceManager per backend and shares it across every
             # driver in the process; closing it would kill all other drivers' sessions.
@@ -274,13 +275,13 @@ class VisaDriver:
         return self._inst
 
 
-def _open_resource_manager(backend: str) -> pyvisa.ResourceManager:
-    """Open a ResourceManager for ``backend``; the default ``@ivi`` falls back to ``@py`` if no IVI library is found."""
-    try:
+def _open_resource_manager(backend: str | None) -> pyvisa.ResourceManager:
+    """Open a ResourceManager. An unset backend uses ``@ivi`` and falls back to ``@py``; an explicit backend is used as-is."""
+    if backend is not None:
         return pyvisa.ResourceManager(backend)
+    try:
+        return pyvisa.ResourceManager(DEFAULT_VISA_BACKEND)
     except OSError as exc:
-        if backend != DEFAULT_VISA_BACKEND:
-            raise
         logger.warning(
             "VISA backend %s unavailable (%s); falling back to %s",
             DEFAULT_VISA_BACKEND,

--- a/tests/lib/test_visa_driver.py
+++ b/tests/lib/test_visa_driver.py
@@ -26,15 +26,18 @@ from instro.lib.transports import (
 def _make_config(
     *,
     visa_resource: str = "TCPIP0::127.0.0.1::5025::SOCKET",
+    visa_backend: str | None = None,
     serial_config: SerialConfig | None = None,
     terminator: TerminatorConfig | None = None,
     timeout: TimeoutConfig | None = None,
 ) -> VisaConfig:
+    kwargs = {} if visa_backend is None else {"visa_backend": visa_backend}
     return VisaConfig(
         visa_resource=visa_resource,
         serial_config=serial_config or SerialConfig(),
         terminator=terminator or TerminatorConfig(read="\n", write="\r\n"),
         timeout=timeout or TimeoutConfig(connect=30, recv=15, send=15),
+        **kwargs,
     )
 
 
@@ -65,7 +68,7 @@ def test_construction_accepts_raw_resource_string(mock_pyvisa):
 
     driver.open()
 
-    rm_class.assert_called_once_with("@py")
+    rm_class.assert_called_once_with("@ivi")
     rm_instance.open_resource.assert_called_once_with("USB0::0x1234::0x5678::SERIAL::INSTR")
 
 
@@ -119,6 +122,38 @@ def test_open_is_idempotent(mock_pyvisa):
 
     rm_class.assert_called_once()
     rm_instance.open_resource.assert_called_once()
+
+
+def test_open_uses_ivi_backend_by_default(mock_pyvisa):
+    rm_class, _, _ = mock_pyvisa
+    driver = _make_driver()
+
+    driver.open()
+
+    rm_class.assert_called_once_with("@ivi")
+
+
+def test_open_falls_back_to_py_when_ivi_backend_missing(mock_pyvisa):
+    rm_class, rm_instance, _ = mock_pyvisa
+    rm_class.side_effect = [OSError("Could not locate a VISA implementation"), rm_instance]
+    driver = _make_driver()
+
+    driver.open()
+
+    assert rm_class.call_args_list == [call("@ivi"), call("@py")]
+    assert driver.is_open is True
+
+
+def test_open_does_not_fall_back_for_explicit_non_default_backend(mock_pyvisa):
+    rm_class, _, _ = mock_pyvisa
+    rm_class.side_effect = OSError("simulation backend not available")
+    driver = _make_driver(_make_config(visa_backend="@sim"))
+
+    with pytest.raises(OSError, match="simulation backend not available"):
+        driver.open()
+
+    rm_class.assert_called_once_with("@sim")
+    assert driver.is_open is False
 
 
 def test_open_leaves_shared_resource_manager_open_when_open_resource_fails(mock_pyvisa):
@@ -429,5 +464,5 @@ def test_transactional_lock_blocks_other_threads_until_released(mock_pyvisa):
     ],
 )
 def test_visa_backend_package_is_installed(module: str) -> None:
-    """Every pyvisa-py backend the default @py setup relies on must ship with instro (issue #102)."""
+    """Every pyvisa-py backend the @py fallback relies on must ship with instro (issue #102)."""
     assert importlib.util.find_spec(module) is not None

--- a/tests/lib/test_visa_driver.py
+++ b/tests/lib/test_visa_driver.py
@@ -106,7 +106,7 @@ def test_open_creates_resource_and_applies_config(mock_pyvisa):
     driver.open()
 
     assert driver.is_open is True
-    rm_class.assert_called_once_with(cfg.visa_backend)
+    rm_class.assert_called_once_with("@ivi")
     rm_instance.open_resource.assert_called_once_with(cfg.visa_resource)
     assert resource.read_termination == "\r"
     assert resource.write_termination == "\n"
@@ -144,15 +144,16 @@ def test_open_falls_back_to_py_when_ivi_backend_missing(mock_pyvisa):
     assert driver.is_open is True
 
 
-def test_open_does_not_fall_back_for_explicit_non_default_backend(mock_pyvisa):
+@pytest.mark.parametrize("backend", ["@ivi", "@py", "@sim"])
+def test_open_does_not_fall_back_for_explicit_backend(mock_pyvisa, backend: str):
     rm_class, _, _ = mock_pyvisa
-    rm_class.side_effect = OSError("simulation backend not available")
-    driver = _make_driver(_make_config(visa_backend="@sim"))
+    rm_class.side_effect = OSError("backend not available")
+    driver = _make_driver(_make_config(visa_backend=backend))
 
-    with pytest.raises(OSError, match="simulation backend not available"):
+    with pytest.raises(OSError, match="backend not available"):
         driver.open()
 
-    rm_class.assert_called_once_with("@sim")
+    rm_class.assert_called_once_with(backend)
     assert driver.is_open is False
 
 


### PR DESCRIPTION
@
## Summary

Closes #129. Changes the default VISA backend for `VisaDriver` from `@py` to `@ivi` (the system IVI VISA implementation, e.g. NI-VISA / Keysight IO Libraries), with an automatic fall back to `@py` when no IVI backend is installed.

## Changes

- `VisaConfig.visa_backend` now defaults to `@ivi` (`DEFAULT_VISA_BACKEND`).
- New `_open_resource_manager()` helper in `instro/lib/transports/visa.py`: on `OSError` (pyvisa raises this — including its `LibraryError` subclass — when no IVI implementation is found), it falls back to `@py` and logs a warning. The fallback applies **only** when the backend is left at the default; an explicitly set non-default backend (e.g. `@py`, `@sim`) propagates the error unchanged.
- Updated the `VisaConfig.visa_backend` docstring and the VISA transport docs (`docs/guides/instrumentation/transports/visa.mdx`).

## Tests

- `test_open_uses_ivi_backend_by_default` — default constructs `@ivi`.
- `test_open_falls_back_to_py_when_ivi_backend_missing` — `@ivi` raises `OSError` → retries with `@py`, opens successfully.
- `test_open_does_not_fall_back_for_explicit_non_default_backend` — explicit `@sim` failure propagates, no fallback.
- Updated the existing default-backend assertion and the `@py` package-availability test docstring (now framed as the fallback backend).

`just check` and `just test` pass (940 passed).
@