### PR TITLE
feat(instrument): auto-prepend instrument name in get_channel

### DIFF
--- a/instro/lib/instrument.py
+++ b/instro/lib/instrument.py
@@ -307,6 +307,8 @@ class Instrument:
         """
         if self._background_thread and self._background_thread.is_alive():
             assert self._channel_buffer
+            if not channel_name.startswith(f"{self.name}."):
+                channel_name = f"{self.name}.{channel_name}"
             return self._channel_buffer.get(channel_name, length, wait_for_latest, timeout)
 
         raise RuntimeError("No channel buffer exists. Ensure start() was called on this instrument.")

--- a/uv.lock
+++ b/uv.lock
@@ -465,7 +465,7 @@ wheels = [
 
 [[package]]
 name = "instro"
-version = "0.12.0"
+version = "0.12.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastavro", extra = ["snappy"] },
@@ -635,7 +635,7 @@ requires-dist = [
 
 [[package]]
 name = "instro-ethernetip"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "packages/instro-ethernetip" }
 dependencies = [
     { name = "instro" },
@@ -661,7 +661,7 @@ requires-dist = [
 
 [[package]]
 name = "instro-unstable"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "packages/instro-unstable" }
 dependencies = [
     { name = "instro" },


### PR DESCRIPTION
If a caller passes a bare channel name (e.g. 'ch0_voltage'), get_channel now prepends 'self.name.' automatically so they don't have to know the published key format. Fully-qualified names are passed through unchanged.

Closes #147

## Summary

_Briefly describe what this PR does and why. If it fixes an existing issue, link it (e.g. `Fixes #123`)._

## Type of change

- [ ] Bug fix (`fix`)
- [x] New feature (`feat`)
- [ ] Breaking change (`feat!` / `fix!`)
- [ ] Refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] Chore / tooling (`chore`)

## Verification

_How did you verify this change works? Provide evidence the reviewer can evaluate without reproducing your setup — e.g. test output, screenshots, logs, repro steps + result. If the change is hardware-specific and you don't have the device, say so._

## Tests

- [ ] Unit tests added or updated
- [x] Existing tests cover this change
- [ ] No tests — explain why:

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(driver): add support for Keysight E36300`)
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] Documentation updated if user-facing behavior changed
- [x] Code follows the style/conventions of the surrounding code

## Notes for reviewers

Corner case where behavior could be unintended: user calls get_channel("instroment.ch1.voltage") when their instrument is instrument. Thus, the error returned would say "couldnt find channel instrument.instroment.ch1.voltage". If thats not OK we should reject this.