### PR TITLE
fix(dmm): apply Agilent34401A manual range without requiring set_digits

### DIFF
--- a/instro/dmm/drivers/agilent_a34401a.py
+++ b/instro/dmm/drivers/agilent_a34401a.py
@@ -66,10 +66,12 @@ class Agilent34401A(DMMDriverBase):
     set_four_wire_resistance_range = _store_range
 
     def _build_meas_cmd(self, base_cmd: str) -> str:
-        """Build ``MEAS:...?`` with ``[range,resolution]`` appended only when both are set."""
-        if self._range is not None and self._resolution is not None:
-            return f"{base_cmd}? {self._range:.6e},{self._resolution:.6e}"
-        return f"{base_cmd}?"
+        """Build ``MEAS:...?`` appending range when set, and resolution when set alongside it."""
+        if self._range is None:
+            return f"{base_cmd}?"
+        if self._resolution is None:
+            return f"{base_cmd}? {self._range:.6e}"
+        return f"{base_cmd}? {self._range:.6e},{self._resolution:.6e}"
 
     def measure_dc_voltage(self) -> float:
         return self._query_checked_float(self._build_meas_cmd("MEAS:VOLT:DC"))

--- a/tests/dmm/test_instro_dmm.py
+++ b/tests/dmm/test_instro_dmm.py
@@ -85,6 +85,17 @@ def test_agilent_measure_with_range_and_resolution_includes_params(
     assert "1.000000e-05" in cmd
 
 
+def test_agilent_measure_with_range_only_appends_range(agilent: Agilent34401A, agilent_visa: MagicMock) -> None:
+    # Range set without set_digits must still reach the wire (issue #145).
+    agilent.set_dc_voltage_range(10.0)
+    agilent_visa.query.side_effect = ["0.5", '0,"No error"']
+
+    agilent.measure_dc_voltage()
+
+    cmd = agilent_visa.query.call_args_list[0].args[0]
+    assert cmd == "MEAS:VOLT:DC? 1.000000e+01"
+
+
 def test_agilent_per_function_range_methods_share_state(agilent: Agilent34401A) -> None:
     # The 34401A applies one shared range cache regardless of function. All
     # per-function range setters should write to the same private slot.


### PR DESCRIPTION
## Problem

`Agilent34401A._build_meas_cmd` only appended the manual range when *both* the range and resolution caches were set. Since `_resolution` is set only by `set_digits`, a user who called `set_range(10.0)` without also calling `set_digits(...)` got the plain `MEAS:VOLT:DC?` form — the instrument stayed in autorange and the requested manual range never reached the wire. Meanwhile `InstroDMM.set_range` had already published `range_mode.cmd = MANUAL`, so the HAL reported a manual range that was not in effect.

The 34401A accepts range without resolution (`MEAS:VOLT:DC? 10` is valid — resolution defaults), so the both-or-neither coupling was an unnecessary limitation rather than a SCPI requirement.

## Fix

Append the range whenever it is set, and resolution only when set alongside it. Resolution-without-range is not expressible in `MEAS?` and is not a valid case.

## Tests

Added `test_agilent_measure_with_range_only_appends_range` asserting `set_range` alone produces `MEAS:VOLT:DC? 1.000000e+01`. `just check` and `uv run pytest tests/dmm/` pass.

Closes #145