### PR TITLE
fix(transports): disable Nagle on raw TCP sockets for pyvisa-py

### DIFF
--- a/docs/guides/instrumentation/transports/visa.mdx
+++ b/docs/guides/instrumentation/transports/visa.mdx
@@ -108,6 +108,10 @@ When the VISA resource is an ASRL (RS-232 / RS-485) interface, `VisaDriver` appl
 
 `VisaConfig.visa_backend` selects which pyvisa backend handles the resource. Most callers should leave it unset. When unset (`None`), `instro` uses the system IVI VISA implementation (`"@ivi"`, e.g. NI-VISA or Keysight IO Libraries) and automatically falls back to the pure-Python `"@py"` backend when no IVI implementation is installed. Setting `visa_backend` to any explicit value (such as `"@ivi"`, `"@py"`, or `"@sim"`) uses that backend as-is, with no fallback.
 
+### Raw TCP Sockets and Nagle's Algorithm
+
+For raw `TCPIP...::SOCKET` resources, `VisaDriver` disables Nagle's algorithm (`TCP_NODELAY`) on `open()`. IVI backends already do this by default, but the pure-Python `"@py"` backend does not, so on `"@py"` it would otherwise leave Nagle enabled. With Nagle on, several small back-to-back SCPI writes can be coalesced into one TCP segment, and some instruments' lightweight LAN firmware resets the connection when that happens. Disabling it makes the `"@py"` SOCKET path behave like IVI. Set `VisaConfig(tcp_nodelay=False)` to opt out; it has no effect on non-socket transports.
+
 ## Building a Custom Driver
 
 The intended use of `VisaDriver` is as an internal transport inside a vendor-specific instrument driver. `instro`'s shipped SCPI drivers all follow the same shape: take a `str | VisaConfig` in the constructor, store a `VisaDriver`, and delegate `open()` / `close()` and all I/O to it.
@@ -243,6 +247,7 @@ Top-level connection parameters.
 | `serial_config` | No | `SerialConfig()` | Serial settings, applied only when the resource is an ASRL interface |
 | `terminator` | No | `TerminatorConfig()` | Read and write terminators |
 | `timeout` | No | `TimeoutConfig()` | Operation timeouts |
+| `tcp_nodelay` | No | `True` | Disable Nagle's algorithm on raw TCP SOCKET connections. No effect on non-socket transports |
 
 ### `TerminatorConfig`
 

--- a/instro/lib/transports/visa.py
+++ b/instro/lib/transports/visa.py
@@ -6,6 +6,7 @@ import contextlib
 import dataclasses
 import enum
 import logging
+import socket
 import threading
 import typing
 
@@ -96,6 +97,10 @@ class VisaConfig:
             ASRL (RS-232/RS-485) interface.
         terminator: Read and write terminators.
         timeout: Operation timeouts.
+        tcp_nodelay: Disable Nagle's algorithm on raw TCP SOCKET connections.
+            NI-VISA does this by default; pyvisa-py does not, which can wedge
+            instruments that reset on coalesced writes (issue #156). No effect
+            on non-socket transports. Defaults to ``True``.
     """
 
     visa_resource: str
@@ -103,6 +108,7 @@ class VisaConfig:
     serial_config: SerialConfig = dataclasses.field(default_factory=SerialConfig)
     terminator: TerminatorConfig = dataclasses.field(default_factory=TerminatorConfig)
     timeout: TimeoutConfig = dataclasses.field(default_factory=TimeoutConfig)
+    tcp_nodelay: bool = True
 
 
 class VisaDriver:
@@ -299,6 +305,9 @@ def _configure_resource(
     inst.write_termination = cfg.terminator.write
     inst.timeout = cfg.timeout.recv * 1000
 
+    if cfg.tcp_nodelay:
+        _disable_nagle(inst)
+
     if inst.interface_type != InterfaceType.asrl:
         return
 
@@ -308,6 +317,27 @@ def _configure_resource(
     inst.stop_bits = int(serial.stop_bits.value * 10)  # type: ignore[attr-defined]
     inst.parity = _PARITY_MAP[serial.parity]  # type: ignore[attr-defined]
     inst.flow_control = serial.flow_control  # type: ignore[attr-defined]
+
+
+def _disable_nagle(inst: pyvisa.resources.MessageBasedResource) -> None:
+    """Turn off Nagle on a raw TCP socket. NI-VISA does this by default; pyvisa-py does not (issue #156)."""
+    sock = _pyvisa_py_socket(inst)
+    if sock is None:
+        return
+    try:
+        sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+    except OSError as exc:
+        logger.warning("Could not disable Nagle (TCP_NODELAY) on %s: %s", inst.resource_name, exc)
+
+
+def _pyvisa_py_socket(inst: pyvisa.resources.MessageBasedResource) -> socket.socket | None:
+    """Return the raw socket backing a pyvisa-py TCPIP SOCKET session, else None (e.g. NI-VISA, serial)."""
+    sessions = getattr(getattr(inst, "visalib", None), "sessions", None)
+    if not isinstance(sessions, dict):
+        return None
+    session = sessions.get(getattr(inst, "session", None))
+    sock = getattr(session, "interface", None)
+    return sock if isinstance(sock, socket.socket) else None
 
 
 def _coerce_connection_config(visa_resource: str | VisaConfig) -> VisaConfig:

--- a/tests/lib/test_visa_driver.py
+++ b/tests/lib/test_visa_driver.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import importlib.util
+import socket
 import threading
 import time
+from types import SimpleNamespace
 from unittest.mock import MagicMock, call, patch
 
 import pytest
@@ -31,6 +33,7 @@ def _make_config(
     serial_config: SerialConfig | None = None,
     terminator: TerminatorConfig | None = None,
     timeout: TimeoutConfig | None = None,
+    tcp_nodelay: bool = True,
 ) -> VisaConfig:
     kwargs = {} if visa_backend is None else {"visa_backend": visa_backend}
     return VisaConfig(
@@ -38,6 +41,7 @@ def _make_config(
         serial_config=serial_config or SerialConfig(),
         terminator=terminator or TerminatorConfig(read="\n", write="\r\n"),
         timeout=timeout or TimeoutConfig(connect=30, recv=15, send=15),
+        tcp_nodelay=tcp_nodelay,
         **kwargs,
     )
 
@@ -280,6 +284,45 @@ def test_open_applies_serial_config_for_asrl(mock_pyvisa):
     assert resource.stop_bits == 10
     assert resource.parity == VisaParity.space
     assert resource.flow_control == ControlFlow.NONE
+
+
+def _attach_pyvisa_py_socket(resource: MagicMock, sock: object) -> None:
+    """Make a mocked resource look like a pyvisa-py session whose .interface is ``sock``."""
+    resource.session = "sess"
+    resource.visalib.sessions = {"sess": SimpleNamespace(interface=sock)}
+
+
+def test_open_disables_nagle_on_pyvisa_py_socket(mock_pyvisa):
+    _, _, resource = mock_pyvisa
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    _attach_pyvisa_py_socket(resource, sock)
+    try:
+        _make_driver().open()
+        assert sock.getsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY) == 1
+    finally:
+        sock.close()
+
+
+def test_open_leaves_nagle_untouched_when_tcp_nodelay_false(mock_pyvisa):
+    _, _, resource = mock_pyvisa
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    _attach_pyvisa_py_socket(resource, sock)
+    try:
+        _make_driver(_make_config(tcp_nodelay=False)).open()
+        assert sock.getsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY) == 0
+    finally:
+        sock.close()
+
+
+def test_open_ignores_non_socket_backend_interface(mock_pyvisa):
+    # NI-VISA has no pyvisa-py sessions dict; a non-socket .interface must be skipped without error.
+    _, _, resource = mock_pyvisa
+    _attach_pyvisa_py_socket(resource, object())
+
+    driver = _make_driver()
+    driver.open()
+
+    assert driver.is_open is True
 
 
 def test_write_when_not_open_raises():

--- a/tests/lib/test_visa_driver.py
+++ b/tests/lib/test_visa_driver.py
@@ -298,7 +298,8 @@ def test_open_disables_nagle_on_pyvisa_py_socket(mock_pyvisa):
     _attach_pyvisa_py_socket(resource, sock)
     try:
         _make_driver().open()
-        assert sock.getsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY) == 1
+        # macOS reads TCP_NODELAY back as a non-1 truthy value; assert "enabled", not literally 1.
+        assert sock.getsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY) != 0
     finally:
         sock.close()
 


### PR DESCRIPTION
## Summary

Fixes a raw-socket transport bug where `VisaDriver` over the pure-Python pyvisa-py (`@py`) backend could wedge an instrument's LAN interface.

pyvisa-py never sets `TCP_NODELAY` on raw `TCPIP...::SOCKET` sessions, so **Nagle's algorithm stays enabled**. When a driver issues several small SCPI writes back-to-back (e.g. `INST 0`, `CURR 0.100`, `SYST:ERR?` — one `send()` each), Nagle + delayed-ACK coalesce them into one TCP segment, and some instruments' lightweight LAN firmware resets the connection. **NI-VISA disables Nagle by default**, which is why the IVI backend is unaffected.

`VisaDriver.open()` now sets `TCP_NODELAY` on the underlying pyvisa-py socket. It is a no-op on NI-VISA (already nodelay) and on non-socket transports. A new `VisaConfig.tcp_nodelay` toggle (default `True`) lets callers opt out.

The VISA-attribute route (`set_visa_attribute(VI_ATTR_TCPIP_NODELAY, …)`) is **not** used because it raises `UnknownAttribute` on pyvisa-py's socket session; the fix reaches the socket directly via `setsockopt`.

## Why this is safe across backends

- **pyvisa-py SOCKET**: the raw socket is found and `TCP_NODELAY` is set to 1.
- **NI-VISA / IVI**: no pyvisa-py `sessions` dict, so the helper returns `None` and does nothing — NI-VISA already disables Nagle by default.
- **Serial / USB / non-socket**: the backing object isn't a `socket.socket`, so it's skipped.

## Evidence

Verified on a B&K 9141 over `TCPIP0::<host>::5025::SOCKET` with a within-connection A/B (one socket, only `TCP_NODELAY` changes):

- default `TCP_NODELAY` = `0` (Nagle on)
- Nagle **OFF** (`=1`): the exact burst that previously reset ran **15/15 cycles stable**
- Nagle **ON** (`=0`, flipped on the same socket): **failed on cycle 1**

Full root-cause analysis and reproduction are in #156.

## Tests

- `test_open_disables_nagle_on_pyvisa_py_socket` — sets `TCP_NODELAY=1` on a real socket exposed through a mocked pyvisa-py session.
- `test_open_leaves_nagle_untouched_when_tcp_nodelay_false` — `tcp_nodelay=False` leaves it at 0.
- `test_open_ignores_non_socket_backend_interface` — non-socket `.interface` is skipped without error (NI-VISA / serial path).

`just check` clean; `uv run pytest` 993 passed (the one unrelated failure is the pre-existing `examples/**` glob picking up a git-ignored local `.claude/settings.local.json`).

## Docs

`docs/guides/instrumentation/transports/visa.mdx`: added the `tcp_nodelay` field to the `VisaConfig` table and a "Raw TCP Sockets and Nagle's Algorithm" note.

## Follow-up

Once the bench unit is back up, validate by running the BK914X hardware suite over `@py` SOCKET on this branch — it should pass where it previously wedged the LAN interface.

Closes #156
