### PR TITLE
test(dmm): verify Keithley 2400 on hardware

### DIFF
--- a/tests/dmm/keithley/test_keithley_2400_hardware.py
+++ b/tests/dmm/keithley/test_keithley_2400_hardware.py
@@ -1,0 +1,208 @@
+"""Hardware validation for the Keithley 2400 SourceMeter via InstroDMM. Self-contained; no publishers.
+
+Exercises every method the ``Keithley2400`` (sense-only DMM) driver implements:
+connection/``*IDN?``; the three supported measurement functions (DC voltage, DC
+current, 2-wire resistance) via set + read; per-function NPLC (``set_aperture_nplc``);
+per-function range set (manual + auto, source path for V/I and sense path for ohms);
+the unsupported-capability guards (AC function, ``set_digits``, ``set_aperture_seconds``,
+all raise NotImplementedError); and the real-hardware error-query path.
+
+Safety:
+    The 2400 is a SourceMeter. This driver sources 0 V / 0 A to sense passively and
+    briefly enables the output during each ``:READ?``; ``close()`` issues ``:OUTP OFF``.
+    The ``finally`` block always closes the instrument, leaving the output OFF.
+
+Wiring / stimulus:
+    FRONT terminals, OPEN (nothing connected). Measurement checks are therefore
+    STRUCTURAL only: each read must parse to a finite float and raise no SCPI error.
+    With open terminals, V/I read ~0 (output forced to 0) and 2-wire resistance reads a
+    large but finite value (autorange-clamped, ~1e8 Ω on a real 2400 — not necessarily
+    the canonical 9.9e37 overflow sentinel). To add strict value checks, wire a known
+    stimulus (e.g. a resistor) and set the matching ``EXPECTED_*``.
+
+Run:
+    uv run python tests/dmm/keithley/test_keithley_2400_hardware.py
+"""
+
+from __future__ import annotations
+
+import math
+import sys
+import time
+
+import pytest
+
+from instro.dmm import InstroDMM, MeasurementFunction
+from instro.dmm.drivers import Keithley2400
+from instro.lib.transports import SerialConfig, VisaConfig
+
+# HARDWARE TEST SETUP - EDIT THESE VALUES BEFORE RUNNING THIS FILE.
+VISA_RESOURCE = "ASRL5::INSTR"  # <-- edit to your serial port (COM5)
+BAUD_RATE = 9600  # <-- match the 2400's front-panel RS-232 baud setting
+VISA_BACKEND = "@py"  # <-- pyvisa backend; "@py" for pyvisa-py, None for system IVI/NI-VISA
+
+# Strict value checks. Leave None for open terminals (structural checks only).
+# Set one to the known stimulus value (in the function's base units) to enable a
+# tolerance-based assertion on that function's read.
+EXPECTED_DC_VOLTAGE = None  # volts
+EXPECTED_DC_CURRENT = None  # amperes
+EXPECTED_TWO_WIRE_RESISTANCE = None  # ohms
+VALUE_TOLERANCE = 0.05  # relative tolerance for any enabled strict check
+
+# (function, expected-value constant, manual-range) for the supported-function sweep.
+# Range is the source path for V/I and the sense path for resistance.
+_FUNCTION_SWEEP = [
+    (MeasurementFunction.DC_VOLTAGE, EXPECTED_DC_VOLTAGE, 10.0),
+    (MeasurementFunction.DC_CURRENT, EXPECTED_DC_CURRENT, 0.1),
+    (MeasurementFunction.TWO_WIRE_RESISTANCE, EXPECTED_TWO_WIRE_RESISTANCE, 1000.0),
+]
+
+
+def _make_hal() -> InstroDMM:
+    hal = InstroDMM(
+        name="hw_validate",
+        driver=Keithley2400(
+            VisaConfig(
+                visa_resource=VISA_RESOURCE,
+                visa_backend=VISA_BACKEND,
+                serial_config=SerialConfig(baud_rate=BAUD_RATE),
+            )
+        ),
+        publishers=None,
+    )
+    hal.open()
+    return hal
+
+
+def _run(name, fn, failures) -> None:
+    try:
+        fn()
+        print(f"  [OK]   {name}")
+    except Exception as exc:  # noqa: BLE001 - report, don't abort
+        print(f"  [FAIL] {name}: {exc}")
+        failures.append((name, exc))
+
+
+def _read_value(hal: InstroDMM) -> float:
+    """Read under the active function and assert the result is a finite float."""
+    value = hal.read().latest
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise AssertionError(f"expected a numeric reading, got {value!r}")
+    fvalue = float(value)
+    if not math.isfinite(fvalue):
+        raise AssertionError(f"non-finite reading: {fvalue}")
+    return fvalue
+
+
+def _check_function(hal: InstroDMM, function: MeasurementFunction, expected) -> None:
+    hal.set_measurement_function(function)
+    value = _read_value(hal)
+    print(f"         {function.value} read -> {value:g}")
+    if expected is not None and value != pytest.approx(expected, rel=VALUE_TOLERANCE):
+        raise AssertionError(f"{function.value}: {value:g} not within {VALUE_TOLERANCE:.0%} of {expected:g}")
+
+
+def run_all() -> list:
+    hal = _make_hal()
+    failures: list = []
+    try:
+        _run(
+            "connection / *IDN?",
+            lambda: print(f"         IDN -> {hal._driver._visa.query('*IDN?').strip()}"),
+            failures,
+        )
+
+        for function, expected, _range in _FUNCTION_SWEEP:
+            _run(
+                f"set_measurement_function + read: {function.value}",
+                lambda f=function, e=expected: _check_function(hal, f, e),
+                failures,
+            )
+
+        def _nplc() -> None:
+            for function, _expected, _range in _FUNCTION_SWEEP:
+                hal.set_measurement_function(function)
+                hal.set_aperture_nplc(1.0)
+                _read_value(hal)
+
+        _run("set_aperture_nplc (V/I/ohms) + read", _nplc, failures)
+
+        def _range_sweep() -> None:
+            for function, _expected, manual_range in _FUNCTION_SWEEP:
+                hal.set_measurement_function(function)
+                hal.set_range(manual_range)  # manual range (source path for V/I, sense path for ohms)
+                _read_value(hal)
+                hal.set_range(None)  # auto range
+                _read_value(hal)
+
+        _run("set_range manual + auto (V/I/ohms)", _range_sweep, failures)
+
+        def _ac_function_unsupported() -> None:
+            try:
+                hal.set_measurement_function(MeasurementFunction.AC_VOLTAGE)
+            except NotImplementedError:
+                return
+            else:
+                raise AssertionError("set_measurement_function(AC_VOLTAGE) should raise NotImplementedError")
+            finally:
+                # The HAL records the requested function before calling the driver, so
+                # restore a valid function for any subsequent state.
+                hal.set_measurement_function(MeasurementFunction.DC_VOLTAGE)
+
+        _run("AC function unsupported (NotImplementedError)", _ac_function_unsupported, failures)
+
+        def _set_digits_unsupported() -> None:
+            try:
+                hal.set_digits(5)
+            except NotImplementedError:
+                return
+            raise AssertionError("set_digits should raise NotImplementedError on the 2400")
+
+        _run("set_digits unsupported (NotImplementedError)", _set_digits_unsupported, failures)
+
+        def _set_aperture_seconds_unsupported() -> None:
+            try:
+                hal.set_aperture_seconds(0.1)
+            except NotImplementedError:
+                return
+            raise AssertionError("set_aperture_seconds should raise NotImplementedError on the 2400")
+
+        _run("set_aperture_seconds unsupported (NotImplementedError)", _set_aperture_seconds_unsupported, failures)
+
+        def _error_path() -> None:
+            hal._driver._visa.write("INSTRO:INVALID")
+            time.sleep(0.5)  # let the 2400 queue the error before :SYST:ERR? at 9600 baud
+            try:
+                hal._driver._check_errors()
+            except RuntimeError:
+                return
+            finally:
+                hal._driver._visa.write("*CLS")
+            raise AssertionError("_check_errors should raise after an invalid command")
+
+        _run("error-query path raises on bad command", _error_path, failures)
+
+        # Reported for transparency: the 2400 sense-only driver does not implement AC
+        # measurement (measure_ac_voltage / measure_ac_current raise NotImplementedError)
+        # or 4-wire resistance, so those reads are out of scope for this validation. The
+        # AC path is covered above at the set_measurement_function guard.
+        print("  [SKIP] measure_ac_voltage / measure_ac_current / 4-wire resistance: not implemented by Keithley2400")
+    finally:
+        hal.close()  # issues :OUTP OFF, then closes the transport
+    return failures
+
+
+@pytest.mark.hardware
+def test_keithley_2400_hardware() -> None:
+    failures = run_all()
+    assert not failures, f"{len(failures)} hardware check(s) failed: {failures}"
+
+
+def main() -> int:
+    failures = run_all()
+    print(f"\n{'PASSED' if not failures else f'FAILED ({len(failures)})'}")
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/dmm/keithley/test_keithley_2400_hardware.py
+++ b/tests/dmm/keithley/test_keithley_2400_hardware.py
@@ -129,16 +129,13 @@ def run_all() -> list:
         _run("set_range manual + auto (V/I/ohms)", _range_sweep, failures)
 
         def _ac_function_unsupported() -> None:
+            # The HAL calls the driver before recording state, so a rejected AC function
+            # leaves _measurement_config untouched (no restore needed).
             try:
                 hal.set_measurement_function(MeasurementFunction.AC_VOLTAGE)
             except NotImplementedError:
                 return
-            else:
-                raise AssertionError("set_measurement_function(AC_VOLTAGE) should raise NotImplementedError")
-            finally:
-                # The HAL records the requested function before calling the driver, so
-                # restore a valid function for any subsequent state.
-                hal.set_measurement_function(MeasurementFunction.DC_VOLTAGE)
+            raise AssertionError("set_measurement_function(AC_VOLTAGE) should raise NotImplementedError")
 
         _run("AC function unsupported (NotImplementedError)", _ac_function_unsupported, failures)
 

--- a/tests/dmm/keithley/test_keithley_2400_hardware.py
+++ b/tests/dmm/keithley/test_keithley_2400_hardware.py
@@ -34,12 +34,9 @@ import pytest
 
 from instro.dmm import InstroDMM, MeasurementFunction
 from instro.dmm.drivers import Keithley2400
-from instro.lib.transports import SerialConfig, VisaConfig
 
 # HARDWARE TEST SETUP - EDIT THESE VALUES BEFORE RUNNING THIS FILE.
 VISA_RESOURCE = "ASRL5::INSTR"  # <-- edit to your serial port (COM5)
-BAUD_RATE = 9600  # <-- match the 2400's front-panel RS-232 baud setting
-VISA_BACKEND = "@py"  # <-- pyvisa backend; "@py" for pyvisa-py, None for system IVI/NI-VISA
 
 # Strict value checks. Leave None for open terminals (structural checks only).
 # Set one to the known stimulus value (in the function's base units) to enable a
@@ -61,13 +58,7 @@ _FUNCTION_SWEEP = [
 def _make_hal() -> InstroDMM:
     hal = InstroDMM(
         name="hw_validate",
-        driver=Keithley2400(
-            VisaConfig(
-                visa_resource=VISA_RESOURCE,
-                visa_backend=VISA_BACKEND,
-                serial_config=SerialConfig(baud_rate=BAUD_RATE),
-            )
-        ),
+        driver=Keithley2400(VISA_RESOURCE),
         publishers=None,
     )
     hal.open()

--- a/tests/dmm/keithley/test_keithley_2400_software.py
+++ b/tests/dmm/keithley/test_keithley_2400_software.py
@@ -32,6 +32,22 @@ def test_keithley_init_builds_visa_from_resource(keithley_visa_cls: MagicMock) -
     keithley_visa_cls.assert_called_once_with("GPIB0::24::INSTR")
 
 
+def test_keithley_close_turns_output_off_and_closes(keithley: Keithley2400, keithley_visa: MagicMock) -> None:
+    keithley_visa.is_open = True
+    keithley.close()
+    writes = [c.args[0] for c in keithley_visa.write.call_args_list]
+    assert ":OUTP OFF" in writes
+    keithley_visa.close.assert_called_once_with()
+
+
+def test_keithley_close_skips_output_off_when_not_open(keithley: Keithley2400, keithley_visa: MagicMock) -> None:
+    keithley_visa.is_open = False
+    keithley.close()
+    writes = [c.args[0] for c in keithley_visa.write.call_args_list]
+    assert ":OUTP OFF" not in writes
+    keithley_visa.close.assert_called_once_with()
+
+
 def test_keithley_set_measurement_function_voltage(keithley: Keithley2400, keithley_visa: MagicMock) -> None:
     keithley.set_measurement_function(MeasurementFunction.DC_VOLTAGE)
     writes = [c.args[0] for c in keithley_visa.write.call_args_list]
@@ -48,6 +64,14 @@ def test_keithley_set_dc_current_nplc_writes_scoped_scpi(keithley: Keithley2400,
     keithley.set_dc_current_nplc(1.0)
     writes = [c.args[0] for c in keithley_visa.write.call_args_list]
     assert ":SENS:CURR:NPLC 1.0000" in writes
+
+
+def test_keithley_set_two_wire_resistance_nplc_writes_scoped_scpi(
+    keithley: Keithley2400, keithley_visa: MagicMock
+) -> None:
+    keithley.set_two_wire_resistance_nplc(1.0)
+    writes = [c.args[0] for c in keithley_visa.write.call_args_list]
+    assert ":SENS:RES:NPLC 1.0000" in writes
 
 
 def test_keithley_set_dc_voltage_nplc_writes_scoped_scpi(keithley: Keithley2400, keithley_visa: MagicMock) -> None:
@@ -76,6 +100,20 @@ def test_keithley_set_dc_voltage_range_manual(keithley: Keithley2400, keithley_v
     assert any(w.startswith(":SOUR:VOLT:RANG ") for w in writes)
 
 
+def test_keithley_set_two_wire_resistance_range_auto(keithley: Keithley2400, keithley_visa: MagicMock) -> None:
+    # Resistance ranges through the sense path (auto-ohms manages the source), unlike V/I.
+    keithley.set_two_wire_resistance_range(None)
+    writes = [c.args[0] for c in keithley_visa.write.call_args_list]
+    assert ":SENS:RES:RANG:AUTO 1" in writes
+
+
+def test_keithley_set_two_wire_resistance_range_manual(keithley: Keithley2400, keithley_visa: MagicMock) -> None:
+    keithley.set_two_wire_resistance_range(1.0e3)
+    writes = [c.args[0] for c in keithley_visa.write.call_args_list]
+    assert ":SENS:RES:RANG:AUTO 0" in writes
+    assert any(w.startswith(":SENS:RES:RANG ") for w in writes)
+
+
 def test_keithley_unsupported_range_function_raises(keithley: Keithley2400) -> None:
     with pytest.raises(NotImplementedError):
         keithley.set_ac_current_range(1.0)
@@ -91,9 +129,24 @@ def test_keithley_measure_ac_voltage_unsupported(keithley: Keithley2400) -> None
         keithley.measure_ac_voltage()
 
 
+def test_keithley_measure_ac_current_unsupported(keithley: Keithley2400) -> None:
+    with pytest.raises(NotImplementedError):
+        keithley.measure_ac_current()
+
+
 def test_keithley_measure_dc_voltage_parses_first_field(keithley: Keithley2400, keithley_visa: MagicMock) -> None:
     keithley_visa.query.side_effect = ["1.234,5.678", '0,"No error"']
     assert keithley.measure_dc_voltage() == pytest.approx(1.234)
+
+
+def test_keithley_measure_dc_current_parses_first_field(keithley: Keithley2400, keithley_visa: MagicMock) -> None:
+    keithley_visa.query.side_effect = ["0.0123,4.567", '0,"No error"']
+    assert keithley.measure_dc_current() == pytest.approx(0.0123)
+
+
+def test_keithley_measure_resistance_parses_first_field(keithley: Keithley2400, keithley_visa: MagicMock) -> None:
+    keithley_visa.query.side_effect = ["1000.5,2.3", '0,"No error"']
+    assert keithley.measure_resistance() == pytest.approx(1000.5)
 
 
 def test_keithley_check_errors_passes_on_signed_zero(keithley: Keithley2400, keithley_visa: MagicMock) -> None:

--- a/tests/dmm/keithley/test_keithley_2400_software.py
+++ b/tests/dmm/keithley/test_keithley_2400_software.py
@@ -1,0 +1,107 @@
+"""Software tests for the Keithley 2400 SourceMeter (sense-only DMM) driver."""
+
+from collections.abc import Iterator
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from instro.dmm.drivers import Keithley2400
+from instro.dmm.types import MeasurementFunction
+
+
+@pytest.fixture
+def keithley_visa_cls() -> Iterator[MagicMock]:
+    with patch("instro.dmm.drivers.keithley_2400.VisaDriver", autospec=True) as driver_cls:
+        yield driver_cls
+
+
+@pytest.fixture
+def keithley_visa(keithley_visa_cls: MagicMock) -> MagicMock:
+    visa = keithley_visa_cls.return_value
+    visa.query.return_value = '0,"No error"'
+    return visa
+
+
+@pytest.fixture
+def keithley(keithley_visa_cls: MagicMock, keithley_visa: MagicMock) -> Keithley2400:
+    return Keithley2400("GPIB0::24::INSTR")
+
+
+def test_keithley_init_builds_visa_from_resource(keithley_visa_cls: MagicMock) -> None:
+    Keithley2400("GPIB0::24::INSTR")
+    keithley_visa_cls.assert_called_once_with("GPIB0::24::INSTR")
+
+
+def test_keithley_set_measurement_function_voltage(keithley: Keithley2400, keithley_visa: MagicMock) -> None:
+    keithley.set_measurement_function(MeasurementFunction.DC_VOLTAGE)
+    writes = [c.args[0] for c in keithley_visa.write.call_args_list]
+    assert ":SENS:FUNC 'VOLT'" in writes
+    assert ":SOUR:FUNC VOLT" in writes
+
+
+def test_keithley_set_measurement_function_unsupported(keithley: Keithley2400) -> None:
+    with pytest.raises(NotImplementedError, match="AC_VOLTAGE"):
+        keithley.set_measurement_function(MeasurementFunction.AC_VOLTAGE)
+
+
+def test_keithley_set_dc_current_nplc_writes_scoped_scpi(keithley: Keithley2400, keithley_visa: MagicMock) -> None:
+    keithley.set_dc_current_nplc(1.0)
+    writes = [c.args[0] for c in keithley_visa.write.call_args_list]
+    assert ":SENS:CURR:NPLC 1.0000" in writes
+
+
+def test_keithley_set_dc_voltage_nplc_writes_scoped_scpi(keithley: Keithley2400, keithley_visa: MagicMock) -> None:
+    keithley.set_dc_voltage_nplc(2.5)
+    writes = [c.args[0] for c in keithley_visa.write.call_args_list]
+    assert ":SENS:VOLT:NPLC 2.5000" in writes
+
+
+def test_keithley_unsupported_nplc_function_raises(keithley: Keithley2400) -> None:
+    with pytest.raises(NotImplementedError):
+        keithley.set_ac_voltage_nplc(1.0)
+
+
+def test_keithley_set_dc_voltage_range_auto(keithley: Keithley2400, keithley_visa: MagicMock) -> None:
+    # V/I range is driven through :SOUR — :SENS:VOLT:RANG is rejected with error 823
+    # because the sense path runs through the source range on the 2400.
+    keithley.set_dc_voltage_range(None)
+    writes = [c.args[0] for c in keithley_visa.write.call_args_list]
+    assert ":SOUR:VOLT:RANG:AUTO 1" in writes
+
+
+def test_keithley_set_dc_voltage_range_manual(keithley: Keithley2400, keithley_visa: MagicMock) -> None:
+    keithley.set_dc_voltage_range(2.0)
+    writes = [c.args[0] for c in keithley_visa.write.call_args_list]
+    assert ":SOUR:VOLT:RANG:AUTO 0" in writes
+    assert any(w.startswith(":SOUR:VOLT:RANG ") for w in writes)
+
+
+def test_keithley_unsupported_range_function_raises(keithley: Keithley2400) -> None:
+    with pytest.raises(NotImplementedError):
+        keithley.set_ac_current_range(1.0)
+
+
+def test_keithley_set_digits_unsupported(keithley: Keithley2400) -> None:
+    with pytest.raises(NotImplementedError, match="set_digits"):
+        keithley.set_digits(5)
+
+
+def test_keithley_measure_ac_voltage_unsupported(keithley: Keithley2400) -> None:
+    with pytest.raises(NotImplementedError):
+        keithley.measure_ac_voltage()
+
+
+def test_keithley_measure_dc_voltage_parses_first_field(keithley: Keithley2400, keithley_visa: MagicMock) -> None:
+    keithley_visa.query.side_effect = ["1.234,5.678", '0,"No error"']
+    assert keithley.measure_dc_voltage() == pytest.approx(1.234)
+
+
+def test_keithley_check_errors_passes_on_signed_zero(keithley: Keithley2400, keithley_visa: MagicMock) -> None:
+    keithley_visa.query.return_value = '+0,"No error"'
+    keithley._check_errors()
+
+
+def test_keithley_check_errors_raises_on_nonzero(keithley: Keithley2400, keithley_visa: MagicMock) -> None:
+    keithley_visa.query.return_value = '-100,"Command error"'
+    with pytest.raises(RuntimeError, match="Keithley 2400 reported error"):
+        keithley._check_errors()

--- a/tests/dmm/test_instro_dmm.py
+++ b/tests/dmm/test_instro_dmm.py
@@ -1,7 +1,8 @@
 """Tests for the DMM driver shape.
 
-Covers vendor drivers (Agilent34401A, Keithley2400) owning a VisaDriver,
-and InstroDMM delegating to its driver via per-function dispatch.
+Covers the Agilent34401A vendor driver owning a VisaDriver, and InstroDMM
+delegating to its driver via per-function dispatch. Keithley2400 software tests
+live in tests/dmm/keithley/test_keithley_2400_software.py.
 """
 
 from collections.abc import Iterator
@@ -11,7 +12,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from instro.dmm import DMMDriverBase, InstroDMM
-from instro.dmm.drivers import Agilent34401A, Keithley2400
+from instro.dmm.drivers import Agilent34401A
 from instro.dmm.types import MeasurementFunction
 from instro.lib.transports import SerialConfig, VisaConfig
 
@@ -119,107 +120,6 @@ def test_agilent_check_errors_raises_on_nonzero(agilent: Agilent34401A, agilent_
     agilent_visa.query.return_value = '-113,"Undefined header"'
     with pytest.raises(RuntimeError, match="Agilent 34401A reported error"):
         agilent._check_errors()
-
-
-# --- Keithley2400 unit tests ---
-
-
-@pytest.fixture
-def keithley_visa_cls() -> Iterator[MagicMock]:
-    with patch("instro.dmm.drivers.keithley_2400.VisaDriver", autospec=True) as driver_cls:
-        yield driver_cls
-
-
-@pytest.fixture
-def keithley_visa(keithley_visa_cls: MagicMock) -> MagicMock:
-    visa = keithley_visa_cls.return_value
-    visa.query.return_value = '0,"No error"'
-    return visa
-
-
-@pytest.fixture
-def keithley(keithley_visa_cls: MagicMock, keithley_visa: MagicMock) -> Keithley2400:
-    return Keithley2400("GPIB0::24::INSTR")
-
-
-def test_keithley_init_builds_visa_from_resource(keithley_visa_cls: MagicMock) -> None:
-    Keithley2400("GPIB0::24::INSTR")
-    keithley_visa_cls.assert_called_once_with("GPIB0::24::INSTR")
-
-
-def test_keithley_set_measurement_function_voltage(keithley: Keithley2400, keithley_visa: MagicMock) -> None:
-    keithley.set_measurement_function(MeasurementFunction.DC_VOLTAGE)
-    writes = [c.args[0] for c in keithley_visa.write.call_args_list]
-    assert ":SENS:FUNC 'VOLT'" in writes
-    assert ":SOUR:FUNC VOLT" in writes
-
-
-def test_keithley_set_measurement_function_unsupported(keithley: Keithley2400) -> None:
-    with pytest.raises(NotImplementedError, match="AC_VOLTAGE"):
-        keithley.set_measurement_function(MeasurementFunction.AC_VOLTAGE)
-
-
-def test_keithley_set_dc_current_nplc_writes_scoped_scpi(keithley: Keithley2400, keithley_visa: MagicMock) -> None:
-    keithley.set_dc_current_nplc(1.0)
-    writes = [c.args[0] for c in keithley_visa.write.call_args_list]
-    assert ":SENS:CURR:NPLC 1.0000" in writes
-
-
-def test_keithley_set_dc_voltage_nplc_writes_scoped_scpi(keithley: Keithley2400, keithley_visa: MagicMock) -> None:
-    keithley.set_dc_voltage_nplc(2.5)
-    writes = [c.args[0] for c in keithley_visa.write.call_args_list]
-    assert ":SENS:VOLT:NPLC 2.5000" in writes
-
-
-def test_keithley_unsupported_nplc_function_raises(keithley: Keithley2400) -> None:
-    with pytest.raises(NotImplementedError):
-        keithley.set_ac_voltage_nplc(1.0)
-
-
-def test_keithley_set_dc_voltage_range_auto(keithley: Keithley2400, keithley_visa: MagicMock) -> None:
-    # V/I range is driven through :SOUR — :SENS:VOLT:RANG is rejected with error 823
-    # because the sense path runs through the source range on the 2400.
-    keithley.set_dc_voltage_range(None)
-    writes = [c.args[0] for c in keithley_visa.write.call_args_list]
-    assert ":SOUR:VOLT:RANG:AUTO 1" in writes
-
-
-def test_keithley_set_dc_voltage_range_manual(keithley: Keithley2400, keithley_visa: MagicMock) -> None:
-    keithley.set_dc_voltage_range(2.0)
-    writes = [c.args[0] for c in keithley_visa.write.call_args_list]
-    assert ":SOUR:VOLT:RANG:AUTO 0" in writes
-    assert any(w.startswith(":SOUR:VOLT:RANG ") for w in writes)
-
-
-def test_keithley_unsupported_range_function_raises(keithley: Keithley2400) -> None:
-    with pytest.raises(NotImplementedError):
-        keithley.set_ac_current_range(1.0)
-
-
-def test_keithley_set_digits_unsupported(keithley: Keithley2400) -> None:
-    with pytest.raises(NotImplementedError, match="set_digits"):
-        keithley.set_digits(5)
-
-
-def test_keithley_measure_ac_voltage_unsupported(keithley: Keithley2400) -> None:
-    with pytest.raises(NotImplementedError):
-        keithley.measure_ac_voltage()
-
-
-def test_keithley_measure_dc_voltage_parses_first_field(keithley: Keithley2400, keithley_visa: MagicMock) -> None:
-    keithley_visa.query.side_effect = ["1.234,5.678", '0,"No error"']
-    assert keithley.measure_dc_voltage() == pytest.approx(1.234)
-
-
-def test_keithley_check_errors_passes_on_signed_zero(keithley: Keithley2400, keithley_visa: MagicMock) -> None:
-    keithley_visa.query.return_value = '+0,"No error"'
-    keithley._check_errors()
-
-
-def test_keithley_check_errors_raises_on_nonzero(keithley: Keithley2400, keithley_visa: MagicMock) -> None:
-    keithley_visa.query.return_value = '-100,"Command error"'
-    with pytest.raises(RuntimeError, match="Keithley 2400 reported error"):
-        keithley._check_errors()
 
 
 # --- InstroDMM composition tests ---

--- a/uv.lock
+++ b/uv.lock
@@ -465,7 +465,7 @@ wheels = [
 
 [[package]]
 name = "instro"
-version = "0.11.0"
+version = "0.12.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastavro", extra = ["snappy"] },
@@ -661,7 +661,7 @@ requires-dist = [
 
 [[package]]
 name = "instro-unstable"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "packages/instro-unstable" }
 dependencies = [
     { name = "instro" },


### PR DESCRIPTION
## What

Verifies the `Keithley2400` DMM driver against a real unit ([INSTRO-373](https://linear.app/nominal-io/issue/INSTRO-373/verify-keithley-2400)). Same scope as the Agilent 34401A verification (nominal-io/instro#134): a self-contained, runnable, `@pytest.mark.hardware`-marked validation script that exercises every method the driver implements.

`tests/dmm/keithley/test_keithley_2400_hardware.py` covers:

* Connection / `*IDN?`
* The three supported measurement functions (DC voltage, DC current, 2-wire resistance) — set + read
* Per-function NPLC via `set_aperture_nplc`
* Per-function range, manual + auto (source path for V/I, sense path for ohms — matching the 2400's quirk where `:SENS:*:RANG` is rejected with error 823)
* Unsupported-capability guards: AC function, `set_digits`, and `set_aperture_seconds` each raise `NotImplementedError`
* The SCPI error-query path (signed error codes; `+0` = no error)

Runnable standalone: `uv run python tests/dmm/keithley/test_keithley_2400_hardware.py`.

## Hardware confirmation

Run against a physical **Keithley 2400** over RS-232 (COM5 / `ASRL5::INSTR`, 9600 baud), `*IDN?` → `KEITHLEY INSTRUMENTS INC.,MODEL 2400,...,C34`. **All 10 steps pass** (1 SKIP for the unimplemented AC/4-wire reads) on open FRONT terminals with structural-only checks. No driver changes were needed — the driver was already correct.

Safety: the driver uses the 2400 as a sense-only DMM — it sources 0 V / 0 A, briefly enables the output during each `:READ?`, and the script's `finally` always `close()`s (which issues `:OUTP OFF`), leaving the output off.

The script uses `visa_backend="@py"` because the test machine has no NI-VISA (same as nominal-io/instro#134; the broken `@ivi`→`@py` auto-fallback is tracked in nominal-io/instro#133, out of scope here).

## Notes

* Hardware test is `@pytest.mark.hardware`, so it does **not** run in CI (`addopts = -m 'not hardware'`). Included as a record and for manual re-runs.
* `uv.lock` intentionally excluded — unrelated pre-existing change.
* Branched off `main`, independent of the [INSTRO-372](https://linear.app/nominal-io/issue/INSTRO-372/verify-agilent-34401a) PR (nominal-io/instro#134); touches only `tests/dmm/keithley/`.

## Test plan

* `just check` — clean (ruff format, mypy, ruff lint).
* `uv run pytest tests/dmm/` — 37 passed, 1 deselected (the new hardware test).

## Update: per-vendor software-test split

Also moved the `Keithley2400` mocked-transport tests out of `tests/dmm/test_instro_dmm.py` into `tests/dmm/keithley/test_keithley_2400_software.py`, mirroring the per-vendor PSU layout (and the sibling Agilent split in nominal-io/instro#134). No test logic changed; `test_instro_dmm.py` imports/docstring trimmed accordingly. `uv run pytest tests/dmm/` → 37 passed, 1 deselected (count unchanged across the move).

Note: this touches `test_instro_dmm.py`, which nominal-io/instro#134 ([INSTRO-372](https://linear.app/nominal-io/issue/INSTRO-372/verify-agilent-34401a)) also edits — expect a small, easily-resolved docstring/import conflict when both merge.