### PR TITLE
docs: point support navbar link to Discourse community

### DIFF
--- a/docs/guides/docs.json
+++ b/docs/guides/docs.json
@@ -204,8 +204,8 @@
   "navbar": {
     "links": [
       {
-        "label": "Support",
-        "href": "https://portal.usepylon.com/nominal"
+        "label": "Community",
+        "href": "https://community.instro.nominal.io"
       }
     ],
     "primary": {


### PR DESCRIPTION
Updates the docs navbar link from the Pylon support portal to our Discourse community page, and relabels it "Community".

In `docs/guides/docs.json`:
- `label`: `Support` → `Community`
- `href`: `https://portal.usepylon.com/nominal` → `https://community.instro.nominal.io`

Closes INSTRO-400