### PR TITLE
fix(visa): catch pyvisa errors so @ivi→@py fallback fires

### DIFF
--- a/instro/lib/transports/visa.py
+++ b/instro/lib/transports/visa.py
@@ -281,7 +281,7 @@ def _open_resource_manager(backend: str | None) -> pyvisa.ResourceManager:
         return pyvisa.ResourceManager(backend)
     try:
         return pyvisa.ResourceManager(DEFAULT_VISA_BACKEND)
-    except OSError as exc:
+    except (OSError, pyvisa.errors.Error) as exc:
         logger.warning(
             "VISA backend %s unavailable (%s); falling back to %s",
             DEFAULT_VISA_BACKEND,

--- a/tests/lib/test_visa_driver.py
+++ b/tests/lib/test_visa_driver.py
@@ -8,7 +8,8 @@ import time
 from unittest.mock import MagicMock, call, patch
 
 import pytest
-from pyvisa.constants import InterfaceType
+import pyvisa
+from pyvisa.constants import VI_ERROR_LIBRARY_NFOUND, InterfaceType
 from pyvisa.constants import Parity as VisaParity
 
 from instro.lib.transports import (
@@ -136,6 +137,18 @@ def test_open_uses_ivi_backend_by_default(mock_pyvisa):
 def test_open_falls_back_to_py_when_ivi_backend_missing(mock_pyvisa):
     rm_class, rm_instance, _ = mock_pyvisa
     rm_class.side_effect = [OSError("Could not locate a VISA implementation"), rm_instance]
+    driver = _make_driver()
+
+    driver.open()
+
+    assert rm_class.call_args_list == [call("@ivi"), call("@py")]
+    assert driver.is_open is True
+
+
+def test_open_falls_back_to_py_when_ivi_library_not_found(mock_pyvisa):
+    """A missing native VISA library surfaces as VisaIOError, not OSError (issue #133)."""
+    rm_class, rm_instance, _ = mock_pyvisa
+    rm_class.side_effect = [pyvisa.errors.VisaIOError(VI_ERROR_LIBRARY_NFOUND), rm_instance]
     driver = _make_driver()
 
     driver.open()


### PR DESCRIPTION
## Summary

A missing native VISA library surfaces as `pyvisa.errors.VisaIOError` (`VI_ERROR_LIBRARY_NFOUND`), whose MRO is `VisaIOError → pyvisa.errors.Error → Exception` — it is **not** an `OSError`. So the `except OSError` in `_open_resource_manager` was skipped and the `@ivi`→`@py` fallback never fired on machines without IVI/NI-VISA installed; `VisaDriver.open()` crashed at ResourceManager construction.

This broadens the `except` to the pyvisa error hierarchy (`pyvisa.errors.Error`, the base of `VisaIOError`) alongside `OSError`.

## Test

Adds `test_open_falls_back_to_py_when_ivi_library_not_found`, which simulates the `@ivi` ResourceManager raising `VisaIOError(VI_ERROR_LIBRARY_NFOUND)` and asserts the driver falls back to `@py` and opens. Verified the test fails against the old `except OSError` and passes with the fix.

Fixes #133