### PR TITLE
fix!: 149 bug documentation for get channel does not match behavior

### DIFF
--- a/docs/guides/instrumentation/daq.mdx
+++ b/docs/guides/instrumentation/daq.mdx
@@ -360,7 +360,7 @@ while True:
         sensor_1 = daq.get_channel(
             channel_name = "myDAQ.sensor_1",
             length = 10,
-            wait_for_latest = True)  # This will block for the next 10 samples from the background daemon
+            wait_for_new_samples = True)  # This will block for the next 10 samples from the background daemon
         print("Stopping acquisition")
         break
     except KeyboardInterrupt:

--- a/docs/guides/instrumentation/eload.mdx
+++ b/docs/guides/instrumentation/eload.mdx
@@ -173,11 +173,11 @@ while True:
         ch1_voltage = eload.get_channel(
             channel_name = "myELoad.ch1.voltage",
             length = 1,
-            wait_for_latest = True)  # This will block for the next sample from the background daemon
+            wait_for_new_samples = True)  # This will block for the next sample from the background daemon
         ch1_current = eload.get_channel(
             channel_name = "myELoad.ch1.current",
             length = 5,
-            wait_for_latest = False)  # This will immediately return with the last 5 measurements for this channel (if available).
+            wait_for_new_samples = False)  # This will immediately return with the last 5 measurements for this channel (if available).
 
     except KeyboardInterrupt:
         print("Stopping...")

--- a/docs/guides/instrumentation/protocols/modbus.mdx
+++ b/docs/guides/instrumentation/protocols/modbus.mdx
@@ -895,7 +895,7 @@ finally:
 | `read(alias, **kwargs)` | Read a register by alias, apply scaling, return `Measurement` |
 | `write(alias, value, **kwargs)` | Write a value to a register by alias (accepts strings for `write_value_map` registers), apply reverse scaling, return `Command` |
 | `unit_id` | Property: returns the Modbus unit/slave ID from config |
-| `get_channel(channel_name, length=1, wait_for_latest=False, timeout=10.0)` | Retrieve buffered poll data for a channel |
+| `get_channel(channel_name, length=1, wait_for_new_samples=False, timeout=10.0)` | Retrieve buffered poll data for a channel |
 | `start()` | Start background polling daemon |
 | `stop()` | Stop background polling daemon |
 

--- a/docs/guides/instrumentation/psu.mdx
+++ b/docs/guides/instrumentation/psu.mdx
@@ -161,11 +161,11 @@ while True:
         ch1_voltage = psu.get_channel(
             channel_name = "myPSU.ch1.voltage",
             length = 1,
-            wait_for_latest = True)  # This will block for the next sample from the background daemon
+            wait_for_new_samples = True)  # This will block for the next sample from the background daemon
         ch1_current = psu.get_channel(
             channel_name = "myPSU.ch1.current",
             length = 5,
-            wait_for_latest = False)  # This will immediately return with the last 5 measurements for this channel (if available).
+            wait_for_new_samples = False)  # This will immediately return with the last 5 measurements for this channel (if available).
         print(f"Voltage, Channel 1: {ch1_voltage}")
         print(f"Current, Channel 1: {ch1_current}")
     except KeyboardInterrupt:

--- a/instro/lib/instrument.py
+++ b/instro/lib/instrument.py
@@ -336,7 +336,6 @@ class Instrument:
 
         return None
 
-
     def _background_daemon_loop(self):
         """Daemon loop: run registered functions every ``background_interval``, publish loop timing."""
         while not self._background_stop_event.is_set():

--- a/instro/lib/instrument.py
+++ b/instro/lib/instrument.py
@@ -294,15 +294,19 @@ class Instrument:
     ) -> Measurement:
         """Return the most recent ``length`` samples for ``channel_name`` from the in-memory buffer.
 
+        If the channel does not exist yet, or no sample is available, the code will always block until ``timeout`` expires.
+
         Args:
             channel_name: Name of the channel to retrieve.
             length: Number of trailing samples to return.
             wait_for_latest: Block until at least ``length`` new values arrive.
-            timeout: Seconds to wait when ``wait_for_latest=True``.
+            timeout: Seconds to wait when insufficient data exists or ``wait_for_latest=True``.
 
         Raises:
             RuntimeError: No background buffer; ``start()`` was not called.
-            ChannelNotFoundTimeoutError: ``wait_for_latest=True`` and channel did not appear within ``timeout``.
+            ChannelNotFoundError:
+                channel had no values and no data appeared before ``timeout``.
+                ``wait_for_latest=True`` and channel did not appear within ``timeout``.
             ChannelValueTimeoutError: ``wait_for_latest=True`` and values did not arrive within ``timeout``.
         """
         if self._background_thread and self._background_thread.is_alive():

--- a/instro/lib/instrument.py
+++ b/instro/lib/instrument.py
@@ -315,6 +315,28 @@ class Instrument:
 
         raise RuntimeError("No channel buffer exists. Ensure start() was called on this instrument.")
 
+    def get_single_channel_value(self, channel_name: str) -> float | None:
+        """Return the most recent sample for ``channel_name`` from the in-memory buffer.
+
+        This will not wait, if data is not available then ``None`` is returned.
+
+        Args:
+            channel_name: Name of the channel to retrieve.
+
+        Raises:
+            RuntimeError: No background buffer; ``start()`` was not called.
+        """
+        try:
+            cached_measurement = self.get_channel(channel_name, length=1, wait_for_latest=False, timeout=0)
+            return cached_measurement.channel_data[channel_name][0]
+        except RuntimeError:  # expect: this means instrument not started, good to report
+            raise
+        except:  # other exceptions just mean data isn't available
+            pass
+
+        return None
+
+
     def _background_daemon_loop(self):
         """Daemon loop: run registered functions every ``background_interval``, publish loop timing."""
         while not self._background_stop_event.is_set():

--- a/instro/lib/instrument.py
+++ b/instro/lib/instrument.py
@@ -290,7 +290,7 @@ class Instrument:
             logger.info("Background daemon not running for instrument '%s'; stop() is a no-op", self.name)
 
     def get_channel(
-        self, channel_name: str, length: int = 1, wait_for_latest: bool = False, timeout: float = 10.0
+        self, channel_name: str, length: int = 1, wait_for_new_samples: bool = False, timeout: float = 10.0
     ) -> Measurement:
         """Return the most recent ``length`` samples for ``channel_name`` from the in-memory buffer.
 
@@ -299,19 +299,19 @@ class Instrument:
         Args:
             channel_name: Name of the channel to retrieve.
             length: Number of trailing samples to return.
-            wait_for_latest: Block until at least ``length`` new values arrive.
-            timeout: Seconds to wait when insufficient data exists or ``wait_for_latest=True``.
+            wait_for_new_samples: Block until at least ``length`` new values arrive.
+            timeout: Seconds to wait when insufficient data exists or ``wait_for_new_samples=True``.
 
         Raises:
             RuntimeError: No background buffer; ``start()`` was not called.
             ChannelNotFoundError:
                 channel had no values and no data appeared before ``timeout``.
-                ``wait_for_latest=True`` and channel did not appear within ``timeout``.
-            ChannelValueTimeoutError: ``wait_for_latest=True`` and values did not arrive within ``timeout``.
+                ``wait_for_new_samples=True`` and channel did not appear within ``timeout``.
+            ChannelValueTimeoutError: ``wait_for_new_samples=True`` and values did not arrive within ``timeout``.
         """
         if self._background_thread and self._background_thread.is_alive():
             assert self._channel_buffer
-            return self._channel_buffer.get(channel_name, length, wait_for_latest, timeout)
+            return self._channel_buffer.get(channel_name, length, wait_for_new_samples, timeout)
 
         raise RuntimeError("No channel buffer exists. Ensure start() was called on this instrument.")
 
@@ -327,7 +327,7 @@ class Instrument:
             RuntimeError: No background buffer; ``start()`` was not called.
         """
         try:
-            cached_measurement = self.get_channel(channel_name, length=1, wait_for_latest=False, timeout=0)
+            cached_measurement = self.get_channel(channel_name, length=1, wait_for_new_samples=False, timeout=0)
             return cached_measurement.channel_data[channel_name][0]
         except RuntimeError:  # expect: this means instrument not started, good to report
             raise

--- a/instro/lib/publishers/channel_buffer.py
+++ b/instro/lib/publishers/channel_buffer.py
@@ -67,11 +67,11 @@ class ChannelBufferPublisher(ABC):
                 self._condition.notify_all()
 
     def get(
-        self, channel_name: str, length: int = 1, wait_for_latest: bool = False, timeout: float = 10.0
+        self, channel_name: str, length: int = 1, wait_for_new_samples: bool = False, timeout: float = 10.0
     ) -> Measurement:
         """Return the trailing ``length`` samples for ``channel_name``.
 
-        With ``wait_for_latest=True`` blocks for new samples; otherwise waits for
+        With ``wait_for_new_samples=True`` blocks for ``length`` new samples; otherwise waits for
         the buffer to already hold ``length``.
 
         Raises:
@@ -79,7 +79,7 @@ class ChannelBufferPublisher(ABC):
             ChannelValueTimeoutError: Values did not arrive within ``timeout``.
         """
         start_time = time.monotonic()
-        if wait_for_latest:
+        if wait_for_new_samples:
             # Wait for channel to exist if it doesn't exist yet
             if channel_name not in self._values:
                 with self._condition:

--- a/packages/instro-unstable/instro/unstable/scope/examples/scope_background.py
+++ b/packages/instro-unstable/instro/unstable/scope/examples/scope_background.py
@@ -5,14 +5,13 @@ Vrms, Vpp, and Frequency on channel 1 while printing results in a main loop.
 
 """
 
+from instro.lib.publishers import NominalCorePublisher
 from instro.unstable.scope import (
     InstroScope,
     ScopeMeasurementType,
 )
 from instro.unstable.scope.drivers.keysight import Keysight1200X
 from instro.unstable.scope.types import AcquisitionMode, Coupling, TriggerMode, TriggerSlope, TriggerType
-
-from instro.lib.publishers import NominalCorePublisher
 
 VISA_RESOURCE = "USB0::10893::923::CN64191203::INSTR"
 DATASET_RID = "ri.catalog.cerulean-staging.dataset.50a647a4-0d00-460c-9898-4c282adfe7a4"

--- a/packages/instro-unstable/instro/unstable/scope/examples/scope_background.py
+++ b/packages/instro-unstable/instro/unstable/scope/examples/scope_background.py
@@ -5,13 +5,14 @@ Vrms, Vpp, and Frequency on channel 1 while printing results in a main loop.
 
 """
 
-from instro.lib.publishers import NominalCorePublisher
 from instro.unstable.scope import (
     InstroScope,
     ScopeMeasurementType,
 )
 from instro.unstable.scope.drivers.keysight import Keysight1200X
 from instro.unstable.scope.types import AcquisitionMode, Coupling, TriggerMode, TriggerSlope, TriggerType
+
+from instro.lib.publishers import NominalCorePublisher
 
 VISA_RESOURCE = "USB0::10893::923::CN64191203::INSTR"
 DATASET_RID = "ri.catalog.cerulean-staging.dataset.50a647a4-0d00-460c-9898-4c282adfe7a4"
@@ -60,7 +61,7 @@ try:
     # --- Main loop: read back measurements and print ---
     while True:
         try:
-            vrms = scope.get_channel("scope.ch1.vrms", length=1, wait_for_latest=True)
+            vrms = scope.get_channel("scope.ch1.vrms", length=1, wait_for_new_samples=True)
             vpp = scope.get_channel("scope.ch1.vpp", length=1)
             freq = scope.get_channel("scope.ch1.frequency", length=1)
 


### PR DESCRIPTION
## Summary

fix: closes #149. First, updates documentation about timeout behavior.

addition: non-breaking new function which wraps get_channel and simply returns a single float or none for simple use cases, rather than a full Measurement object.

breaking: renamed "wait for latest" to "wait for new samples" to better reflect the purpose of the flag. Has the most impacts, but still fairly staightforward to resolve. Can easily reverse this.

## Type of change

- [x] Bug fix (`fix`)
- [ ] New feature (`feat`)
- [x] Breaking change (`feat!` / `fix!`)
- [ ] Refactor (`refactor`)
- [x] Documentation (`docs`)
- [ ] Chore / tooling (`chore`)

## Verification

Inspection (ctrl+f, ctrl+r) only

## Tests

- [ ] Unit tests added or updated
- [x] Existing tests cover this change
- [ ] No tests — explain why:

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(driver): add support for Keysight E36300`)
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] Documentation updated if user-facing behavior changed
- [x] Code follows the style/conventions of the surrounding code

## Notes for reviewers

Tell me if you want me to revert the third commit. Its "breaking" but...