### PR TITLE
fix(dmm): record measurement function only after driver accepts it

### DIFF
--- a/instro/dmm/dmm.py
+++ b/instro/dmm/dmm.py
@@ -218,15 +218,15 @@ class InstroDMM(Instrument):
     @publish_command
     def set_measurement_function(self, function: MeasurementFunction, **kwargs) -> Command:
         """Configure the DMM for ``function`` (DC voltage, resistance, etc.)."""
-        if self._measurement_config is None:
-            self._measurement_config = DMMMeasurementConfig(function)
-        else:
-            self._measurement_config.function = function
-
         logger.debug("Sending DMM set_measurement_function command to '%s'", self.name)
         with self._resource_lock:
             self._driver.set_measurement_function(function)
             timestamp = time.time_ns()
+
+        if self._measurement_config is None:
+            self._measurement_config = DMMMeasurementConfig(function)
+        else:
+            self._measurement_config = replace(self._measurement_config, function=function)
 
         return self._package_command("set_measurement_function.cmd", function.value, timestamp, **kwargs)
 

--- a/tests/dmm/test_instro_dmm.py
+++ b/tests/dmm/test_instro_dmm.py
@@ -329,6 +329,34 @@ def test_nominal_dmm_set_measurement_function_delegates(stub_driver: _StubDMMDri
     assert stub_driver.last_function is MeasurementFunction.DC_VOLTAGE
 
 
+def test_nominal_dmm_set_measurement_function_keeps_config_when_driver_rejects(stub_driver: _StubDMMDriver) -> None:
+    dmm = InstroDMM(name="ut", driver=stub_driver)
+    dmm.set_measurement_function(MeasurementFunction.DC_VOLTAGE)
+
+    stub_driver.set_measurement_function = MagicMock(  # type: ignore[method-assign]
+        side_effect=NotImplementedError("unsupported")
+    )
+    with pytest.raises(NotImplementedError):
+        dmm.set_measurement_function(MeasurementFunction.AC_VOLTAGE)
+
+    # The rejected function must not be recorded: config still reflects the hardware.
+    assert dmm._measurement_config is not None
+    assert dmm._measurement_config.function is MeasurementFunction.DC_VOLTAGE
+
+
+def test_nominal_dmm_first_set_measurement_function_not_recorded_when_driver_rejects(
+    stub_driver: _StubDMMDriver,
+) -> None:
+    dmm = InstroDMM(name="ut", driver=stub_driver)
+    stub_driver.set_measurement_function = MagicMock(  # type: ignore[method-assign]
+        side_effect=NotImplementedError("unsupported")
+    )
+    with pytest.raises(NotImplementedError):
+        dmm.set_measurement_function(MeasurementFunction.AC_VOLTAGE)
+
+    assert dmm._measurement_config is None
+
+
 def test_nominal_dmm_set_aperture_nplc_dispatches_to_function_method(stub_driver: _StubDMMDriver) -> None:
     dmm = InstroDMM(name="ut", driver=stub_driver)
     dmm.set_measurement_function(MeasurementFunction.DC_CURRENT)


### PR DESCRIPTION
## What

`InstroDMM.set_measurement_function` recorded the requested function on `self._measurement_config` *before* calling the driver. If the driver rejected the function (e.g. the Keithley 2400 raising `NotImplementedError` on AC), the HAL was left tracking a function the hardware was never put into — subsequent `read()` / `set_range` / `set_aperture_nplc` calls then dispatched against the wrong function.

This call the driver first, then records state on success (via `replace()`), matching the pattern already used by `set_range` / `set_digits` / `set_aperture_*`.

Fixes #144.

## Changes

- `instro/dmm/dmm.py` — reorder so `_measurement_config` is updated only after the driver call returns.
- `tests/dmm/test_instro_dmm.py` — two regression tests:
  - an existing config is preserved when the driver rejects a new function
  - the first-ever call leaves `_measurement_config` as `None` on rejection

## Test plan

- `just check` — clean (ruff format, mypy, ruff lint).
- `uv run pytest tests/dmm/` — 39 passed (was 37; +2 new regression tests).