### PR TITLE
fix(ethernetip): disable cpppo UDP in simulator tests

### DIFF
--- a/tests/cpppo_sim_server.py
+++ b/tests/cpppo_sim_server.py
@@ -91,7 +91,7 @@ class CpppoTestServer:
 
         try:
             enip_main(
-                argv=tag_args + ["--address", f"{self.address}:{self.port}"],
+                argv=build_cpppo_argv(tag_args, self.address, self.port),
                 idle_service=idle_sync,
             )
         except KeyboardInterrupt:
@@ -109,12 +109,11 @@ def reserve_local_port(address: str) -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as tcp_sock:
         tcp_sock.bind((address, 0))
         tcp_sock.listen(1)
-        port = tcp_sock.getsockname()[1]
+        return tcp_sock.getsockname()[1]
 
-        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as udp_sock:
-            udp_sock.bind((address, port))
 
-        return port
+def build_cpppo_argv(tag_args: list[str], address: str, port: int) -> list[str]:
+    return tag_args + ["--address", f"{address}:{port}", "--no-udp"]
 
 
 def is_retryable_bind_error(error: Exception | None) -> bool:

--- a/tests/test_cpppo_sim_server.py
+++ b/tests/test_cpppo_sim_server.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 import errno
 
-from tests.cpppo_sim_server import WINDOWS_SOCKET_ACCESS_DENIED, is_retryable_bind_error
+from tests.cpppo_sim_server import (
+    WINDOWS_SOCKET_ACCESS_DENIED,
+    build_cpppo_argv,
+    is_retryable_bind_error,
+)
 
 
 class WindowsSocketAccessDenied(OSError):
@@ -24,3 +28,12 @@ def test_retryable_bind_error_includes_windows_socket_access_denied() -> None:
 
 def test_retryable_bind_error_rejects_other_os_errors() -> None:
     assert not is_retryable_bind_error(OSError(errno.ECONNREFUSED, "connection refused"))
+
+
+def test_cpppo_argv_disables_udp() -> None:
+    assert build_cpppo_argv(["test_dint=DINT"], "127.0.0.1", 12345) == [
+        "test_dint=DINT",
+        "--address",
+        "127.0.0.1:12345",
+        "--no-udp",
+    ]


### PR DESCRIPTION
## Summary
- start the bundled cpppo simulator with --no-udp for explicit-session tests
- stop pre-reserving a UDP socket for the simulator's random local port
- add unit coverage for the cpppo argv

## Verification
- uv run ruff format tests/cpppo_sim_server.py tests/test_cpppo_sim_server.py
- uv run ruff check tests/cpppo_sim_server.py tests/test_cpppo_sim_server.py
- uv run pytest tests/test_cpppo_sim_server.py -q
- cargo test -p instro-ethernetip-rs --test explicit_session_integration