### PR TITLE
refactor(opcua): storage of node hierarchy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,6 +114,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "bstr"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f7dc094d718f2e1c1559ad110e27eeaae14a5465d3d56dd6dbd793079fbd530"
+dependencies = [
+ "memchr",
+ "serde_core",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -381,6 +391,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "globset"
+version = "0.4.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e47d37d2ae4464254884b60ab7071be2b876a9c35b696bd018ddcc76847309cd"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -468,6 +491,7 @@ dependencies = [
  "anyhow",
  "base64",
  "futures-util",
+ "globset",
  "instro-opcua-test",
  "instro-test-utils",
  "itertools",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ rust-version = "1.93"
 
 [workspace.dependencies]
 base64 = "0.22"
-uuid = "1"
+uuid = { version = "1", features = ["serde"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 anyhow = "1"
@@ -23,6 +23,7 @@ itertools = "0.13"
 open62541 = { version = "0.12", features = ["mbedtls", "x509"] }
 open62541-sys = { version = "0.6", features = ["mbedtls"] }
 futures-util = "0.3"
+globset = "0.4"
 instro-opcua-test = { path = "crates/instro-opcua-test" }
 instro-test-utils = { path = "crates/instro-test-utils" }
 

--- a/crates/instro-opcua/Cargo.toml
+++ b/crates/instro-opcua/Cargo.toml
@@ -27,6 +27,7 @@ open62541.workspace = true
 open62541-sys.workspace = true
 uuid.workspace = true
 futures-util.workspace = true
+globset.workspace = true
 
 # private
 time = { version = "0.3", features = [

--- a/crates/instro-opcua/README.md
+++ b/crates/instro-opcua/README.md
@@ -9,8 +9,8 @@ This crate is the pure-Rust OPC UA core for instro. It wraps `open62541` with in
 ```toml
 [dependencies]
 anyhow = "1"
-instro-opcua = "0.1"
-open62541 = { version = "0.10", features = ["mbedtls", "x509"] }
+instro-opcua = "1"
+open62541 = { version = "0.12", features = ["mbedtls", "x509"] }
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ```
 
@@ -19,10 +19,10 @@ tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 ## Usage
 
 ```rust
-use instro_opcua::browse::BrowseAll as _;
+use instro_opcua::browse::OpcUaBrowseOptions;
 use instro_opcua::client::{OpcUaClientBuilder, OpcUaNodeReadBatch};
 use instro_opcua::types::{
-    OpcUaNodeId, OpcUaPki, OpcUaSecurityMode, OpcUaSecurityPolicy, OpcUaUserToken,
+    OpcUaPki, OpcUaSecurityMode, OpcUaSecurityPolicy, OpcUaUserToken,
 };
 use open62541::ua;
 
@@ -34,18 +34,28 @@ fn main() -> anyhow::Result<()> {
         .pki(OpcUaPki::None)
         .connect("opc.tcp://127.0.0.1:4840")?;
 
-    let node_id: OpcUaNodeId = "ns=0;i=85".parse()?;
-    let nodes = client.browse_all(node_id, Some(2));
-
     let runtime = tokio::runtime::Runtime::new()?;
-    let nodes = runtime.block_on(nodes)?;
-    let batch = OpcUaNodeReadBatch::new(nodes, ua::AttributeId::VALUE);
-    let samples = runtime.block_on(client.read_nodes(&batch))?;
+    let graph = runtime.block_on(client.browse_root(OpcUaBrowseOptions::new()))?;
+    let variables = graph
+        .find_all("/Objects/**/{Temperature,Pressure*}")?
+        .variables()
+        .leaves();
+    let batch = OpcUaNodeReadBatch::new(variables.read_targets(), ua::AttributeId::VALUE);
+    let outcomes = runtime.block_on(client.read_nodes(&batch))?;
+    let samples = outcomes.into_iter().collect::<anyhow::Result<Vec<_>>>()?;
 
     println!("read {} samples", samples.len());
     runtime.block_on(client.disconnect())
 }
 ```
+
+`browse_root` eagerly returns one immutable route graph including the standard Root route at `/`. Queries remain tied to that graph and are reusable: `routes()` can be iterated repeatedly, while `find_all`, `variables`, and `leaves` return another reusable selection. Glob segments use globset's full grammar; a whole `**` segment recursively matches zero or more route segments.
+
+All browse paths are rooted and absolute. `browse_path(path, options)` resolves every matching route from `/`, while `browse_from(node_id, path, options)` reads the node metadata and requires the asserted mount path to end in its actual browse name. `/` is reserved for the standard Root node; empty and relative paths are rejected when parsed.
+
+All forward hierarchical references are expanded regardless of node class. Diamonds, duplicate node IDs, duplicate paths, and server order are preserved as routes, while each NodeId's complete continuation-drained child snapshot is fetched once per operation. An ancestry cycle inserts a terminal `Cycle` route and continues with siblings. Routes stopped by `max_depth` are `DepthLimited`; only fully `Expanded` routes with no children are leaves.
+
+Browse operations have no hidden route or fetch ceiling. Use `OpcUaBrowseOptions::with_max_depth` when the caller needs an explicit limit.
 
 ## Development
 

--- a/crates/instro-opcua/src/browse.rs
+++ b/crates/instro-opcua/src/browse.rs
@@ -1,958 +1,1041 @@
-//! Recursive browsing of an OPC-UA server's address space.
-//!
-//! The [`Browse`] trait defines a single-level browse that returns the immediate
-//! children of a given node. [`BrowseAll`] extends any `Browse` implementor
-//! with a recursive depth-first traversal that:
-//!
-//! - **Detects cycles** via the current ancestor path — diamonds are preserved,
-//!   but a node ID already present in its own ancestry is reported as an error.
-//! - **Limits depth** with an optional `max_depth` parameter.
-//! - **Limits total browsed nodes** with a high defensive ceiling.
-//! - **Recurses into `Object` and `Variable` nodes** — `Method`, `View`, and
-//!   type nodes are kept as leaves.
-//!
-//! The [`OpcUaClient`](super::client::OpcUaClient) implementation of `Browse`
-//! handles continuation points transparently, issuing `browse_next` calls until
-//! all references for a node have been collected.
+//! Immutable OPC UA browse graphs and reusable local queries.
 
+use std::collections::HashMap;
 use std::collections::HashSet;
-use std::future::Future;
-use std::pin::Pin;
+use std::fmt;
+use std::sync::Arc;
 
 use anyhow::Context as _;
 use anyhow::Result;
 use anyhow::bail;
+use globset::GlobBuilder;
+use globset::GlobMatcher;
 use open62541::ua;
 
-use super::client::OpcUaClient;
-use super::types::BrowsePath;
-use super::types::OpcUaNode;
-use super::types::OpcUaNodeClass;
-use super::types::OpcUaNodeId;
-use super::types::QualifiedBrowseName;
+use crate::client::OpcUaClient;
+use crate::path::OpcUaBrowseName;
+use crate::path::OpcUaBrowsePath;
+use crate::path::split_absolute_segments;
+use crate::path::split_namespace_prefix;
+use crate::types::OpcUaNode;
+use crate::types::OpcUaNodeClass;
+use crate::types::OpcUaNodeId;
+use crate::types::OpcUaNodeReadTarget;
 
-const DEFAULT_MAX_BROWSE_NODES: usize = 1_000_000;
+const ROOT_NODE_ID: OpcUaNodeId = OpcUaNodeId::numeric(0, 84);
 
-/// A trait for browsing a single node and returning its children.
-pub trait Browse {
-    /// Browse a single node and return its children.
-    fn browse_node(&self, node_id: OpcUaNodeId) -> impl Future<Output = Result<Vec<OpcUaNode>>>;
+/// Options shared by recursive browse operations.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[non_exhaustive]
+pub struct OpcUaBrowseOptions {
+    /// Maximum number of edges below each selected start route.
+    pub max_depth: Option<usize>,
 }
 
-/// A trait for browsing all nodes in a subtree and returning a list of all nodes.
-pub trait BrowseAll: Browse {
-    /// Browse all nodes in the subtree rooted at `node_id` and return a list of all nodes.
-    ///
-    /// The result is a nested tree of [`OpcUaNode`]. A repeated [`OpcUaNodeId`] is
-    /// allowed when reached through a different parent path, but a node ID that
-    /// repeats in the current ancestry is treated as a cycle and returns an error.
-    fn browse_all(
-        &self,
-        node_id: OpcUaNodeId,
-        max_depth: Option<usize>,
-    ) -> impl Future<Output = Result<Vec<OpcUaNode>>>;
-
-    /// Browse all nodes below `node_id`, assigning returned children under
-    /// `parent_path`.
-    fn browse_all_from_path(
-        &self,
-        node_id: OpcUaNodeId,
-        parent_path: BrowsePath,
-        max_depth: Option<usize>,
-    ) -> impl Future<Output = Result<Vec<OpcUaNode>>>;
-}
-
-impl<T: Browse> BrowseAll for T {
-    async fn browse_all(
-        &self,
-        node_id: OpcUaNodeId,
-        max_depth: Option<usize>,
-    ) -> Result<Vec<OpcUaNode>> {
-        self.browse_all_from_path(node_id, BrowsePath::default(), max_depth)
-            .await
+impl OpcUaBrowseOptions {
+    /// Creates options with no depth limit.
+    pub const fn new() -> Self {
+        Self { max_depth: None }
     }
 
-    async fn browse_all_from_path(
-        &self,
-        node_id: OpcUaNodeId,
-        parent_path: BrowsePath,
-        max_depth: Option<usize>,
-    ) -> Result<Vec<OpcUaNode>> {
-        let mut ancestors = HashSet::new();
-        ancestors.insert(node_id.clone());
-        let mut visited = 0;
-        browse_recursive(
-            self,
-            node_id,
-            0,
-            max_depth,
-            parent_path,
-            &mut ancestors,
-            &mut visited,
-            DEFAULT_MAX_BROWSE_NODES,
+    /// Limits the number of edges collected below each start route.
+    #[must_use]
+    pub const fn with_max_depth(mut self, max_depth: usize) -> Self {
+        self.max_depth = Some(max_depth);
+        self
+    }
+}
+
+/// Describes whether a route's outgoing references were expanded.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum OpcUaExpansion {
+    /// The complete ordered child snapshot was collected.
+    Expanded,
+    /// Expansion stopped at the caller-selected maximum depth.
+    DepthLimited,
+    /// The route repeated a node already in its own ancestry.
+    Cycle,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+struct RouteIndex(usize);
+
+#[derive(Debug, Clone)]
+struct RouteNode {
+    node: OpcUaNode,
+    parent: Option<RouteIndex>,
+    children: Vec<RouteIndex>,
+    expansion: OpcUaExpansion,
+}
+
+#[derive(Debug, Default)]
+struct NodeGraph {
+    routes: Vec<RouteNode>,
+    root_path: OpcUaBrowsePath,
+}
+
+impl NodeGraph {
+    fn route(&self, index: RouteIndex) -> &RouteNode {
+        let Some(route) = self.routes.get(index.0) else {
+            unreachable!("route indices are created by their backing graph");
+        };
+        route
+    }
+
+    fn route_mut(&mut self, index: RouteIndex) -> &mut RouteNode {
+        let Some(route) = self.routes.get_mut(index.0) else {
+            unreachable!("route indices are created by their backing graph");
+        };
+        route
+    }
+
+    fn set_expansion(&mut self, index: RouteIndex, expansion: OpcUaExpansion) {
+        self.route_mut(index).expansion = expansion;
+    }
+
+    fn add_root(&mut self, node: OpcUaNode) -> RouteIndex {
+        let index = RouteIndex(self.routes.len());
+
+        self.routes.push(RouteNode {
+            node,
+            parent: None,
+            children: Vec::new(),
+            expansion: OpcUaExpansion::DepthLimited,
+        });
+
+        index
+    }
+
+    fn add_child(&mut self, parent: RouteIndex, node: OpcUaNode) -> RouteIndex {
+        let index = RouteIndex(self.routes.len());
+
+        self.routes.push(RouteNode {
+            node,
+            parent: Some(parent),
+            children: Vec::new(),
+            expansion: OpcUaExpansion::DepthLimited,
+        });
+
+        self.route_mut(parent).children.push(index);
+
+        index
+    }
+
+    fn path_segments(&self, index: RouteIndex) -> Vec<&OpcUaBrowseName> {
+        let mut current = index;
+        let mut suffix = Vec::new();
+
+        loop {
+            let route = self.route(current);
+            if let Some(parent) = route.parent {
+                suffix.push(route.node.browse_name());
+                current = parent;
+                continue;
+            }
+
+            let mut segments = self.root_path.segments().iter().collect::<Vec<_>>();
+            segments.extend(suffix.into_iter().rev());
+            return segments;
+        }
+    }
+
+    fn browse_path(&self, index: RouteIndex) -> OpcUaBrowsePath {
+        self.path_segments(index).into_iter().cloned().collect()
+    }
+
+    fn path_matches(&self, index: RouteIndex, path: &OpcUaBrowsePath) -> bool {
+        let segments = self.path_segments(index);
+        segments.len() == path.segments().len()
+            && segments
+                .into_iter()
+                .zip(path.segments())
+                .all(|(actual, expected)| actual == expected)
+    }
+}
+
+/// Immutable route topology collected by one browse operation.
+#[derive(Clone, Default)]
+pub struct OpcUaNodeGraph {
+    inner: Arc<NodeGraph>,
+}
+
+impl fmt::Debug for OpcUaNodeGraph {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("OpcUaNodeGraph")
+            .field(
+                "roots",
+                &self
+                    .inner
+                    .routes
+                    .iter()
+                    .filter(|route| route.parent.is_none())
+                    .count(),
+            )
+            .field("routes", &self.inner.routes.len())
+            .finish()
+    }
+}
+
+impl OpcUaNodeGraph {
+    fn from_graph(graph: NodeGraph) -> Self {
+        Self {
+            inner: Arc::new(graph),
+        }
+    }
+
+    fn route(&self, index: RouteIndex) -> OpcUaRoute {
+        OpcUaRoute {
+            graph: self.clone(),
+            index,
+        }
+    }
+
+    /// Returns every route in server browse order.
+    pub fn routes(&self) -> impl DoubleEndedIterator<Item = OpcUaRoute> + ExactSizeIterator + '_ {
+        (0..self.len()).map(|index| self.route(RouteIndex(index)))
+    }
+
+    /// Returns every selected start route.
+    pub fn roots(&self) -> OpcUaQuery {
+        OpcUaQuery::new(
+            self.clone(),
+            self.inner
+                .routes
+                .iter()
+                .enumerate()
+                .filter_map(|(index, route)| route.parent.is_none().then_some(RouteIndex(index)))
+                .collect(),
         )
-        .await
+    }
+
+    /// Returns a reusable query over every route.
+    pub fn query(&self) -> OpcUaQuery {
+        OpcUaQuery::new(
+            self.clone(),
+            (0..self.len()).map(RouteIndex).collect::<Vec<_>>(),
+        )
+    }
+
+    /// Returns every route whose absolute path equals `path`.
+    pub fn resolve_path(&self, path: &OpcUaBrowsePath) -> OpcUaQuery {
+        self.query().resolve_path(path)
+    }
+
+    /// Matches routes against an absolute filesystem-style glob.
+    pub fn find_all(&self, pattern: impl AsRef<str>) -> Result<OpcUaQuery> {
+        self.query().find_all(pattern)
+    }
+
+    /// Returns read targets for every route.
+    pub fn read_targets(&self) -> impl Iterator<Item = OpcUaNodeReadTarget> + '_ {
+        self.routes().map(|route| route.to_read_target())
+    }
+
+    /// Returns the number of routes.
+    pub fn len(&self) -> usize {
+        self.inner.routes.len()
+    }
+
+    /// Returns whether the graph contains no routes.
+    pub fn is_empty(&self) -> bool {
+        self.inner.routes.is_empty()
     }
 }
 
-impl Browse for OpcUaClient {
-    async fn browse_node(&self, node_id: OpcUaNodeId) -> Result<Vec<OpcUaNode>> {
-        let browse_desc = ua::BrowseDescription::default().with_node_id(&node_id.into());
-        let (mut all_refs, mut cont_pt) = self.browse(&browse_desc).await?;
+/// A reusable route selection tied to one immutable graph.
+#[derive(Clone)]
+pub struct OpcUaQuery {
+    graph: OpcUaNodeGraph,
+    indices: Vec<RouteIndex>,
+}
 
-        while let Some(cp) = cont_pt {
-            let mut results = self.browse_next(&[cp]).await?;
+impl fmt::Debug for OpcUaQuery {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("OpcUaQuery")
+            .field("routes", &self.indices.len())
+            .field("graph", &self.graph)
+            .finish()
+    }
+}
 
-            match results.pop() {
-                Some(result) => {
-                    let (more_refs, next_cp) = result?;
-                    all_refs.extend(more_refs);
-                    cont_pt = next_cp;
+impl OpcUaQuery {
+    fn new(graph: OpcUaNodeGraph, indices: Vec<RouteIndex>) -> Self {
+        Self { graph, indices }
+    }
+
+    fn select(&self, mut predicate: impl FnMut(RouteIndex, &RouteNode) -> bool) -> Self {
+        let indices = self
+            .indices
+            .iter()
+            .copied()
+            .filter(|index| predicate(*index, self.graph.inner.route(*index)))
+            .collect();
+
+        Self::new(self.graph.clone(), indices)
+    }
+
+    /// Returns the immutable graph backing this query.
+    pub const fn graph(&self) -> &OpcUaNodeGraph {
+        &self.graph
+    }
+
+    /// Iterates over the selected routes without consuming the query.
+    pub fn routes(&self) -> impl DoubleEndedIterator<Item = OpcUaRoute> + ExactSizeIterator + '_ {
+        self.indices
+            .iter()
+            .copied()
+            .map(|index| self.graph.route(index))
+    }
+
+    /// Returns selected routes whose absolute path equals `path`.
+    pub fn resolve_path(&self, path: &OpcUaBrowsePath) -> Self {
+        self.select(|index, _| self.graph.inner.path_matches(index, path))
+    }
+
+    /// Matches selected routes against an absolute filesystem-style glob.
+    ///
+    /// A whole `**` segment matches zero or more path segments. Every other
+    /// segment is passed directly to globset, including its full pattern grammar.
+    /// An optional numeric `namespace:` prefix restricts one segment.
+    pub fn find_all(&self, pattern: impl AsRef<str>) -> Result<Self> {
+        let pattern = QueryPattern::new(pattern.as_ref())?;
+        Ok(self.select(|index, _| pattern.matches(&self.graph.inner.path_segments(index))))
+    }
+
+    /// Retains Variable routes.
+    pub fn variables(&self) -> Self {
+        self.select(|_, route| *route.node.node_class() == OpcUaNodeClass::Variable)
+    }
+
+    /// Retains fully expanded routes that have no children.
+    pub fn leaves(&self) -> Self {
+        self.select(|_, route| {
+            route.expansion == OpcUaExpansion::Expanded && route.children.is_empty()
+        })
+    }
+
+    /// Returns read targets for the selected routes.
+    pub fn read_targets(&self) -> impl Iterator<Item = OpcUaNodeReadTarget> + '_ {
+        self.routes().map(|route| route.to_read_target())
+    }
+
+    /// Collects selected read targets into a vector.
+    pub fn to_read_targets(&self) -> Vec<OpcUaNodeReadTarget> {
+        self.read_targets().collect()
+    }
+
+    /// Returns the number of selected routes.
+    pub fn len(&self) -> usize {
+        self.indices.len()
+    }
+
+    /// Returns whether no routes are selected.
+    pub fn is_empty(&self) -> bool {
+        self.indices.is_empty()
+    }
+}
+
+/// An owned handle to one route in an immutable graph.
+#[derive(Clone)]
+pub struct OpcUaRoute {
+    graph: OpcUaNodeGraph,
+    index: RouteIndex,
+}
+
+impl fmt::Debug for OpcUaRoute {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("OpcUaRoute")
+            .field("node", self.node())
+            .field("path", &self.browse_path())
+            .field("expansion", &self.expansion())
+            .finish()
+    }
+}
+
+impl OpcUaRoute {
+    fn route(&self) -> &RouteNode {
+        self.graph.inner.route(self.index)
+    }
+
+    /// Returns the node metadata at this route.
+    pub fn node(&self) -> &OpcUaNode {
+        &self.route().node
+    }
+
+    /// Returns the route's rooted absolute path.
+    pub fn browse_path(&self) -> OpcUaBrowsePath {
+        self.graph.inner.browse_path(self.index)
+    }
+
+    /// Returns the route's expansion outcome.
+    pub fn expansion(&self) -> OpcUaExpansion {
+        self.route().expansion
+    }
+
+    /// Returns the parent route, or `None` for a selected start.
+    pub fn parent(&self) -> Option<Self> {
+        self.route().parent.map(|parent| self.graph.route(parent))
+    }
+
+    /// Returns children in server browse order.
+    pub fn children(&self) -> OpcUaQuery {
+        OpcUaQuery::new(self.graph.clone(), self.route().children.clone())
+    }
+
+    /// Converts this route into an owned read target.
+    pub fn to_read_target(&self) -> OpcUaNodeReadTarget {
+        OpcUaNodeReadTarget::new(self.node().node_id().clone(), self.browse_path())
+    }
+}
+
+impl From<OpcUaRoute> for OpcUaNodeReadTarget {
+    fn from(route: OpcUaRoute) -> Self {
+        route.to_read_target()
+    }
+}
+
+#[derive(Debug)]
+enum QuerySegment {
+    Recursive,
+    Matcher {
+        namespace: Option<u16>,
+        matcher: GlobMatcher,
+    },
+}
+
+#[derive(Debug)]
+struct QueryPattern {
+    segments: Vec<QuerySegment>,
+}
+
+impl QueryPattern {
+    fn new(pattern: &str) -> Result<Self> {
+        let segments = split_absolute_segments(pattern, '\\')?
+            .into_iter()
+            .map(|segment| {
+                if segment == "**" {
+                    Ok(QuerySegment::Recursive)
+                } else {
+                    let (namespace, pattern) = split_namespace_prefix(&segment, '\\')?;
+
+                    if pattern.is_empty() {
+                        bail!("OPC UA route pattern cannot contain an empty browse name");
+                    }
+
+                    let matcher = GlobBuilder::new(pattern)
+                        .literal_separator(false)
+                        .backslash_escape(true)
+                        .build()?
+                        .compile_matcher();
+
+                    Ok(QuerySegment::Matcher { namespace, matcher })
                 }
-                None => break,
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        Ok(Self { segments })
+    }
+
+    fn matches(&self, path: &[&OpcUaBrowseName]) -> bool {
+        let mut reachable = vec![false; path.len() + 1];
+        if let Some(first) = reachable.first_mut() {
+            *first = true;
+        }
+
+        for pattern in &self.segments {
+            match pattern {
+                QuerySegment::Recursive => {
+                    let mut matched = false;
+                    for slot in &mut reachable {
+                        matched |= *slot;
+                        *slot = matched;
+                    }
+                }
+
+                QuerySegment::Matcher { namespace, matcher } => {
+                    let mut next = vec![false; reachable.len()];
+
+                    for ((can_reach, browse_name), output) in
+                        reachable.iter().zip(path).zip(next.iter_mut().skip(1))
+                    {
+                        *output = *can_reach
+                            && namespace
+                                .is_none_or(|namespace| namespace == browse_name.namespace())
+                            && matcher.is_match(browse_name.name());
+                    }
+
+                    reachable = next;
+                }
             }
         }
 
-        let nodes = all_refs
+        reachable.last().copied().unwrap_or(false)
+    }
+}
+
+#[allow(async_fn_in_trait)]
+trait BrowseSource {
+    async fn node(&self, node_id: &OpcUaNodeId) -> Result<OpcUaNode>;
+    async fn children(&self, node_id: &OpcUaNodeId) -> Result<Vec<OpcUaNode>>;
+}
+
+impl BrowseSource for OpcUaClient {
+    async fn node(&self, node_id: &OpcUaNodeId) -> Result<OpcUaNode> {
+        let (browse_name, display_name, node_class) = self.read_node_metadata(node_id).await?;
+
+        Ok(OpcUaNode::new(
+            node_id.clone(),
+            display_name,
+            node_class,
+            browse_name,
+        ))
+    }
+
+    async fn children(&self, node_id: &OpcUaNodeId) -> Result<Vec<OpcUaNode>> {
+        let description =
+            ua::BrowseDescription::default().with_node_id(&ua::NodeId::from(node_id.clone()));
+
+        let client = <OpcUaClient as std::ops::Deref>::deref(self);
+        let (mut references, mut continuation) = client.browse(&description).await?;
+
+        while let Some(point) = continuation {
+            let mut results = self.browse_next(&[point]).await?;
+            let result = results
+                .pop()
+                .context("OPC UA browse_next omitted its requested continuation result")?;
+            let (next_references, next_continuation) = result?;
+            references.extend(next_references);
+            continuation = next_continuation;
+        }
+
+        Ok(references
             .into_iter()
             .filter_map(|reference| {
                 let id = reference.node_id().node_id();
+                let node_id = id
+                    .clone()
+                    .try_into()
+                    .inspect_err(|error| {
+                        tracing::warn!(
+                            target: "opcua::browse",
+                            ?error,
+                            node_id = ?id,
+                            "skipping non-local browse reference"
+                        );
+                    })
+                    .ok()?;
 
-                let Ok(node_id) = id.clone().try_into() else {
-                    tracing::warn!(
-                        target: "opcua::browse",
-                        node_id = ?id,
-                        "skipping reference during browse"
-                    );
+                let browse_name = reference.browse_name();
 
-                    return None;
-                };
-
-                let node_class = OpcUaNodeClass::from(reference.node_class());
-                let qualified_browse_name = QualifiedBrowseName {
-                    namespace_index: reference.browse_name().namespace_index(),
-                    name: reference.browse_name().name().to_string(),
-                };
-
-                Some(OpcUaNode {
+                Some(OpcUaNode::new(
                     node_id,
-                    browse_name: qualified_browse_name.name.clone(),
-                    display_name: reference.display_name().text().to_string(),
-                    node_class,
-                    browse_path: BrowsePath::from_segment(qualified_browse_name),
-                    children: Vec::new(),
-                })
+                    reference.display_name().text().to_string(),
+                    reference.node_class().into(),
+                    OpcUaBrowseName::new(
+                        browse_name.namespace_index(),
+                        browse_name.name().to_string(),
+                    ),
+                ))
             })
-            .collect();
-
-        Ok(nodes)
+            .collect())
     }
 }
 
-// not taking a dep on futures just for this type
-type BoxedFuture<'a, T> = Pin<Box<dyn Future<Output = Result<T>> + 'a>>;
+struct StartRoute {
+    node: OpcUaNode,
+    ancestors: HashSet<OpcUaNodeId>,
+}
 
-/// Recursive DFS browse helper. Returns a list of nodes in the subtree rooted at `node_id`.
-fn browse_recursive<'a, B: Browse>(
-    browser: &'a B,
+struct BrowseFrame {
+    route: RouteIndex,
     node_id: OpcUaNodeId,
     depth: usize,
-    max_depth: Option<usize>,
-    parent_path: BrowsePath,
-    ancestors: &'a mut HashSet<OpcUaNodeId>,
-    visited: &'a mut usize,
-    max_nodes: usize,
-) -> BoxedFuture<'a, Vec<OpcUaNode>> {
-    Box::pin(async move {
-        if let Some(max_depth) = max_depth
-            && depth >= max_depth
-        {
-            return Ok(Vec::new());
+    children: Option<Arc<[OpcUaNode]>>,
+    next_child: usize,
+}
+
+struct Collector<'source, S> {
+    source: &'source S,
+    options: OpcUaBrowseOptions,
+    children: HashMap<OpcUaNodeId, Arc<[OpcUaNode]>>,
+    graph: NodeGraph,
+}
+
+impl<'source, S> Collector<'source, S>
+where
+    S: BrowseSource + 'source,
+{
+    fn new(source: &'source S, options: OpcUaBrowseOptions) -> Self {
+        Self {
+            source,
+            options,
+            children: HashMap::new(),
+            graph: NodeGraph::default(),
+        }
+    }
+
+    async fn child_snapshot(&mut self, node_id: &OpcUaNodeId) -> Result<Arc<[OpcUaNode]>> {
+        if let Some(children) = self.children.get(node_id) {
+            return Ok(Arc::clone(children));
         }
 
-        let raw = browser.browse_node(node_id).await?;
-        let mut nodes = Vec::with_capacity(raw.len());
+        let children = Arc::from(self.source.children(node_id).await?);
+        self.children.insert(node_id.clone(), Arc::clone(&children));
 
-        for mut node in raw {
-            if ancestors.contains(&node.node_id) {
-                bail!(
-                    "cycle detected while browsing node {} at path {}",
-                    node.node_id,
-                    parent_path
-                );
-            }
+        Ok(children)
+    }
 
-            if *visited >= max_nodes {
-                bail!("browse exceeded maximum node count of {max_nodes}");
-            }
-            *visited = visited.saturating_add(1);
+    async fn resolve_path(&mut self, path: &OpcUaBrowsePath) -> Result<Vec<StartRoute>> {
+        let root = self.source.node(&ROOT_NODE_ID).await?;
 
-            let segment = node
-                .browse_path
-                .segments()
-                .last()
-                .cloned()
-                .with_context(|| {
-                    format!("browse result for node {} had no browse path", node.node_id)
-                })?;
-            let node_path = parent_path.child(segment);
-            node.browse_path = node_path.clone();
+        let mut candidates = vec![StartRoute {
+            node: root,
+            ancestors: HashSet::from([ROOT_NODE_ID]),
+        }];
 
-            if matches!(
-                node.node_class,
-                OpcUaNodeClass::Object | OpcUaNodeClass::Variable
-            ) {
-                ancestors.insert(node.node_id.clone());
-                node.children.extend(
-                    browse_recursive(
-                        browser,
-                        node.node_id.clone(),
-                        depth.saturating_add(1),
-                        max_depth,
-                        node_path,
+        for segment in path.segments() {
+            let mut matches = Vec::new();
+
+            for candidate in candidates {
+                let snapshot = self.child_snapshot(candidate.node.node_id()).await?;
+
+                for child in snapshot.iter().filter(|node| node.browse_name() == segment) {
+                    let node_id = child.node_id().clone();
+
+                    if candidate.ancestors.contains(&node_id) {
+                        continue;
+                    }
+
+                    let mut ancestors = candidate.ancestors.clone();
+                    ancestors.insert(node_id);
+
+                    matches.push(StartRoute {
+                        node: child.clone(),
                         ancestors,
-                        visited,
-                        max_nodes,
-                    )
-                    .await?,
-                );
-                ancestors.remove(&node.node_id);
+                    });
+                }
             }
 
-            nodes.push(node);
+            if matches.is_empty() {
+                return Ok(Vec::new());
+            }
+
+            candidates = matches;
         }
 
-        Ok(nodes)
-    })
+        Ok(candidates)
+    }
+
+    async fn collect(
+        mut self,
+        root_path: OpcUaBrowsePath,
+        starts: Vec<StartRoute>,
+    ) -> Result<OpcUaNodeGraph> {
+        self.graph.root_path = root_path;
+
+        for start in starts {
+            let node_id = start.node.node_id().clone();
+            let route = self.graph.add_root(start.node);
+            let mut ancestors = start.ancestors;
+            let mut stack = vec![BrowseFrame {
+                route,
+                node_id,
+                depth: 0,
+                children: None,
+                next_child: 0,
+            }];
+
+            loop {
+                let Some(frame) = stack.last() else {
+                    break;
+                };
+                let should_limit = self
+                    .options
+                    .max_depth
+                    .is_some_and(|max_depth| frame.depth >= max_depth);
+                if should_limit {
+                    let Some(frame) = stack.pop() else {
+                        break;
+                    };
+                    self.graph
+                        .set_expansion(frame.route, OpcUaExpansion::DepthLimited);
+                    ancestors.remove(&frame.node_id);
+                    continue;
+                }
+
+                let unloaded_node = stack
+                    .last()
+                    .filter(|frame| frame.children.is_none())
+                    .map(|frame| frame.node_id.clone());
+                if let Some(node_id) = unloaded_node {
+                    let snapshot = self.child_snapshot(&node_id).await?;
+                    let Some(frame) = stack.last_mut() else {
+                        unreachable!("the browse frame remains present while loading children");
+                    };
+                    frame.children = Some(snapshot);
+                    self.graph
+                        .set_expansion(frame.route, OpcUaExpansion::Expanded);
+                }
+
+                let next = if let Some(frame) = stack.last_mut() {
+                    let child = frame
+                        .children
+                        .as_ref()
+                        .and_then(|children| children.get(frame.next_child))
+                        .cloned();
+                    frame.next_child = frame
+                        .next_child
+                        .saturating_add(usize::from(child.is_some()));
+                    child.map(|child| (frame.route, frame.depth, child))
+                } else {
+                    None
+                };
+
+                let Some((parent, parent_depth, child)) = next else {
+                    if let Some(frame) = stack.pop() {
+                        ancestors.remove(&frame.node_id);
+                    }
+                    continue;
+                };
+
+                let node_id = child.node_id().clone();
+                let route = self.graph.add_child(parent, child);
+                if ancestors.contains(&node_id) {
+                    self.graph.set_expansion(route, OpcUaExpansion::Cycle);
+                    continue;
+                }
+
+                ancestors.insert(node_id.clone());
+                stack.push(BrowseFrame {
+                    route,
+                    node_id,
+                    depth: parent_depth.saturating_add(1),
+                    children: None,
+                    next_child: 0,
+                });
+            }
+        }
+
+        Ok(OpcUaNodeGraph::from_graph(self.graph))
+    }
+}
+
+impl OpcUaClient {
+    /// Browses the standard Root node at `/`.
+    pub async fn browse_root(&self, options: OpcUaBrowseOptions) -> Result<OpcUaNodeGraph> {
+        let mut collector = Collector::new(self, options);
+        let root = OpcUaBrowsePath::root();
+        let starts = collector.resolve_path(&root).await?;
+        collector.collect(root, starts).await
+    }
+
+    /// Resolves a rooted absolute path from Root and browses every matching route.
+    pub async fn browse_path(
+        &self,
+        path: OpcUaBrowsePath,
+        options: OpcUaBrowseOptions,
+    ) -> Result<OpcUaNodeGraph> {
+        let mut collector = Collector::new(self, options);
+        let starts = collector.resolve_path(&path).await?;
+        collector.collect(path, starts).await
+    }
+
+    /// Browses `node_id` mounted at the asserted rooted absolute `path`.
+    ///
+    /// The supplied path must end in the node's actual browse name. The standard
+    /// Root node is mounted only at `/`.
+    pub async fn browse_from(
+        &self,
+        node_id: OpcUaNodeId,
+        path: OpcUaBrowsePath,
+        options: OpcUaBrowseOptions,
+    ) -> Result<OpcUaNodeGraph> {
+        let collector = Collector::new(self, options);
+        let node = collector.source.node(&node_id).await?;
+        validate_mount(&node, &path)?;
+        collector
+            .collect(
+                path,
+                vec![StartRoute {
+                    node,
+                    ancestors: HashSet::from([node_id]),
+                }],
+            )
+            .await
+    }
+}
+
+fn validate_mount(node: &OpcUaNode, path: &OpcUaBrowsePath) -> Result<()> {
+    if node.node_id() == &ROOT_NODE_ID {
+        if !path.is_root() {
+            bail!("the standard Root node must be mounted at '/'");
+        }
+    } else if path.is_root() {
+        bail!("only the standard Root node can be mounted at '/'");
+    } else if path.segments().last() != Some(node.browse_name()) {
+        bail!(
+            "browse path {path} does not end with node browse name {}",
+            node.browse_name()
+        );
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]
 mod tests {
+    use std::cell::RefCell;
     use std::collections::HashMap;
     use std::collections::HashSet;
 
+    use anyhow::Context as _;
     use anyhow::Result;
-    use tokio::runtime::Builder;
 
-    use super::Browse;
-    use super::BrowseAll;
-    use super::DEFAULT_MAX_BROWSE_NODES;
-    use super::browse_recursive;
-    use crate::types::BrowsePath;
+    use super::BrowseSource;
+    use super::Collector;
+    use super::OpcUaBrowseOptions;
+    use super::OpcUaExpansion;
+    use super::StartRoute;
+    use super::validate_mount;
+    use crate::path::OpcUaBrowseName;
     use crate::types::OpcUaNode;
     use crate::types::OpcUaNodeClass;
     use crate::types::OpcUaNodeId;
-    use crate::types::QualifiedBrowseName;
 
-    fn nid(n: u32) -> OpcUaNodeId {
-        OpcUaNodeId::numeric(0, n)
+    fn id(value: u32) -> OpcUaNodeId {
+        OpcUaNodeId::numeric(0, value)
     }
 
-    fn browse_path(namespace_index: u16, name: String) -> BrowsePath {
-        BrowsePath::from_segment(QualifiedBrowseName::new(namespace_index, name))
+    fn node(value: u32, name: &str, class: OpcUaNodeClass) -> OpcUaNode {
+        OpcUaNode::new(
+            id(value),
+            name.to_owned(),
+            class,
+            OpcUaBrowseName::new(0, name.to_owned()),
+        )
     }
 
-    fn obj(id: u32) -> OpcUaNode {
-        let browse_name = format!("Object_{id}");
-        OpcUaNode {
-            node_id: nid(id),
-            browse_name: browse_name.clone(),
-            display_name: format!("Object {id}"),
-            node_class: OpcUaNodeClass::Object,
-            browse_path: browse_path(0, browse_name),
-            children: Vec::new(),
+    fn object(value: u32, name: &str) -> OpcUaNode {
+        node(value, name, OpcUaNodeClass::Object)
+    }
+
+    fn start(node: OpcUaNode) -> StartRoute {
+        let node_id = node.node_id().clone();
+        StartRoute {
+            node,
+            ancestors: HashSet::from([node_id]),
         }
     }
 
-    fn var(id: u32) -> OpcUaNode {
-        let browse_name = format!("Variable_{id}");
-        OpcUaNode {
-            node_id: nid(id),
-            browse_name: browse_name.clone(),
-            display_name: format!("Variable {id}"),
-            node_class: OpcUaNodeClass::Variable,
-            browse_path: browse_path(0, browse_name),
-            children: Vec::new(),
-        }
+    struct MockSource {
+        nodes: HashMap<OpcUaNodeId, OpcUaNode>,
+        children: HashMap<OpcUaNodeId, Vec<OpcUaNode>>,
+        fetches: RefCell<HashMap<OpcUaNodeId, usize>>,
     }
 
-    fn method(id: u32) -> OpcUaNode {
-        let browse_name = format!("Method_{id}");
-        OpcUaNode {
-            node_id: nid(id),
-            browse_name: browse_name.clone(),
-            display_name: format!("Method {id}"),
-            node_class: OpcUaNodeClass::Method,
-            browse_path: browse_path(0, browse_name),
-            children: Vec::new(),
-        }
-    }
-
-    fn view(id: u32) -> OpcUaNode {
-        let browse_name = format!("View_{id}");
-        OpcUaNode {
-            node_id: nid(id),
-            browse_name: browse_name.clone(),
-            display_name: format!("View {id}"),
-            node_class: OpcUaNodeClass::View,
-            browse_path: browse_path(0, browse_name),
-            children: Vec::new(),
-        }
-    }
-
-    /// Counts the total number of nodes (including nested children) in the tree.
-    fn count_nodes(nodes: &[OpcUaNode]) -> usize {
-        nodes
-            .iter()
-            .map(|n| 1usize.saturating_add(count_nodes(&n.children)))
-            .sum()
-    }
-
-    fn count_node_id(nodes: &[OpcUaNode], node_id: &OpcUaNodeId) -> usize {
-        nodes
-            .iter()
-            .map(|node| {
-                usize::from(&node.node_id == node_id)
-                    .saturating_add(count_node_id(&node.children, node_id))
-            })
-            .sum()
-    }
-
-    fn collect_paths(nodes: &[OpcUaNode]) -> Vec<String> {
-        nodes
-            .iter()
-            .flat_map(|node| {
-                std::iter::once(node.browse_path.to_string()).chain(collect_paths(&node.children))
-            })
-            .collect()
-    }
-
-    /// Returns the maximum depth of the browse result tree (0 for empty, 1 for
-    /// flat list of nodes with no children, etc.)
-    fn max_tree_depth(nodes: &[OpcUaNode]) -> usize {
-        if nodes.is_empty() {
-            return 0;
-        }
-        nodes
-            .iter()
-            .map(|n| 1usize.saturating_add(max_tree_depth(&n.children)))
-            .max()
-            .unwrap_or(0)
-    }
-
-    /// A fake `Browser` implementation backed by an adjacency map.
-    ///
-    /// For each `OpcUaNodeId`, the map stores the list of `OpcUaBrowseNode`s
-    /// that `browse_node` should return (these represent the immediate children
-    /// of that node in the OPC UA address space).
-    struct MockBrowser {
-        graph: HashMap<OpcUaNodeId, Vec<OpcUaNode>>,
-    }
-
-    impl MockBrowser {
+    impl MockSource {
         fn new() -> Self {
+            let root = node(84, "Root", OpcUaNodeClass::Object);
             Self {
-                graph: HashMap::new(),
+                nodes: HashMap::from([(root.node_id().clone(), root)]),
+                children: HashMap::new(),
+                fetches: RefCell::new(HashMap::new()),
             }
         }
 
-        /// Registers `children` as the browse result for `parent`.
-        fn add_children(&mut self, parent: OpcUaNodeId, children: Vec<OpcUaNode>) {
-            self.graph.entry(parent).or_default().extend(children);
+        fn add_children(&mut self, parent: u32, children: Vec<OpcUaNode>) {
+            for child in &children {
+                self.nodes.insert(child.node_id().clone(), child.clone());
+            }
+            self.children.insert(id(parent), children);
         }
 
-        /// Convenience: run `browse_recursive` from `root` with the given
-        /// `max_depth`, returning the result tree.
-        fn browse(&self, root: OpcUaNodeId, max_depth: Option<usize>) -> Result<Vec<OpcUaNode>> {
-            self.browse_with_parent(root, BrowsePath::default(), max_depth)
-        }
-
-        fn browse_with_parent(
+        async fn browse(
             &self,
-            root: OpcUaNodeId,
-            parent_path: BrowsePath,
-            max_depth: Option<usize>,
-        ) -> Result<Vec<OpcUaNode>> {
-            let mut ancestors = HashSet::new();
-            ancestors.insert(root.clone());
-            let mut visited = 0;
-            let runtime = Builder::new_current_thread()
-                .enable_all()
-                .max_blocking_threads(1)
-                .build()
-                .expect("failed to build tokio runtime");
-
-            runtime.block_on(browse_recursive(
-                self,
-                root,
-                0,
-                max_depth,
-                parent_path,
-                &mut ancestors,
-                &mut visited,
-                DEFAULT_MAX_BROWSE_NODES,
-            ))
-        }
-
-        fn browse_with_limit(&self, root: OpcUaNodeId, max_nodes: usize) -> Result<Vec<OpcUaNode>> {
-            let mut ancestors = HashSet::new();
-            ancestors.insert(root.clone());
-            let mut visited = 0;
-            let runtime = Builder::new_current_thread()
-                .enable_all()
-                .max_blocking_threads(1)
-                .build()
-                .expect("failed to build tokio runtime");
-
-            runtime.block_on(browse_recursive(
-                self,
-                root,
-                0,
-                None,
-                BrowsePath::default(),
-                &mut ancestors,
-                &mut visited,
-                max_nodes,
-            ))
+            selected: OpcUaNode,
+            path: &str,
+            options: OpcUaBrowseOptions,
+        ) -> Result<super::OpcUaNodeGraph> {
+            Collector::new(self, options)
+                .collect(path.parse()?, vec![start(selected)])
+                .await
         }
     }
 
-    impl Browse for MockBrowser {
-        async fn browse_node(&self, node_id: OpcUaNodeId) -> Result<Vec<OpcUaNode>> {
-            Ok(self.graph.get(&node_id).cloned().unwrap_or_default())
+    impl BrowseSource for MockSource {
+        async fn node(&self, node_id: &OpcUaNodeId) -> Result<OpcUaNode> {
+            self.nodes
+                .get(node_id)
+                .cloned()
+                .context("mock node is missing")
+        }
+
+        async fn children(&self, node_id: &OpcUaNodeId) -> Result<Vec<OpcUaNode>> {
+            *self
+                .fetches
+                .borrow_mut()
+                .entry(node_id.clone())
+                .or_default() += 1;
+            Ok(self.children.get(node_id).cloned().unwrap_or_default())
         }
     }
 
-    /// A -> A (node references itself as a child).
-    fn self_loop() -> (MockBrowser, OpcUaNodeId) {
-        let mut browser = MockBrowser::new();
-        browser.add_children(nid(1), vec![obj(1)]);
-        (browser, nid(1))
-    }
-
-    /// A -> B -> A (two-node cycle).
-    fn direct_cycle() -> (MockBrowser, OpcUaNodeId) {
-        let mut browser = MockBrowser::new();
-        browser.add_children(nid(1), vec![obj(2)]);
-        browser.add_children(nid(2), vec![obj(1)]);
-        (browser, nid(1))
-    }
-
-    /// Ring of `len` nodes: 1 -> 2 -> 3 -> ... -> len -> 1.
-    fn long_cycle(len: usize) -> (MockBrowser, OpcUaNodeId) {
-        let mut browser = MockBrowser::new();
-        for i in 1..=len {
-            let next = if i == len { 1 } else { i.saturating_add(1) };
-            browser.add_children(nid(i as u32), vec![obj(next as u32)]);
-        }
-        (browser, nid(1))
-    }
-
-    /// Diamond:
-    /// ```text
-    ///     1
-    ///    / \
-    ///   2   3
-    ///    \ /
-    ///     4
-    /// ```
-    fn diamond() -> (MockBrowser, OpcUaNodeId) {
-        let mut browser = MockBrowser::new();
-        browser.add_children(nid(1), vec![obj(2), obj(3)]);
-        browser.add_children(nid(2), vec![obj(4)]);
-        browser.add_children(nid(3), vec![obj(4)]);
-        (browser, nid(1))
-    }
-
-    /// Linear chain: 1 -> 2 -> 3 -> ... -> n (all Object nodes).
-    fn deep_chain(n: u32) -> (MockBrowser, OpcUaNodeId) {
-        let mut browser = MockBrowser::new();
-        for i in 1..n {
-            browser.add_children(nid(i), vec![obj(i.saturating_add(1))]);
-        }
-        (browser, nid(1))
-    }
-
-    /// Single root with `n` Object children (flat, one level deep).
-    fn wide_tree(n: u32) -> (MockBrowser, OpcUaNodeId) {
-        let mut browser = MockBrowser::new();
-        let children: Vec<_> = (2..=n.saturating_add(1)).map(obj).collect();
-        browser.add_children(nid(1), children);
-        (browser, nid(1))
-    }
-
-    /// Overlapping cycles:
-    /// ```text
-    ///       1 - 4
-    ///      / \ /
-    ///     2 - 3
-    /// ```
-    fn multi_cycle() -> (MockBrowser, OpcUaNodeId) {
-        let mut browser = MockBrowser::new();
-        browser.add_children(nid(1), vec![obj(2), obj(4)]);
-        browser.add_children(nid(2), vec![obj(3)]);
-        browser.add_children(nid(3), vec![obj(1)]);
-        browser.add_children(nid(4), vec![obj(3)]);
-        (browser, nid(1))
-    }
-
-    /// Cycle involving a Variable node:
-    /// ```text
-    ///   1(Object) -> 2(Variable) -> 3(Object) -> 1(Object)
-    /// ```
-    fn mixed_class_cycle() -> (MockBrowser, OpcUaNodeId) {
-        let mut browser = MockBrowser::new();
-        browser.add_children(nid(1), vec![var(2)]);
-        browser.add_children(nid(2), vec![obj(3)]);
-        browser.add_children(nid(3), vec![obj(1)]);
-        (browser, nid(1))
-    }
-
-    /// Chain of diamonds sharing intermediate nodes:
-    /// ```text
-    ///     1
-    ///    / \
-    ///   1   4 - 6
-    ///    \ / \ /
-    ///     3 - 5
-    /// ```
-    fn convergent_diamond_chain() -> (MockBrowser, OpcUaNodeId) {
-        let mut browser = MockBrowser::new();
-        browser.add_children(nid(1), vec![obj(2), obj(3)]);
-        browser.add_children(nid(2), vec![obj(4)]);
-        browser.add_children(nid(3), vec![obj(4), obj(5)]);
-        browser.add_children(nid(4), vec![obj(6)]);
-        browser.add_children(nid(5), vec![obj(6)]);
-        (browser, nid(1))
-    }
-
-    /// Object with both Variable and Object children, where the Variable's id
-    /// is also reachable through the Object branch.
-    fn variable_shadows_object() -> (MockBrowser, OpcUaNodeId) {
-        let mut browser = MockBrowser::new();
-        // Root returns node 2 as a Variable, and node 3 as an Object.
-        browser.add_children(nid(1), vec![var(2), obj(3)]);
-        // Node 3 returns node 2 as an Object.
-        browser.add_children(nid(3), vec![obj(2)]);
-        // If browse_recursive visited node 2 as an Object, it would find node 4.
-        browser.add_children(nid(2), vec![obj(4)]);
-        (browser, nid(1))
-    }
-
-    #[test]
-    fn self_loop_errors() {
-        let (browser, root) = self_loop();
-        assert!(browser.browse(root, None).is_err());
-    }
-
-    #[test]
-    fn direct_cycle_errors() {
-        let (browser, root) = direct_cycle();
-        assert!(browser.browse(root, None).is_err());
-    }
-
-    #[test]
-    fn long_cycle_errors() {
-        let cycle_len = 10usize;
-        let (browser, root) = long_cycle(cycle_len);
-        assert!(browser.browse(root, None).is_err());
-    }
-
-    #[test]
-    fn diamond_keeps_each_route() {
-        let (browser, root) = diamond();
-        let result = browser.browse(root, None).expect("browse should succeed");
-
-        assert_eq!(result.len(), 2);
-
-        let node2 = result.first().expect("root should have two children");
-        let node3 = result.get(1).expect("root should have two children");
-        assert_eq!(node2.node_id, nid(2));
-        assert_eq!(node3.node_id, nid(3));
-
-        assert_eq!(node2.children.len(), 1);
-        assert_eq!(
-            node2
-                .children
-                .first()
-                .expect("node2 should have a child")
-                .node_id,
-            nid(4)
-        );
-        assert_eq!(node3.children.len(), 1);
-        assert_eq!(
-            node3
-                .children
-                .first()
-                .expect("node3 should have a child")
-                .node_id,
-            nid(4)
-        );
-
-        assert_eq!(count_node_id(&result, &nid(4)), 2);
-    }
-
-    #[test]
-    fn deep_chain_respects_max_depth() {
-        let chain_len = 20;
-        let max_depth = 5;
-        let (browser, root) = deep_chain(chain_len);
-        let result = browser
-            .browse(root, Some(max_depth))
-            .expect("browse should succeed");
-
-        let depth = max_tree_depth(&result);
-        assert!(
-            depth <= max_depth,
-            "tree depth {depth} should not exceed max_depth {max_depth}"
-        );
-    }
-
-    #[test]
-    fn deep_chain_no_max_depth() {
-        let chain_len = 50;
-        let (browser, root) = deep_chain(chain_len);
-        let result = browser.browse(root, None).expect("browse should succeed");
-
-        // With no depth limit, we should get all nodes.
-        let total = count_nodes(&result);
-        // chain_len - 1 because the chain is 1->2->...->chain_len, and the
-        // root (1) calls browse_node which returns 2..chain_len-1 in a chain.
-        // Actually: deep_chain(n) creates edges 1->2, 2->3, ..., (n-1)->n.
-        // browse_recursive(1) -> browse_node(1) = [obj(2)]
-        //   recurse into 2 -> browse_node(2) = [obj(3)]
-        //     ...
-        //   recurse into (n-1) -> browse_node(n-1) = [obj(n)]
-        //     recurse into n -> browse_node(n) = [] (no entry in map)
-        // Total nodes: n-1 (nodes 2 through n)
-        let expected = chain_len.saturating_sub(1) as usize;
-        assert_eq!(
-            total, expected,
-            "should traverse all {expected} nodes in chain"
-        );
-    }
-
-    #[test]
-    fn wide_tree_returns_all_children() {
-        let width = 100;
-        let (browser, root) = wide_tree(width);
-        let result = browser.browse(root, None).expect("browse should succeed");
-
-        assert_eq!(
-            result.len(),
-            width as usize,
-            "all children should be returned"
-        );
-        for node in &result {
-            assert!(
-                node.children.is_empty(),
-                "leaf objects should have no children"
-            );
-        }
-    }
-
-    #[test]
-    fn multi_cycle_errors() {
-        let (browser, root) = multi_cycle();
-        assert!(browser.browse(root, None).is_err());
-    }
-
-    #[test]
-    fn mixed_class_cycle_errors_after_recursing_into_variable() {
-        let (browser, root) = mixed_class_cycle();
-        assert!(browser.browse(root, None).is_err());
-    }
-
-    #[test]
-    fn empty_graph_returns_empty() {
-        let browser = MockBrowser::new();
-        let result = browser
-            .browse(nid(999), None)
-            .expect("browse should succeed");
-        assert!(result.is_empty());
-    }
-
-    #[test]
-    fn browse_populates_paths_from_parent_path() {
-        let mut browser = MockBrowser::new();
-        browser.add_children(nid(1), vec![obj(2)]);
-        browser.add_children(nid(2), vec![var(3)]);
-        browser.add_children(nid(3), vec![var(4)]);
-
-        let root_path = BrowsePath::from_segment(QualifiedBrowseName::new(0, "Root".into()));
-        let result = browser
-            .browse_with_parent(nid(1), root_path, None)
-            .expect("browse should succeed");
-
-        assert_eq!(
-            collect_paths(&result),
-            vec![
-                "/Root/Object_2",
-                "/Root/Object_2/Variable_3",
-                "/Root/Object_2/Variable_3/Variable_4",
-            ]
-        );
-    }
-
-    #[test]
-    fn browse_all_uses_empty_parent_path_by_default() {
-        let mut browser = MockBrowser::new();
-        browser.add_children(nid(1), vec![obj(2)]);
-
-        let runtime = Builder::new_current_thread()
-            .enable_all()
-            .max_blocking_threads(1)
-            .build()
-            .expect("failed to build tokio runtime");
-        let result = runtime
-            .block_on(browser.browse_all(nid(1), None))
-            .expect("browse should succeed");
-
-        assert_eq!(collect_paths(&result), vec!["/Object_2"]);
-    }
-
-    #[test]
-    fn browse_enforces_node_ceiling() {
-        let (browser, root) = wide_tree(2);
-
-        let result = browser
-            .browse_with_limit(root.clone(), 2)
-            .expect("browse up to node ceiling should succeed");
-
-        assert_eq!(count_nodes(&result), 2);
-        assert!(browser.browse_with_limit(root, 1).is_err());
-    }
-
-    #[test]
-    fn convergent_diamond_chain_duplicates_per_route() {
-        let (browser, root) = convergent_diamond_chain();
-        let result = browser.browse(root, None).expect("browse should succeed");
-
-        assert_eq!(count_node_id(&result, &nid(4)), 2);
-        assert_eq!(count_node_id(&result, &nid(6)), 3);
-    }
-
-    #[test]
-    fn variable_and_object_with_same_id_are_kept_on_distinct_routes() {
-        let (browser, root) = variable_shadows_object();
-        let result = browser.browse(root, None).expect("browse should succeed");
-
-        assert_eq!(result.len(), 2);
-
-        let var_node = result.first().expect("root should have a child");
-        assert_eq!(var_node.node_class, OpcUaNodeClass::Variable);
-        assert_eq!(var_node.children.len(), 1);
-
-        let obj_3 = result.get(1).expect("root should have two children");
-        assert_eq!(obj_3.node_id, nid(3));
-        assert_eq!(obj_3.children.len(), 1);
-        assert_eq!(
-            obj_3.children.first().map(|node| &node.node_id),
-            Some(&nid(2))
-        );
-
-        assert_eq!(count_node_id(&result, &nid(2)), 2);
-        assert_eq!(count_node_id(&result, &nid(4)), 2);
-    }
-
-    /// Two object parents both reference the same variable id (convergent non-object).
-    fn convergent_variable_diamond() -> (MockBrowser, OpcUaNodeId) {
-        let mut browser = MockBrowser::new();
-        browser.add_children(nid(1), vec![obj(2), obj(3)]);
-        browser.add_children(nid(2), vec![var(4)]);
-        browser.add_children(nid(3), vec![var(4)]);
-        (browser, nid(1))
-    }
-
-    #[test]
-    fn convergent_paths_duplicate_variable_reference() {
-        let (browser, root) = convergent_variable_diamond();
-        let result = browser.browse(root, None).expect("browse should succeed");
-
-        assert_eq!(result.len(), 2);
-        let node2 = result.first().expect("root children");
-        let node3 = result.get(1).expect("root children");
-        assert_eq!(node2.node_id, nid(2));
-        assert_eq!(node3.node_id, nid(3));
-
-        assert_eq!(node2.children.len(), 1);
-        assert_eq!(
-            node2
-                .children
-                .first()
-                .expect("variable under first branch")
-                .node_id,
-            nid(4)
-        );
-        assert_eq!(node3.children.len(), 1);
-        assert_eq!(
-            node3
-                .children
-                .first()
-                .expect("variable under second branch")
-                .node_id,
-            nid(4)
-        );
-
-        assert_eq!(count_node_id(&result, &nid(4)), 2);
-    }
-
-    /// Regression test: a bug caused the depth counter to be decremented while
-    /// simultaneously being incremented, so the effective depth never advanced
-    /// and the browse stopped too shallow. This test asserts that when the chain
-    /// is long enough to fill the requested depth, the tree depth is *exactly*
-    /// `max_depth` — not just `<=`.
-    #[test]
-    fn deep_chain_reaches_exact_max_depth() {
-        let chain_len = 20;
-        let max_depth = 5;
-        let (browser, root) = deep_chain(chain_len);
-        let result = browser
-            .browse(root, Some(max_depth))
-            .expect("browse should succeed");
-
-        let depth = max_tree_depth(&result);
-        assert_eq!(
-            depth, max_depth,
-            "tree depth {depth} should be exactly max_depth {max_depth} when the chain is long \
-             enough to fill it"
-        );
-    }
-
-    /// Regression test: when `max_depth` exceeds the actual graph depth, the
-    /// entire tree must be browsed. A bug that both incremented `depth` and
-    /// decremented `max_depth` at each level would halve the effective reach
-    /// (stopping at `ceil(max_depth / 2)`), silently truncating the tree even
-    /// though `max_depth` was larger than the graph.
-    ///
-    /// Chain of 10 nodes (depth 9) with `max_depth = 15`:
-    ///   - Correct:  effective limit = 15, full chain browsed -> 9 nodes.
-    ///   - Buggy:    effective limit = ceil(15/2) = 8, last node lost -> 8 nodes.
-    #[test]
-    fn max_depth_greater_than_graph_depth_browses_entire_tree() {
-        let chain_len = 10;
-        let max_depth = 15; // well beyond the actual depth of 9
-        let (browser, root) = deep_chain(chain_len);
-        let result = browser
-            .browse(root, Some(max_depth))
-            .expect("browse should succeed");
-
-        let expected_nodes = chain_len.saturating_sub(1) as usize; // nodes 2..=10
-        let expected_depth = expected_nodes; // linear chain, depth == node count
-
-        let total = count_nodes(&result);
-        assert_eq!(
-            total, expected_nodes,
-            "all {expected_nodes} nodes should be browsed when max_depth ({max_depth}) exceeds \
-             the graph depth ({expected_depth}), but only {total} were found"
-        );
-
-        let depth = max_tree_depth(&result);
-        assert_eq!(
-            depth, expected_depth,
-            "tree depth should equal the full graph depth {expected_depth} when max_depth \
-             ({max_depth}) is not a limiting factor, but was {depth}"
-        );
-    }
-
-    #[test]
-    fn max_depth_zero_returns_empty() {
-        let (browser, root) = deep_chain(10);
-        let result = browser
-            .browse(root, Some(0))
-            .expect("browse should succeed");
-        assert!(result.is_empty(), "max_depth=0 should return no nodes");
-    }
-
-    #[test]
-    fn max_depth_one_returns_flat_children() {
-        let (browser, root) = deep_chain(10);
-        let result = browser
-            .browse(root, Some(1))
-            .expect("browse should succeed");
-
-        // max_depth=1, depth=0: 0 >= 1 is false, so browse_node(root) runs.
-        // It returns [obj(2)]. Recurse into 2 with depth=1, max_depth=Some(0).
-        // depth=1, max_depth=Some(0): 1 >= 0 is true -> return empty.
-        // So node 2 has no children.
-        assert_eq!(result.len(), 1);
-        assert!(
-            result
-                .first()
-                .expect("root should have a child")
-                .children
-                .is_empty(),
-            "at max_depth=1, children should not be recursed into"
-        );
-    }
-
-    #[test]
-    fn method_nodes_not_recursed() {
-        let mut browser = MockBrowser::new();
-        browser.add_children(nid(1), vec![method(2), obj(3), view(6)]);
-        browser.add_children(nid(2), vec![obj(4)]); // should never be reached
-        browser.add_children(nid(3), vec![var(5)]);
-        browser.add_children(nid(6), vec![obj(7)]); // should never be reached
-
-        let result = browser.browse(nid(1), None).expect("browse should succeed");
-
-        assert_eq!(result.len(), 3);
-
-        let method_node = result
-            .iter()
-            .find(|n| n.node_id == nid(2))
-            .expect("method node");
-        assert!(
-            method_node.children.is_empty(),
-            "method nodes should not be recursed"
-        );
-        let view_node = result
-            .iter()
-            .find(|n| n.node_id == nid(6))
-            .expect("view node");
-        assert!(
-            view_node.children.is_empty(),
-            "view nodes should not be recursed"
-        );
-
-        let obj_node = result
-            .iter()
-            .find(|n| n.node_id == nid(3))
-            .expect("object node");
-        assert_eq!(
-            obj_node.children.len(),
+    #[tokio::test]
+    async fn every_node_class_is_expanded() -> Result<()> {
+        let mut source = MockSource::new();
+        source.add_children(
             1,
-            "object node 3 should have var(5) as child"
+            vec![
+                node(2, "Variable", OpcUaNodeClass::Variable),
+                node(3, "Method", OpcUaNodeClass::Method),
+                node(4, "View", OpcUaNodeClass::View),
+                node(5, "Other", OpcUaNodeClass::Other(99)),
+            ],
         );
-    }
+        for value in 2..=5 {
+            source.add_children(value, vec![object(value + 10, &format!("Child{value}"))]);
+        }
 
-    #[test]
-    fn single_object_no_children() {
-        let mut browser = MockBrowser::new();
-        browser.add_children(nid(1), vec![obj(2)]);
-        // node 2 has no entries in the map -> browse_node returns empty
-
-        let result = browser.browse(nid(1), None).expect("browse should succeed");
-        assert_eq!(result.len(), 1, "root should only have one child");
-        assert_eq!(
-            result.first().expect("root should have one child").node_id,
-            nid(2),
-            "root should have child node 2"
-        );
+        let graph = source
+            .browse(object(1, "Start"), "/Start", OpcUaBrowseOptions::new())
+            .await?;
+        assert_eq!(graph.len(), 9);
         assert!(
-            result
-                .first()
-                .expect("root should have one child")
-                .children
-                .is_empty(),
-            "child node 2 should have no children"
+            graph
+                .routes()
+                .all(|route| route.expansion() == OpcUaExpansion::Expanded)
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn cycles_are_terminal_and_siblings_continue() -> Result<()> {
+        let mut source = MockSource::new();
+        source.add_children(1, vec![object(2, "Loop"), object(3, "Sibling")]);
+        source.add_children(2, vec![object(1, "Start")]);
+        source.add_children(3, vec![object(4, "Leaf")]);
+
+        let graph = source
+            .browse(object(1, "Start"), "/Start", OpcUaBrowseOptions::new())
+            .await?;
+        let cycle = graph
+            .resolve_path(&"/Start/Loop/Start".parse()?)
+            .routes()
+            .next();
+        let sibling = graph
+            .resolve_path(&"/Start/Sibling/Leaf".parse()?)
+            .routes()
+            .next();
+        assert_eq!(
+            cycle.map(|route| route.expansion()),
+            Some(OpcUaExpansion::Cycle)
+        );
+        assert!(sibling.is_some());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn depth_limited_routes_are_not_leaves() -> Result<()> {
+        let mut source = MockSource::new();
+        source.add_children(1, vec![object(2, "Child")]);
+        source.add_children(2, vec![object(3, "Grandchild")]);
+
+        let graph = source
+            .browse(
+                object(1, "Start"),
+                "/Start",
+                OpcUaBrowseOptions::new().with_max_depth(1),
+            )
+            .await?;
+        let child = graph.resolve_path(&"/Start/Child".parse()?);
+        assert_eq!(
+            child.routes().next().map(|route| route.expansion()),
+            Some(OpcUaExpansion::DepthLimited)
+        );
+        assert!(child.leaves().is_empty());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn duplicate_routes_share_one_child_snapshot() -> Result<()> {
+        let mut source = MockSource::new();
+        source.add_children(1, vec![object(2, "Left"), object(3, "Right")]);
+        source.add_children(2, vec![object(4, "Shared")]);
+        source.add_children(3, vec![object(4, "Shared")]);
+        source.add_children(4, vec![object(5, "Leaf")]);
+
+        let graph = source
+            .browse(object(1, "Start"), "/Start", OpcUaBrowseOptions::new())
+            .await?;
+        assert_eq!(
+            graph
+                .resolve_path(&"/Start/Left/Shared/Leaf".parse()?)
+                .len(),
+            1
+        );
+        assert_eq!(
+            graph
+                .resolve_path(&"/Start/Right/Shared/Leaf".parse()?)
+                .len(),
+            1
+        );
+        assert_eq!(source.fetches.borrow().get(&id(4)), Some(&1));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn absolute_path_resolution_keeps_every_match_and_reuses_cache() -> Result<()> {
+        let mut source = MockSource::new();
+        source.add_children(84, vec![object(1, "Device"), object(2, "Device")]);
+        source.add_children(1, vec![object(3, "LeafA")]);
+        source.add_children(2, vec![object(4, "LeafB")]);
+
+        let mut collector = Collector::new(&source, OpcUaBrowseOptions::new());
+        let path = "/Device".parse()?;
+        let starts = collector.resolve_path(&path).await?;
+        let graph = collector.collect(path, starts).await?;
+        assert_eq!(graph.roots().len(), 2);
+        assert_eq!(source.fetches.borrow().get(&id(84)), Some(&1));
+        assert!(graph.resolve_path(&"/Device/LeafA".parse()?).len() == 1);
+        assert!(graph.resolve_path(&"/Device/LeafB".parse()?).len() == 1);
+        Ok(())
     }
 
     #[test]
-    fn large_cycle_stress() {
-        let cycle_len = 500;
-        let (browser, root) = long_cycle(cycle_len);
-        assert!(browser.browse(root, None).is_err());
+    fn explicit_mounts_validate_root_and_final_browse_name() -> Result<()> {
+        let root = node(84, "Root", OpcUaNodeClass::Object);
+        let sensor = object(1, "Sensor");
+        assert!(validate_mount(&root, &"/".parse()?).is_ok());
+        assert!(validate_mount(&root, &"/Root".parse()?).is_err());
+        assert!(validate_mount(&sensor, &"/Objects/Sensor".parse()?).is_ok());
+        assert!(validate_mount(&sensor, &"/".parse()?).is_err());
+        assert!(validate_mount(&sensor, &"/Objects/Other".parse()?).is_err());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn reusable_single_graph_queries_preserve_globset_grammar() -> Result<()> {
+        let mut source = MockSource::new();
+        source.add_children(
+            1,
+            vec![
+                node(2, "Temperature", OpcUaNodeClass::Variable),
+                node(3, "Pressure", OpcUaNodeClass::Variable),
+                object(4, "Group"),
+                node(6, "2:A/B", OpcUaNodeClass::Variable),
+            ],
+        );
+        source.add_children(4, vec![node(5, "Flow1", OpcUaNodeClass::Variable)]);
+
+        let graph = source
+            .browse(object(1, "Start"), "/Start", OpcUaBrowseOptions::new())
+            .await?;
+        let query = graph.find_all("/Start/**/{Temperature,Pressure,Flow[0-9]}")?;
+        assert_eq!(query.variables().leaves().len(), 3);
+        assert_eq!(query.routes().count(), 3);
+        assert_eq!(query.routes().count(), 3);
+        assert_eq!(graph.find_all(r"/Start/2\:A\/B")?.len(), 1);
+        assert!(graph.find_all("Start/**").is_err());
+        Ok(())
     }
 }

--- a/crates/instro-opcua/src/client.rs
+++ b/crates/instro-opcua/src/client.rs
@@ -10,19 +10,20 @@
 //! [`OpcUaClientBuilder`] provides a builder API for configuring security mode,
 //! security policy, user authentication, PKI certificates, timeouts, and
 //! server trust before connecting to an endpoint.
+//! [`OpcUaClient`] exposes graph-first recursive browse methods and
+//! filesystem-style local route queries.
 //!
 //! [`OpcUaStreamSession`] manages background OPC-UA streaming. In polling mode it
 //! periodically reads node attribute values via [`OpcUaClient::read_nodes`] and
-//! delivers each batch of decoded [`OpcUaSample`](super::types::OpcUaSample)s
+//! delivers each batch of decoded [`OpcUaSample`]s
 //! through a caller-supplied callback. In subscription mode it forwards
-//! monitored-item notifications via a merged [`Stream`](futures_util::stream::Stream)
+//! monitored-item notifications via a merged [`Stream`]
 //! of all monitored items, delivering each sample through the same `on_data` callback.
 //!
 //! Streams are started with [`OpcUaClient::start_polling`] or
 //! [`OpcUaClient::start_subscription`]. Both modes of streaming are stopped by
 //! dropping the [`OpcUaStreamSession`].
 
-use std::borrow::Cow;
 use std::collections::HashMap;
 use std::future;
 use std::ops::Deref;
@@ -66,52 +67,36 @@ use super::metrics::NodeReadCounts;
 use super::metrics::PollLoopMetricsLogger;
 use super::types::OpcUaDataPoint;
 use super::types::OpcUaMonitoredItemConfig;
-use super::types::OpcUaNode;
 use super::types::OpcUaNodeClass;
+use super::types::OpcUaNodeReadTarget;
 use super::types::OpcUaPki;
 use super::types::OpcUaSample;
 use super::types::OpcUaSecurityMode;
 use super::types::OpcUaSecurityPolicy;
 use super::types::OpcUaSubscriptionConfig;
 use super::types::OpcUaUserToken;
-use super::types::QualifiedBrowseName;
+use crate::path::OpcUaBrowseName;
 use crate::types::OpcUaNodeId;
 
-/// Enables either borrow or move of the nodes via the default implementations, avoiding clones out-of-the-box.
-/// Downstream implementations can choose to clone, but it's not the default.
-pub trait OpcUaNodeListSource<'nodes> {
-    /// Converts the source into a list of nodes, preserving the value category of the underlying source.
-    fn into_node_list(self) -> Cow<'nodes, [OpcUaNode]>;
-}
-
-impl<'nodes, D: Deref<Target = [OpcUaNode]>> OpcUaNodeListSource<'nodes> for &'nodes D {
-    fn into_node_list(self) -> Cow<'nodes, [OpcUaNode]> {
-        Cow::Borrowed(self.deref())
-    }
-}
-
-impl OpcUaNodeListSource<'static> for Vec<OpcUaNode> {
-    fn into_node_list(self) -> Cow<'static, [OpcUaNode]> {
-        Cow::Owned(self)
-    }
-}
-
 /// A list of OPC-UA nodes, paired with an attribute ID.
-/// Opinionated against taking ownership of nodes via a clone, instead accepting a borrow or move of the nodes.
 /// Pre-calculates the list of node attribute pairs to avoid recalculating on every read request.
 #[derive(Debug, Clone)]
-pub struct OpcUaNodeReadBatch<'nodes> {
-    nodes: Cow<'nodes, [OpcUaNode]>,
+pub struct OpcUaNodeReadBatch {
+    nodes: Vec<OpcUaNodeReadTarget>,
     node_attr_pairs: Vec<(ua::NodeId, ua::AttributeId)>,
 }
 
-impl<'nodes> OpcUaNodeReadBatch<'nodes> {
+/// The positional decoding outcome for one requested read target.
+pub type OpcUaNodeReadOutcome = Result<OpcUaSample>;
+
+impl OpcUaNodeReadBatch {
     /// Creates a new batch of nodes and attribute pairs.
-    pub fn new<Src>(nodes: Src, attr: ua::AttributeId) -> Self
+    pub fn new<Nodes, Node>(nodes: Nodes, attr: ua::AttributeId) -> Self
     where
-        Src: OpcUaNodeListSource<'nodes>,
+        Nodes: IntoIterator<Item = Node>,
+        Node: Into<OpcUaNodeReadTarget>,
     {
-        let nodes = nodes.into_node_list();
+        let nodes = nodes.into_iter().map(Into::into).collect::<Vec<_>>();
         Self {
             node_attr_pairs: nodes
                 .iter()
@@ -122,7 +107,7 @@ impl<'nodes> OpcUaNodeReadBatch<'nodes> {
     }
 
     /// Returns the list of nodes, used in read requests.
-    pub fn nodes(&self) -> &[OpcUaNode] {
+    pub fn nodes(&self) -> &[OpcUaNodeReadTarget] {
         &self.nodes
     }
 
@@ -216,6 +201,8 @@ impl SessionHandle {
 /// Wraps an [`AsyncClient`].
 ///
 /// The client is created by the [`OpcUaClientBuilder::connect`] method, which returns an [`Arc`] of the client.
+/// Browse methods return immutable route graphs and follow continuation points
+/// transparently while collecting each node's references.
 /// Streaming sessions started from this client own their own tokio runtime; see [`OpcUaStreamSession`].
 pub struct OpcUaClient {
     client: AsyncClient,
@@ -244,12 +231,17 @@ impl OpcUaClient {
     ///
     /// The runtime and thread are shut down when the session is dropped.
     #[must_use = "dropping the returned session will stop the polling loop"]
-    pub fn start_polling(
+    pub fn start_polling<Nodes, Node>(
         self: &Arc<Self>,
-        nodes: Vec<OpcUaNode>,
+        nodes: Nodes,
         polling_interval: Duration,
         on_data: impl FnMut(Box<dyn Iterator<Item = OpcUaSample>>) + Send + 'static,
-    ) -> Result<OpcUaStreamSession> {
+    ) -> Result<OpcUaStreamSession>
+    where
+        Nodes: IntoIterator<Item = Node>,
+        Node: Into<OpcUaNodeReadTarget>,
+    {
+        let nodes = nodes.into_iter().map(Into::into).collect();
         let this = Arc::downgrade(self);
         OpcUaStreamSession::new("opcua-poll-loop", async move || {
             // Downgrade the client to a weak reference to avoid holding onto the strong reference.
@@ -258,13 +250,14 @@ impl OpcUaClient {
         })
     }
 
-    /// Reads the configured attribute for every node in `node_list` and returns
-    /// the successfully decoded samples in the same order as the input nodes.
+    /// Reads the configured attribute for every node in `node_list`.
     ///
-    /// Returns [`Err`] if the underlying batched [`AsyncClient::read_many_attributes`] call fails.
-    /// Per-node decoding failures are logged at [`tracing::warn`] and dropped from the
-    /// returned vector, so the output may be shorter than `node_list.len()`.
-    pub async fn read_nodes(&self, node_list: &OpcUaNodeReadBatch<'_>) -> Result<Vec<OpcUaSample>> {
+    /// The outer error reports a failed batch operation. A successful batch
+    /// contains exactly one positional decoding outcome per requested target.
+    pub async fn read_nodes(
+        &self,
+        node_list: &OpcUaNodeReadBatch,
+    ) -> Result<Vec<OpcUaNodeReadOutcome>> {
         let read_result = self
             .read_many_attributes(node_list.pairs())
             .await
@@ -283,28 +276,20 @@ impl OpcUaClient {
             .iter()
             .zip(read_result)
             .enumerate()
-            .filter_map(|(i, (node, value))| match OpcUaDataPoint::try_from(value) {
-                Err(e) => {
-                    tracing::warn!(
-                        target: "opcua::client",
-                        error = ?e,
-                        node_index = i,
-                        "discarding data due to error decoding value for node"
-                    );
-
-                    None
-                }
-
-                Ok(value) => Some(OpcUaSample::new(node.node_id.clone(), value)),
+            .map(|(index, (node, value))| {
+                OpcUaDataPoint::try_from(value)
+                    .map(|value| OpcUaSample::from_target(node, value))
+                    .with_context(|| {
+                        format!("decoding value for read target {index} ({})", node.node_id)
+                    })
             })
             .collect_vec())
     }
 
-    /// Reads the browse name, display name, and node class for a node.
-    pub async fn read_node_metadata(
+    pub(crate) async fn read_node_metadata(
         &self,
         node_id: &OpcUaNodeId,
-    ) -> Result<(QualifiedBrowseName, String, OpcUaNodeClass)> {
+    ) -> Result<(OpcUaBrowseName, String, OpcUaNodeClass)> {
         let ua_node_id = ua::NodeId::from(node_id.clone());
 
         let browse_name_value = self
@@ -338,10 +323,10 @@ impl OpcUaClient {
             .with_context(|| format!("node class attribute for node {node_id} was not readable"));
 
         Ok((
-            QualifiedBrowseName {
-                namespace_index: browse_name.namespace_index(),
-                name: browse_name.name().to_string(),
-            },
+            OpcUaBrowseName::new(
+                browse_name.namespace_index(),
+                browse_name.name().to_string(),
+            ),
             display_name.text().to_string(),
             match node_class {
                 Ok(node_class) => OpcUaNodeClass::from(node_class),
@@ -359,16 +344,19 @@ impl OpcUaClient {
     ///
     /// The runtime and thread are shut down when the session is dropped.
     #[must_use = "dropping the returned session will deregister the subscription"]
-    pub async fn start_subscription<F>(
+    pub async fn start_subscription<Nodes, Node, F>(
         self: &Arc<Self>,
-        nodes: Vec<OpcUaNode>,
+        nodes: Nodes,
         sub_config: OpcUaSubscriptionConfig,
         item: OpcUaMonitoredItemConfig,
         on_data: F,
     ) -> Result<OpcUaStreamSession>
     where
+        Nodes: IntoIterator<Item = Node>,
+        Node: Into<OpcUaNodeReadTarget>,
         F: FnMut(Box<dyn Iterator<Item = OpcUaSample>>) + Send + 'static,
     {
+        let nodes = nodes.into_iter().map(Into::into).collect::<Vec<_>>();
         // Configure the `AsyncSubscription` and per-node monitoring config
         let subscription_builder = SubscriptionBuilder::from(sub_config);
         let item_builder = item.apply_to_builder(MonitoredItemCreateRequestBuilder::new(
@@ -397,8 +385,8 @@ impl OpcUaClient {
         let requested_count = nodes.len();
         let mut valid_streams = Vec::with_capacity(requested_count);
 
-        for (node, result) in nodes.iter().cloned().zip(item_results) {
-            let node_id = node.node_id;
+        for (target_key, (node, result)) in nodes.iter().cloned().zip(item_results).enumerate() {
+            let node_id = node.node_id.clone();
 
             match result {
                 Ok((create_result, monitored_item)) => {
@@ -409,12 +397,15 @@ impl OpcUaClient {
                     valid_streams.push(
                         monitored_item
                             .filter_map(move |value| {
-                                let node_id = node_id.clone();
+                                let node = node.clone();
                                 async move {
                                     match OpcUaDataPoint::try_from(value) {
-                                        Ok(data) => Some((node_id, data)),
+                                        Ok(data) => {
+                                            Some((target_key, OpcUaSample::from_target(&node, data)))
+                                        }
 
                                         Err(e) => {
+                                            let node_id = &node.node_id;
                                             tracing::warn!(
                                                 target: "opcua::client::subscribe",
                                                 error = ?e,
@@ -469,7 +460,7 @@ impl OpcUaClient {
     /// Polls `nodes` at `polling_interval`, yielding decoded samples through `on_data`.
     async fn poll_loop(
         this: Weak<Self>,
-        nodes: Vec<OpcUaNode>,
+        nodes: Vec<OpcUaNodeReadTarget>,
         polling_interval: Duration,
         mut on_data: impl FnMut(Box<dyn Iterator<Item = OpcUaSample>>),
     ) {
@@ -513,16 +504,28 @@ impl OpcUaClient {
             };
 
             let (outcome, samples) = match read_result {
-                Ok(values) => {
-                    let successful_reads = values.len() as u64;
+                Ok(outcomes) => {
+                    let successful_reads =
+                        outcomes.iter().filter(|result| result.is_ok()).count() as u64;
                     let failed_reads = total_nodes.saturating_sub(successful_reads);
+                    let samples = outcomes.into_iter().filter_map(|result| match result {
+                        Ok(sample) => Some(sample),
+                        Err(error) => {
+                            tracing::warn!(
+                                target: "opcua::client::poll",
+                                ?error,
+                                "discarding data due to read decoding error"
+                            );
+                            None
+                        }
+                    });
 
                     (
                         Some(NodeReadCounts {
                             valid_samples: successful_reads,
                             invalid_samples: failed_reads,
                         }),
-                        Some(values),
+                        Some(samples.collect_vec()),
                     )
                 }
 
@@ -558,21 +561,18 @@ impl OpcUaClient {
         mut timer: Option<T>,
     ) where
         R: NodeReader,
-        S: Stream<Item = (OpcUaNodeId, OpcUaDataPoint)> + Send + Unpin + 'static,
+        S: Stream<Item = (usize, OpcUaSample)> + Send + Unpin + 'static,
         F: FnMut(Box<dyn Iterator<Item = OpcUaSample>>) + Send + 'static,
-        N: IntoIterator<Item = OpcUaNode>,
+        N: IntoIterator<Item = OpcUaNodeReadTarget>,
         T: PollTimer,
     {
-        let all_nodes = nodes
-            .into_iter()
-            .map(|n| (n.node_id.clone(), n))
-            .collect::<HashMap<_, _>>();
+        let all_nodes = nodes.into_iter().enumerate().collect::<HashMap<_, _>>();
 
         // Nodes still quiet in the current interval; notifications remove nodes until the next tick.
         let mut quiet_nodes = all_nodes.clone();
 
         // Poll results wait one tick before flushing so late notifications can dedup by timestamp.
-        let mut polled_nodes = HashMap::<OpcUaNodeId, OpcUaSample>::new();
+        let mut polled_nodes = HashMap::<_, OpcUaSample>::new();
 
         let mut stream = stream.ready_chunks(10);
 
@@ -601,8 +601,15 @@ impl OpcUaClient {
                     on_data(Box::new(polled_samples_to_flush.into_iter()));
 
                     if !quiet_nodes.is_empty() {
-                        let nodes = quiet_nodes.values().cloned().collect_vec();
-                        let batch = OpcUaNodeReadBatch::new(&nodes, ua::AttributeId::VALUE);
+                        let nodes = quiet_nodes
+                            .iter()
+                            .map(|(target_key, node)| (*target_key, node.clone()))
+                            .collect_vec();
+                        let read_targets = nodes
+                            .iter()
+                            .map(|(_, node)| node.clone())
+                            .collect_vec();
+                        let batch = OpcUaNodeReadBatch::new(read_targets, ua::AttributeId::VALUE);
 
                         let reads = match reader.read_nodes(&batch).await {
                             Ok(reads) => reads,
@@ -618,32 +625,50 @@ impl OpcUaClient {
                             }
                         };
 
-                        let to_flush = reads
-                            .into_iter()
-                            .map(|sample| (sample.node_id.clone(), sample));
-                        polled_nodes.extend(to_flush);
+                        if reads.len() != nodes.len() {
+                            tracing::error!(
+                                target: "opcua::client::subscribe",
+                                outcomes = reads.len(),
+                                targets = nodes.len(),
+                                "background poll returned misaligned read outcomes"
+                            );
+                            continue;
+                        }
+
+                        for ((target_key, _), outcome) in nodes.into_iter().zip(reads) {
+                            match outcome {
+                                Ok(sample) => {
+                                    polled_nodes.insert(target_key, sample);
+                                }
+                                Err(error) => {
+                                    tracing::warn!(
+                                        target: "opcua::client::subscribe",
+                                        ?error,
+                                        target_key,
+                                        "discarding background poll decoding failure"
+                                    );
+                                }
+                            }
+                        }
                     }
 
-                    quiet_nodes = all_nodes
-                        .iter()
-                        .map(|(node_id, n)| (node_id.clone(), n.clone()))
-                        .collect();
+                    quiet_nodes = all_nodes.clone();
                 },
 
                 chunk = stream.next().fuse() => if let Some(chunk) = chunk {
                     let mut samples = Vec::with_capacity(chunk.len() * 2);
 
-                    for (node_id, data) in chunk {
-                        quiet_nodes.remove(&node_id);
+                    for (target_key, sample) in chunk {
+                        quiet_nodes.remove(&target_key);
 
                         // Older poll values preserve ordering; same-or-newer poll values are stale.
-                        if let Some(polled_sample) = polled_nodes.remove(&node_id)
-                            && polled_sample.data.server_timestamp < data.server_timestamp
+                        if let Some(polled_sample) = polled_nodes.remove(&target_key)
+                            && polled_sample.data.server_timestamp < sample.data.server_timestamp
                         {
                             samples.push(polled_sample);
                         }
 
-                        samples.push(OpcUaSample::new(node_id, data));
+                        samples.push(sample);
                     }
 
                     if !samples.is_empty() {
@@ -684,8 +709,8 @@ pub(crate) trait NodeReader {
     /// Returns `false` once the backing client has been dropped, signalling the loop to stop.
     fn is_alive(&self) -> bool;
 
-    /// Reads the configured attribute for every node in `batch`, returning decoded samples.
-    async fn read_nodes(&self, batch: &OpcUaNodeReadBatch<'_>) -> Result<Vec<OpcUaSample>>;
+    /// Reads every target, retaining one positional outcome per target.
+    async fn read_nodes(&self, batch: &OpcUaNodeReadBatch) -> Result<Vec<OpcUaNodeReadOutcome>>;
 }
 
 /// Production [`NodeReader`] backed by a [`Weak`] reference to the owning [`OpcUaClient`].
@@ -698,7 +723,7 @@ impl NodeReader for ClientNodeReader {
         self.client.strong_count() > 0
     }
 
-    async fn read_nodes(&self, batch: &OpcUaNodeReadBatch<'_>) -> Result<Vec<OpcUaSample>> {
+    async fn read_nodes(&self, batch: &OpcUaNodeReadBatch) -> Result<Vec<OpcUaNodeReadOutcome>> {
         // Holding the upgraded strong reference across the read makes a concurrent
         // `OpcUaClient::disconnect()` bail rather than tearing the client down mid-read,
         // matching the previous in-loop `Weak::upgrade` behaviour.
@@ -1015,21 +1040,24 @@ mod subscription_loop_tests {
     use anyhow::anyhow;
     use futures_util::Stream;
     use futures_util::StreamExt as _;
+    use open62541::ua;
     use tokio::sync::mpsc;
     use tokio::time::timeout;
 
     use super::NodeReader;
     use super::OpcUaClient;
     use super::OpcUaNodeReadBatch;
+    use super::OpcUaNodeReadOutcome;
     use super::PollTimer;
-    use crate::types::BrowsePath;
+    use crate::path::OpcUaBrowseName;
+    use crate::path::OpcUaBrowsePath;
     use crate::types::OpcUaDataPoint;
     use crate::types::OpcUaNode;
     use crate::types::OpcUaNodeClass;
     use crate::types::OpcUaNodeId;
+    use crate::types::OpcUaNodeReadTarget;
     use crate::types::OpcUaSample;
     use crate::types::OpcUaValue;
-    use crate::types::QualifiedBrowseName;
 
     /// Generous deadline; the deterministic loop should make progress near-instantly, so this
     /// only fires if the loop wedges (which is itself a test failure worth surfacing).
@@ -1043,6 +1071,8 @@ mod subscription_loop_tests {
         next_timestamp: u64,
         /// The set of node ids requested on each `read_nodes` call, in call order.
         requested: Vec<HashSet<OpcUaNodeId>>,
+        /// Positional read outcomes forced to fail in every batch.
+        failed_indices: HashSet<usize>,
     }
 
     /// In-memory [`NodeReader`] returning canned samples with test-controlled timestamps.
@@ -1056,10 +1086,18 @@ mod subscription_loop_tests {
         fn new(
             initial_timestamp: u64,
         ) -> (Self, Arc<Mutex<ReaderState>>, mpsc::UnboundedReceiver<()>) {
+            Self::with_failures(initial_timestamp, HashSet::new())
+        }
+
+        fn with_failures(
+            initial_timestamp: u64,
+            failed_indices: HashSet<usize>,
+        ) -> (Self, Arc<Mutex<ReaderState>>, mpsc::UnboundedReceiver<()>) {
             let state = Arc::new(Mutex::new(ReaderState {
                 is_alive: true,
                 next_timestamp: initial_timestamp,
                 requested: Vec::new(),
+                failed_indices,
             }));
             let (read_done, read_done_rx) = mpsc::unbounded_channel();
             let reader = Self {
@@ -1075,7 +1113,10 @@ mod subscription_loop_tests {
             self.state.lock().map(|s| s.is_alive).unwrap_or(false)
         }
 
-        async fn read_nodes(&self, batch: &OpcUaNodeReadBatch<'_>) -> Result<Vec<OpcUaSample>> {
+        async fn read_nodes(
+            &self,
+            batch: &OpcUaNodeReadBatch,
+        ) -> Result<Vec<OpcUaNodeReadOutcome>> {
             let samples = {
                 let mut state = self
                     .state
@@ -1095,7 +1136,17 @@ mod subscription_loop_tests {
                 batch
                     .nodes()
                     .iter()
-                    .map(|node| OpcUaSample::new(node.node_id.clone(), datapoint(timestamp, 0.0)))
+                    .enumerate()
+                    .map(|(index, node)| {
+                        if state.failed_indices.contains(&index) {
+                            Err(anyhow!("forced decode failure at index {index}"))
+                        } else {
+                            Ok(OpcUaSample::from_target(
+                                node,
+                                datapoint(timestamp, index as f64),
+                            ))
+                        }
+                    })
                     .collect::<Vec<_>>()
             };
 
@@ -1121,15 +1172,28 @@ mod subscription_loop_tests {
         }
     }
 
-    fn test_node(id: u32, name: &str) -> OpcUaNode {
-        OpcUaNode {
-            node_id: OpcUaNodeId::numeric(1, id),
-            browse_name: name.to_owned(),
-            display_name: name.to_owned(),
-            node_class: OpcUaNodeClass::Variable,
-            browse_path: BrowsePath::from_segment(QualifiedBrowseName::new(1, name.to_owned())),
-            children: Vec::new(),
-        }
+    fn test_node(id: u32, name: &str) -> OpcUaNodeReadTarget {
+        OpcUaNodeReadTarget::new(
+            OpcUaNodeId::numeric(1, id),
+            OpcUaBrowsePath::from_segment(OpcUaBrowseName::new(1, name.to_owned())),
+        )
+    }
+
+    #[test]
+    fn read_batch_accepts_node_metadata_without_inventing_paths() {
+        let node = OpcUaNode::new(
+            OpcUaNodeId::numeric(1, 1),
+            "Node".to_owned(),
+            OpcUaNodeClass::Variable,
+            OpcUaBrowseName::new(1, "Node".to_owned()),
+        );
+
+        let batch = OpcUaNodeReadBatch::new([node], ua::AttributeId::VALUE);
+
+        assert_eq!(batch.len(), 1);
+        let target = batch.nodes().first().expect("batch should contain node");
+        assert_eq!(target.node_id, OpcUaNodeId::numeric(1, 1));
+        assert_eq!(target.browse_path, None);
     }
 
     fn datapoint(server_timestamp: u64, value: f64) -> OpcUaDataPoint {
@@ -1140,11 +1204,19 @@ mod subscription_loop_tests {
         }
     }
 
+    fn notification(
+        target_key: usize,
+        target: &OpcUaNodeReadTarget,
+        data: OpcUaDataPoint,
+    ) -> (usize, OpcUaSample) {
+        (target_key, OpcUaSample::from_target(target, data))
+    }
+
     /// Wraps an unbounded channel as a notification [`Stream`]; the stream ends when the sender
     /// is dropped, after draining any buffered items (exercising the loop's exit drain).
     fn notification_stream(
-        rx: mpsc::UnboundedReceiver<(OpcUaNodeId, OpcUaDataPoint)>,
-    ) -> impl Stream<Item = (OpcUaNodeId, OpcUaDataPoint)> + Send + Unpin + 'static {
+        rx: mpsc::UnboundedReceiver<(usize, OpcUaSample)>,
+    ) -> impl Stream<Item = (usize, OpcUaSample)> + Send + Unpin + 'static {
         futures_util::stream::unfold(rx, |mut rx| async move {
             rx.recv().await.map(|item| (item, rx))
         })
@@ -1263,6 +1335,95 @@ mod subscription_loop_tests {
         Ok(())
     }
 
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn duplicate_browse_paths_remain_distinct_in_background_polling() -> Result<()> {
+        let first = test_node(1, "Shared");
+        let second = test_node(2, "Shared");
+        let (reader, state, mut read_done_rx) = MockNodeReader::new(1);
+        let (note_tx, note_rx) = mpsc::unbounded_channel();
+        let (pulse_tx, pulse_rx) = mpsc::unbounded_channel();
+        let (on_data, mut out_rx) = output_sink();
+
+        let handle = tokio::spawn(OpcUaClient::subscription_loop(
+            reader,
+            vec![first.clone(), second.clone()],
+            notification_stream(note_rx),
+            on_data,
+            Some(MockPollTimer { pulses: pulse_rx }),
+        ));
+
+        pulse_tx.send(()).context("pulsing poll tick")?;
+        await_signal(&mut read_done_rx, "background poll read").await?;
+
+        drop(note_tx);
+        await_loop(handle).await?;
+
+        let samples = drain_batches(&mut out_rx)
+            .into_iter()
+            .flatten()
+            .collect::<Vec<_>>();
+        let sample_node_ids = samples
+            .iter()
+            .map(|sample| sample.node_id.clone())
+            .collect::<HashSet<_>>();
+        assert_eq!(
+            sample_node_ids,
+            HashSet::from([first.node_id.clone(), second.node_id.clone()])
+        );
+
+        let requested = state
+            .lock()
+            .map_err(|_| anyhow!("state poisoned"))?
+            .requested
+            .clone();
+        assert_eq!(
+            requested.first(),
+            Some(&HashSet::from([
+                first.node_id.clone(),
+                second.node_id.clone()
+            ])),
+            "duplicate browse paths should not collapse target reads"
+        );
+
+        Ok(())
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn decode_failures_keep_duplicate_poll_targets_positionally_aligned() -> Result<()> {
+        let duplicate = test_node(1, "Shared");
+        let targets = vec![duplicate; 5];
+        let (reader, _state, mut read_done_rx) =
+            MockNodeReader::with_failures(1, HashSet::from([0, 2, 4]));
+        let (note_tx, note_rx) = mpsc::unbounded_channel();
+        let (pulse_tx, pulse_rx) = mpsc::unbounded_channel();
+        let (on_data, mut out_rx) = output_sink();
+
+        let handle = tokio::spawn(OpcUaClient::subscription_loop(
+            reader,
+            targets,
+            notification_stream(note_rx),
+            on_data,
+            Some(MockPollTimer { pulses: pulse_rx }),
+        ));
+
+        pulse_tx.send(()).context("pulsing poll tick")?;
+        await_signal(&mut read_done_rx, "background poll read").await?;
+        drop(note_tx);
+        await_loop(handle).await?;
+
+        let mut values = drain_batches(&mut out_rx)
+            .into_iter()
+            .flatten()
+            .map(|sample| match sample.data.value {
+                OpcUaValue::Double(value) => Ok(value),
+                other => Err(anyhow!("unexpected polled value {other:?}")),
+            })
+            .collect::<Result<Vec<_>>>()?;
+        values.sort_by(f64::total_cmp);
+        assert_eq!(values, vec![1.0, 3.0]);
+        Ok(())
+    }
+
     /// When a buffered polled sample is not older than an arriving notification, it is dropped
     /// in favour of the live notification (the dedup window).
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1287,7 +1448,7 @@ mod subscription_loop_tests {
 
         // Notification at ts=100 (not newer) -> buffered polled sample dropped, only this emitted.
         note_tx
-            .send((x.node_id.clone(), datapoint(100, 1.0)))
+            .send(notification(0, &x, datapoint(100, 1.0)))
             .context("sending notification")?;
         drop(note_tx);
         await_loop(handle).await?;
@@ -1331,7 +1492,7 @@ mod subscription_loop_tests {
 
         // Notification at ts=200 (newer) -> emit polled@100 then notification@200.
         note_tx
-            .send((x.node_id.clone(), datapoint(200, 2.0)))
+            .send(notification(0, &x, datapoint(200, 2.0)))
             .context("sending notification")?;
         drop(note_tx);
         await_loop(handle).await?;
@@ -1418,7 +1579,7 @@ mod subscription_loop_tests {
 
         // Y notifies -> removed from quiet for the current interval.
         note_tx
-            .send((y.node_id.clone(), datapoint(10, 1.0)))
+            .send(notification(1, &y, datapoint(10, 1.0)))
             .context("sending Y notification")?;
         recv_nonempty(&mut out_rx, "Y notification batch").await?;
 
@@ -1478,7 +1639,7 @@ mod subscription_loop_tests {
         ));
 
         note_tx
-            .send((x.node_id.clone(), datapoint(7, 9.5)))
+            .send(notification(0, &x, datapoint(7, 9.5)))
             .context("sending notification")?;
         drop(note_tx);
         await_loop(handle).await?;
@@ -1528,7 +1689,7 @@ mod subscription_loop_tests {
 
         // Active node notifies.
         note_tx
-            .send((y.node_id.clone(), datapoint(5, 1.0)))
+            .send(notification(1, &y, datapoint(5, 1.0)))
             .context("sending Y notification")?;
         batches.push(recv_nonempty(&mut out_rx, "first Y notification").await?);
 
@@ -1538,7 +1699,7 @@ mod subscription_loop_tests {
 
         // Active node notifies again.
         note_tx
-            .send((y.node_id.clone(), datapoint(6, 2.0)))
+            .send(notification(1, &y, datapoint(6, 2.0)))
             .context("sending second Y notification")?;
         batches.push(recv_nonempty(&mut out_rx, "second Y notification").await?);
 

--- a/crates/instro-opcua/src/lib.rs
+++ b/crates/instro-opcua/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod browse;
 pub mod client;
 pub(crate) mod metrics;
+pub mod path;
 pub mod types;
 
 use anyhow::Context as _;

--- a/crates/instro-opcua/src/path.rs
+++ b/crates/instro-opcua/src/path.rs
@@ -1,0 +1,317 @@
+//! Absolute OPC UA browse paths and browse-name segment encoding.
+
+use std::fmt;
+use std::str::FromStr;
+
+use anyhow::Error;
+use anyhow::Result;
+use anyhow::bail;
+use serde::Deserialize;
+use serde::Serialize;
+
+const fn is_reserved(ch: char) -> bool {
+    matches!(ch, '/' | '.' | '<' | '>' | ':' | '#' | '!' | '&')
+}
+
+pub(crate) fn split_absolute_segments(path: &str, escape: char) -> Result<Vec<String>> {
+    let Some(path) = path.strip_prefix('/') else {
+        bail!("browse path must be absolute");
+    };
+
+    if path.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut segments = Vec::new();
+    let mut segment = String::new();
+    let mut escaped = false;
+
+    for ch in path.chars() {
+        if escaped {
+            segment.push(escape);
+            segment.push(ch);
+            escaped = false;
+        } else if ch == escape {
+            escaped = true;
+        } else if ch == '/' {
+            if segment.is_empty() {
+                bail!("browse path cannot contain an empty segment");
+            }
+
+            segments.push(std::mem::take(&mut segment));
+        } else {
+            segment.push(ch);
+        }
+    }
+
+    if escaped {
+        bail!("browse path cannot end with an escape marker");
+    }
+
+    if segment.is_empty() {
+        bail!("browse path cannot end with '/'");
+    }
+
+    segments.push(segment);
+
+    Ok(segments)
+}
+
+pub(crate) fn split_namespace_prefix(segment: &str, escape: char) -> Result<(Option<u16>, &str)> {
+    let mut escaped = false;
+
+    for (index, ch) in segment.char_indices() {
+        if escaped {
+            escaped = false;
+        } else if ch == escape {
+            escaped = true;
+        } else if ch == ':' {
+            let namespace = &segment[..index];
+
+            if !namespace.is_empty() && namespace.chars().all(|ch| ch.is_ascii_digit()) {
+                return Ok((Some(namespace.parse()?), &segment[index + ch.len_utf8()..]));
+            }
+
+            break;
+        }
+    }
+
+    Ok((None, segment))
+}
+
+fn encode_name(name: &str) -> String {
+    let mut encoded = String::with_capacity(name.len());
+    for ch in name.chars() {
+        if is_reserved(ch) {
+            encoded.push('&');
+        }
+
+        encoded.push(ch);
+    }
+
+    encoded
+}
+
+fn decode_name(encoded: &str) -> Result<String> {
+    let mut decoded = String::with_capacity(encoded.len());
+    let mut chars = encoded.chars();
+
+    while let Some(ch) = chars.next() {
+        if ch == '&' {
+            let escaped = chars
+                .next()
+                .ok_or_else(|| Error::msg("browse name cannot end with an escape marker"))?;
+
+            if !is_reserved(escaped) {
+                bail!("'&' in a browse name must escape a reserved character");
+            }
+
+            decoded.push(escaped);
+        } else if is_reserved(ch) {
+            bail!("reserved character '{ch}' in a browse name must be escaped");
+        } else {
+            decoded.push(ch);
+        }
+    }
+
+    Ok(decoded)
+}
+
+/// A browse-path segment preserving the namespace that qualifies its name.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct OpcUaBrowseName {
+    namespace: u16,
+    name: String,
+}
+
+impl OpcUaBrowseName {
+    /// Creates a browse name from an unescaped name.
+    pub const fn new(namespace: u16, name: String) -> Self {
+        Self { namespace, name }
+    }
+
+    pub const fn namespace(&self) -> u16 {
+        self.namespace
+    }
+
+    pub const fn name(&self) -> &str {
+        self.name.as_str()
+    }
+}
+
+impl fmt::Display for OpcUaBrowseName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.namespace != 0 {
+            write!(f, "{}:", self.namespace)?;
+        }
+
+        f.write_str(&encode_name(&self.name))
+    }
+}
+
+impl FromStr for OpcUaBrowseName {
+    type Err = Error;
+
+    fn from_str(segment: &str) -> Result<Self> {
+        if segment.is_empty() {
+            bail!("browse name cannot be empty");
+        }
+
+        let (namespace, name) = split_namespace_prefix(segment, '&')?;
+        let name = decode_name(name)?;
+
+        if name.is_empty() {
+            bail!("browse name cannot be empty");
+        }
+
+        Ok(Self::new(namespace.unwrap_or(0), name))
+    }
+}
+
+/// A rooted absolute path through OPC UA browse names.
+///
+/// `/` is the standard Root node. Every other path begins at Root and contains
+/// one or more encoded browse-name segments.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[serde(try_from = "String", into = "String")]
+pub struct OpcUaBrowsePath {
+    segments: Vec<OpcUaBrowseName>,
+}
+
+impl OpcUaBrowsePath {
+    /// Returns the standard Root path.
+    pub const fn root() -> Self {
+        Self {
+            segments: Vec::new(),
+        }
+    }
+
+    /// Creates an absolute path containing one segment below Root.
+    pub fn from_segment(segment: OpcUaBrowseName) -> Self {
+        Self {
+            segments: vec![segment],
+        }
+    }
+
+    /// Creates an absolute path from browse-name segments below Root.
+    pub fn from_segments(segments: impl IntoIterator<Item = OpcUaBrowseName>) -> Self {
+        Self {
+            segments: segments.into_iter().collect(),
+        }
+    }
+
+    /// Appends one child segment.
+    pub fn append(&mut self, segment: OpcUaBrowseName) -> &mut Self {
+        self.segments.push(segment);
+        self
+    }
+
+    /// Returns a new path with one child segment appended.
+    #[must_use]
+    pub fn with_child(mut self, segment: OpcUaBrowseName) -> Self {
+        self.segments.push(segment);
+        self
+    }
+
+    /// Returns whether this is `/`.
+    pub const fn is_root(&self) -> bool {
+        self.segments.is_empty()
+    }
+
+    /// Returns the segments below Root.
+    pub const fn segments(&self) -> &[OpcUaBrowseName] {
+        self.segments.as_slice()
+    }
+}
+
+impl fmt::Display for OpcUaBrowsePath {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.is_root() {
+            return f.write_str("/");
+        }
+
+        for segment in &self.segments {
+            write!(f, "/{segment}")?;
+        }
+
+        Ok(())
+    }
+}
+
+impl FromStr for OpcUaBrowsePath {
+    type Err = Error;
+
+    fn from_str(path: &str) -> Result<Self> {
+        split_absolute_segments(path, '&')?
+            .into_iter()
+            .map(|segment| segment.parse())
+            .collect()
+    }
+}
+
+impl TryFrom<String> for OpcUaBrowsePath {
+    type Error = Error;
+
+    fn try_from(path: String) -> Result<Self> {
+        path.parse()
+    }
+}
+
+impl From<OpcUaBrowsePath> for String {
+    fn from(path: OpcUaBrowsePath) -> Self {
+        path.to_string()
+    }
+}
+
+impl FromIterator<OpcUaBrowseName> for OpcUaBrowsePath {
+    fn from_iter<T: IntoIterator<Item = OpcUaBrowseName>>(segments: T) -> Self {
+        Self::from_segments(segments)
+    }
+}
+
+impl AsRef<[OpcUaBrowseName]> for OpcUaBrowsePath {
+    fn as_ref(&self) -> &[OpcUaBrowseName] {
+        self.segments()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+
+    use super::OpcUaBrowseName;
+    use super::OpcUaBrowsePath;
+
+    #[test]
+    fn browse_names_and_paths_share_one_roundtrip_codec() -> Result<()> {
+        let names = [
+            OpcUaBrowseName::new(0, "Root".to_owned()),
+            OpcUaBrowseName::new(0, "2:numeric-colon".to_owned()),
+            OpcUaBrowseName::new(4, "PLC/MAIN:TEMP&<hot>".to_owned()),
+            OpcUaBrowseName::new(7, "温度🌡".to_owned()),
+        ];
+
+        for name in &names {
+            assert_eq!(name.to_string().parse::<OpcUaBrowseName>()?, *name);
+        }
+
+        let path = OpcUaBrowsePath::from_segments(names);
+        assert_eq!(path.to_string().parse::<OpcUaBrowsePath>()?, path);
+        Ok(())
+    }
+
+    #[test]
+    fn root_is_slash_and_relative_or_empty_text_is_rejected() {
+        assert_eq!(OpcUaBrowsePath::root().to_string(), "/");
+        assert_eq!(
+            "/".parse::<OpcUaBrowsePath>().expect("root path"),
+            OpcUaBrowsePath::root()
+        );
+        assert!("".parse::<OpcUaBrowsePath>().is_err());
+        assert!("Root".parse::<OpcUaBrowsePath>().is_err());
+        assert!("/Root/".parse::<OpcUaBrowsePath>().is_err());
+        assert!("/Root//Objects".parse::<OpcUaBrowsePath>().is_err());
+        assert!("".parse::<OpcUaBrowseName>().is_err());
+        assert!("4:".parse::<OpcUaBrowseName>().is_err());
+    }
+}

--- a/crates/instro-opcua/src/types.rs
+++ b/crates/instro-opcua/src/types.rs
@@ -19,8 +19,7 @@
 //!    counterparts in the [`open62541`] Rust wrapper and raw [`open62541_sys`] FFI
 //!    bindings. The [`read_inner`] helper provides safe access to the
 //!    `#[repr(transparent)]` wrapper internals, and [`scalar_to_variant`] /
-//!    [`variant_to_value`] bridge scalar values through [`ua::Variant`] for
-//!    read and write operations.
+//!    bridge scalar values through [`ua::Variant`] for read and write operations.
 
 use std::borrow::Cow;
 use std::fmt::Display;
@@ -72,6 +71,9 @@ use serde::Serialize;
 use time::UtcDateTime;
 use uuid::Uuid;
 use zeroize::Zeroize as _;
+
+use crate::path::OpcUaBrowseName;
+use crate::path::OpcUaBrowsePath;
 
 /// Convenience function to read values from raw `open62541-sys` types.
 /// This is necessary in some cases to access values from the raw C
@@ -628,236 +630,44 @@ pub enum NodeIdKind {
     Guid(Uuid),
 }
 
-/// A browse-path segment preserving the OPC UA namespace that qualifies its name.
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct QualifiedBrowseName {
-    /// The namespace index qualifying the browse name.
-    pub namespace_index: u16,
-    /// The browse name within its namespace.
-    pub name: String,
-}
-
-impl QualifiedBrowseName {
-    /// Creates a namespace-qualified browse name.
-    pub fn new(namespace_index: u16, name: String) -> Self {
-        Self {
-            namespace_index,
-            name,
-        }
-    }
-}
-
-/// A route whose namespace-qualified browse-name segments keep duplicate names distinct.
-#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[serde(try_from = "String", into = "String")]
-pub struct BrowsePath {
-    segments: Vec<QualifiedBrowseName>,
-}
-
-impl BrowsePath {
-    /// Creates a browse path containing one segment.
-    pub fn from_segment(segment: QualifiedBrowseName) -> Self {
-        Self {
-            segments: vec![segment],
-        }
-    }
-
-    /// Returns a new browse path with `segment` appended.
-    pub fn child(&self, segment: QualifiedBrowseName) -> Self {
-        let mut segments = self.segments.clone();
-        segments.push(segment);
-        Self { segments }
-    }
-
-    /// Returns whether the browse path contains no segments.
-    pub fn is_empty(&self) -> bool {
-        self.segments.is_empty()
-    }
-
-    /// Returns the path's namespace-qualified segments.
-    pub fn segments(&self) -> &[QualifiedBrowseName] {
-        &self.segments
-    }
-}
-
-impl Display for BrowsePath {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        for segment in &self.segments {
-            f.write_str("/")?;
-            if segment.namespace_index != 0 {
-                write!(f, "{}:", segment.namespace_index)?;
-            }
-            f.write_str(&escape_browse_name(&segment.name))?;
-        }
-
-        Ok(())
-    }
-}
-
-impl FromStr for BrowsePath {
-    type Err = Error;
-
-    fn from_str(s: &str) -> Result<Self> {
-        if s.is_empty() {
-            return Ok(Self::default());
-        }
-
-        if !s.starts_with('/') {
-            bail!("browse path must start with '/' or be empty: {s}");
-        }
-
-        let mut segments = Vec::new();
-        let mut segment_start = 1;
-        let mut escaped = false;
-
-        for (i, ch) in s.char_indices().skip(1) {
-            if escaped {
-                escaped = false;
-                continue;
-            }
-
-            match ch {
-                '&' => escaped = true,
-                '/' => {
-                    segments.push(parse_browse_path_segment(&s[segment_start..i])?);
-                    segment_start = i.saturating_add(ch.len_utf8());
-                }
-                _ => {}
-            }
-        }
-
-        segments.push(parse_browse_path_segment(&s[segment_start..])?);
-
-        Ok(Self { segments })
-    }
-}
-
-impl TryFrom<String> for BrowsePath {
-    type Error = Error;
-
-    fn try_from(value: String) -> Result<Self> {
-        value.parse()
-    }
-}
-
-impl From<BrowsePath> for String {
-    fn from(value: BrowsePath) -> Self {
-        value.to_string()
-    }
-}
-
-fn parse_browse_path_segment(segment: &str) -> Result<QualifiedBrowseName> {
-    if segment.is_empty() {
-        bail!("browse path contains an empty segment");
-    }
-
-    let namespace_separator = namespace_separator(segment)?;
-    let (namespace_index, name) = match namespace_separator {
-        Some(separator) => {
-            let (namespace, rest) = segment.split_at(separator);
-            let name = rest
-                .strip_prefix(':')
-                .context("namespace separator should point at ':'")?;
-            (namespace.parse::<u16>()?, name)
-        }
-        None => (0, segment),
-    };
-
-    let name = unescape_browse_name(name)?;
-    if name.is_empty() {
-        bail!("browse path segment name must not be empty");
-    }
-
-    Ok(QualifiedBrowseName {
-        namespace_index,
-        name,
-    })
-}
-
-fn namespace_separator(segment: &str) -> Result<Option<usize>> {
-    let mut escaped = false;
-
-    for (i, ch) in segment.char_indices() {
-        if escaped {
-            escaped = false;
-            continue;
-        }
-
-        if ch == '&' {
-            escaped = true;
-            continue;
-        }
-
-        if ch == ':' {
-            if i > 0 && segment[..i].chars().all(|c| c.is_ascii_digit()) {
-                return Ok(Some(i));
-            }
-
-            bail!("':' in a browse path segment must be escaped unless it separates a namespace");
-        }
-    }
-
-    Ok(None)
-}
-
-fn escape_browse_name(name: &str) -> String {
-    let mut escaped = String::with_capacity(name.len());
-
-    for ch in name.chars() {
-        if is_browse_path_reserved(ch) {
-            escaped.push('&');
-        }
-        escaped.push(ch);
-    }
-
-    escaped
-}
-
-fn unescape_browse_name(name: &str) -> Result<String> {
-    let mut unescaped = String::with_capacity(name.len());
-    let mut escaped = false;
-
-    for ch in name.chars() {
-        if escaped {
-            if !is_browse_path_reserved(ch) {
-                bail!("'&' in a browse path segment must escape a reserved character");
-            }
-
-            unescaped.push(ch);
-            escaped = false;
-            continue;
-        }
-
-        if ch == '&' {
-            escaped = true;
-        } else if is_browse_path_reserved(ch) {
-            bail!("reserved character '{ch}' in a browse path segment must be escaped");
-        } else {
-            unescaped.push(ch);
-        }
-    }
-
-    if escaped {
-        bail!("browse path segment cannot end with an escape marker");
-    }
-
-    Ok(unescaped)
-}
-
-const fn is_browse_path_reserved(ch: char) -> bool {
-    matches!(ch, '/' | '.' | '<' | '>' | ':' | '#' | '!' | '&')
-}
-
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct OpcUaNode {
-    pub node_id: OpcUaNodeId,
-    pub browse_name: String,
-    pub display_name: String,
-    pub node_class: OpcUaNodeClass,
-    /// The namespace-qualified browse path to this node.
-    #[serde(default)]
-    pub browse_path: BrowsePath,
-    pub children: Vec<OpcUaNode>,
+    node_id: OpcUaNodeId,
+    display_name: String,
+    node_class: OpcUaNodeClass,
+    browse_name: OpcUaBrowseName,
+}
+
+impl OpcUaNode {
+    pub const fn new(
+        node_id: OpcUaNodeId,
+        display_name: String,
+        node_class: OpcUaNodeClass,
+        browse_name: OpcUaBrowseName,
+    ) -> Self {
+        Self {
+            node_id,
+            display_name,
+            node_class,
+            browse_name,
+        }
+    }
+
+    pub const fn node_id(&self) -> &OpcUaNodeId {
+        &self.node_id
+    }
+
+    pub const fn display_name(&self) -> &String {
+        &self.display_name
+    }
+
+    pub const fn node_class(&self) -> &OpcUaNodeClass {
+        &self.node_class
+    }
+
+    pub const fn browse_name(&self) -> &OpcUaBrowseName {
+        &self.browse_name
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -1050,16 +860,72 @@ impl OpcUaMonitoredItemConfig {
     }
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct OpcUaNodeReadTarget {
+    pub node_id: OpcUaNodeId,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub browse_path: Option<OpcUaBrowsePath>,
+}
+
+impl OpcUaNodeReadTarget {
+    pub const fn new(node_id: OpcUaNodeId, browse_path: OpcUaBrowsePath) -> Self {
+        Self {
+            node_id,
+            browse_path: Some(browse_path),
+        }
+    }
+}
+
+impl From<OpcUaNode> for OpcUaNodeReadTarget {
+    fn from(node: OpcUaNode) -> Self {
+        Self {
+            node_id: node.node_id,
+            browse_path: None,
+        }
+    }
+}
+
+impl From<&OpcUaNode> for OpcUaNodeReadTarget {
+    fn from(node: &OpcUaNode) -> Self {
+        Self {
+            node_id: node.node_id().clone(),
+            browse_path: None,
+        }
+    }
+}
+
+impl From<&OpcUaNodeReadTarget> for OpcUaNodeReadTarget {
+    fn from(target: &OpcUaNodeReadTarget) -> Self {
+        target.clone()
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct OpcUaSample {
     pub node_id: OpcUaNodeId,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(default)]
+    pub browse_path: Option<OpcUaBrowsePath>,
     #[serde(flatten)]
     pub data: OpcUaDataPoint,
 }
 
 impl OpcUaSample {
     pub fn new(node_id: OpcUaNodeId, data: OpcUaDataPoint) -> Self {
-        Self { node_id, data }
+        Self {
+            node_id,
+            browse_path: None,
+            data,
+        }
+    }
+
+    pub fn from_target(target: &OpcUaNodeReadTarget, data: OpcUaDataPoint) -> Self {
+        Self {
+            node_id: target.node_id.clone(),
+            browse_path: target.browse_path.clone(),
+            data,
+        }
     }
 }
 
@@ -1752,107 +1618,15 @@ mod tests {
     }
 
     #[test]
-    fn browse_path_display_and_parse_roundtrip() {
-        let cases = [
-            BrowsePath::default(),
-            BrowsePath::from_segment(QualifiedBrowseName::new(0, "Root".into())),
-            BrowsePath::from_segment(QualifiedBrowseName::new(0, "Root".into()))
-                .child(QualifiedBrowseName::new(0, "Objects".into()))
-                .child(QualifiedBrowseName::new(0, "Temperature".into())),
-            BrowsePath::from_segment(QualifiedBrowseName::new(4, "PLC1".into())),
-            BrowsePath::from_segment(QualifiedBrowseName::new(
-                2,
-                "Name/with:reserved&chars".into(),
-            )),
-        ];
-
-        for path in cases {
-            let rendered = path.to_string();
-            let parsed: BrowsePath = rendered.parse().expect("browse path should parse");
-            assert_eq!(parsed, path);
-        }
-    }
-
-    #[test]
-    fn browse_path_renders_standard_relative_path_text() {
-        let path = BrowsePath::from_segment(QualifiedBrowseName::new(0, "Root".into()))
-            .child(QualifiedBrowseName::new(0, "Objects".into()))
-            .child(QualifiedBrowseName::new(4, "PLC1/MAIN:TEMP&<hot>".into()));
-
-        assert_eq!(
-            path.to_string(),
-            "/Root/Objects/4:PLC1&/MAIN&:TEMP&&&<hot&>"
-        );
-    }
-
-    #[test]
-    fn browse_path_rejects_malformed_text() {
-        for malformed in [
-            "Root",
-            "/Root/",
-            "/Root//Objects",
-            "/Root/4:",
-            "/Root/Foo:Bar",
-            "/Root/Foo&x",
-            "/Root/Foo&",
-            "/Root/Foo.Bar",
-        ] {
-            let parsed: Result<BrowsePath> = malformed.parse();
-            assert!(parsed.is_err(), "{malformed} should fail to parse");
-        }
-    }
-
-    #[test]
-    fn browse_path_serializes_as_json_object_key() {
-        let path = BrowsePath::from_segment(QualifiedBrowseName::new(0, "Root".into()))
-            .child(QualifiedBrowseName::new(0, "Objects".into()));
-        let mut map = std::collections::BTreeMap::new();
-        map.insert(path.clone(), "selected".to_owned());
-
-        let json = serde_json::to_value(&map).expect("serialize browse path map");
-        assert_eq!(json, serde_json::json!({ "/Root/Objects": "selected" }));
-
-        let back: std::collections::BTreeMap<BrowsePath, String> =
-            serde_json::from_value(json).expect("deserialize browse path map");
-        assert_eq!(back.get(&path).map(String::as_str), Some("selected"));
-    }
-
-    #[test]
     fn serde_roundtrip_browse_node() {
-        let browse = OpcUaNode {
-            node_id: OpcUaNodeId::numeric(0, 85),
-            browse_name: "Objects".into(),
-            display_name: "Objects".into(),
-            node_class: OpcUaNodeClass::Object,
-            browse_path: BrowsePath::from_segment(QualifiedBrowseName::new(0, "Objects".into())),
-            children: vec![OpcUaNode {
-                node_id: OpcUaNodeId::string(2, "Temp".into()),
-                browse_name: "Temperature".into(),
-                display_name: "Temperature".into(),
-                node_class: OpcUaNodeClass::Variable,
-                browse_path: BrowsePath::from_segment(QualifiedBrowseName::new(
-                    2,
-                    "Temperature".into(),
-                )),
-                children: vec![],
-            }],
-        };
+        let browse = OpcUaNode::new(
+            OpcUaNodeId::numeric(0, 85),
+            "Objects".into(),
+            OpcUaNodeClass::Object,
+            "Objects".parse().expect("browse name should parse"),
+        );
 
         assert_serde_json_roundtrip_eq(&browse);
-    }
-
-    #[test]
-    fn opcua_node_deserializes_without_browse_path() {
-        let node: OpcUaNode = serde_json::from_value(serde_json::json!({
-            "node_id": "ns=0;i=85",
-            "browse_name": "Objects",
-            "display_name": "Objects",
-            "node_class": "Object",
-            "children": [],
-        }))
-        .expect("node without browse path should deserialize");
-
-        assert!(node.browse_path.is_empty());
     }
 
     #[test]

--- a/crates/instro-opcua/tests/client_harness.rs
+++ b/crates/instro-opcua/tests/client_harness.rs
@@ -5,17 +5,17 @@ use std::time::Duration;
 use anyhow::Context as _;
 use anyhow::Result;
 use anyhow::bail;
-use instro_opcua::browse::Browse as _;
-use instro_opcua::browse::BrowseAll as _;
+use instro_opcua::browse::OpcUaBrowseOptions;
 use instro_opcua::client::OpcUaClient;
 use instro_opcua::client::OpcUaClientBuilder;
 use instro_opcua::client::OpcUaNodeReadBatch;
-use instro_opcua::types::BrowsePath;
+use instro_opcua::path::OpcUaBrowseName;
+use instro_opcua::path::OpcUaBrowsePath;
 use instro_opcua::types::NodeIdKind;
 use instro_opcua::types::OpcUaMonitoredItemConfig;
-use instro_opcua::types::OpcUaNode;
 use instro_opcua::types::OpcUaNodeClass;
 use instro_opcua::types::OpcUaNodeId;
+use instro_opcua::types::OpcUaNodeReadTarget;
 use instro_opcua::types::OpcUaPki;
 use instro_opcua::types::OpcUaSample;
 use instro_opcua::types::OpcUaSecurityMode;
@@ -23,7 +23,6 @@ use instro_opcua::types::OpcUaSecurityPolicy;
 use instro_opcua::types::OpcUaSubscriptionConfig;
 use instro_opcua::types::OpcUaUserToken;
 use instro_opcua::types::OpcUaValue;
-use instro_opcua::types::QualifiedBrowseName;
 use instro_opcua_test::FolderSpec;
 use instro_opcua_test::ParentRef;
 use instro_opcua_test::TestNodeId;
@@ -58,16 +57,22 @@ fn opcua_node_id(server: &TestServer, browse_name: &str) -> Result<OpcUaNodeId> 
 fn opcua_node(
     server: &TestServer,
     browse_name: &str,
-    node_class: OpcUaNodeClass,
-) -> Result<OpcUaNode> {
-    Ok(OpcUaNode {
-        node_id: opcua_node_id(server, browse_name)?,
-        browse_name: browse_name.to_owned(),
-        display_name: browse_name.to_owned(),
-        node_class,
-        browse_path: BrowsePath::from_segment(QualifiedBrowseName::new(1, browse_name.to_owned())),
-        children: Vec::new(),
-    })
+    _node_class: OpcUaNodeClass,
+) -> Result<OpcUaNodeReadTarget> {
+    Ok(OpcUaNodeReadTarget::new(
+        opcua_node_id(server, browse_name)?,
+        OpcUaBrowsePath::from_segment(OpcUaBrowseName::new(
+            server.namespace_index(),
+            browse_name.to_owned(),
+        )),
+    ))
+}
+
+fn browse_path(namespace: u16, segments: &[&str]) -> OpcUaBrowsePath {
+    segments
+        .iter()
+        .map(|segment| OpcUaBrowseName::new(namespace, (*segment).to_owned()))
+        .collect()
 }
 
 fn nonzero(value: u32) -> Result<NonZeroU32> {
@@ -124,7 +129,7 @@ fn has_value(samples: &[OpcUaSample], node_id: &OpcUaNodeId, expected: &OpcUaVal
 async fn recv_matching_batch(
     rx: &mut mpsc::UnboundedReceiver<Vec<OpcUaSample>>,
     description: &str,
-    mut matches: impl FnMut(&[OpcUaSample]) -> bool,
+    mut matcher: impl FnMut(&[OpcUaSample]) -> bool,
 ) -> Result<Vec<OpcUaSample>> {
     let deadline = tokio::time::Instant::now() + LIFETIME_TIMEOUT;
 
@@ -142,7 +147,7 @@ async fn recv_matching_batch(
         let samples = maybe_samples
             .with_context(|| format!("callback channel closed while waiting for {description}"))?;
 
-        if matches(&samples) {
+        if matcher(&samples) {
             return Ok(samples);
         }
     }
@@ -249,7 +254,11 @@ async fn read_nodes_decodes_samples_in_request_order() -> Result<()> {
     let batch = OpcUaNodeReadBatch::new(&nodes, ua::AttributeId::VALUE);
     let client = connect_client(&server)?;
 
-    let samples = client.read_nodes(&batch).await?;
+    let samples = client
+        .read_nodes(&batch)
+        .await?
+        .into_iter()
+        .collect::<Result<Vec<_>>>()?;
     assert_eq!(samples.len(), 5);
     assert_timestamps_present(&samples);
 
@@ -277,7 +286,68 @@ async fn read_nodes_decodes_samples_in_request_order() -> Result<()> {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn browse_node_and_browse_all_return_test_hierarchy() -> Result<()> {
+async fn read_nodes_retains_first_middle_and_last_decode_failures() -> Result<()> {
+    let unsupported = || {
+        ua::Variant::array(ua::Array::from_slice(&[
+            ua::Double::new(1.0),
+            ua::Double::new(2.0),
+        ]))
+    };
+    let server = TestServer::builder()
+        .variable(TestNodeId::Numeric(1100), "InvalidFirst", unsupported())
+        .variable(
+            TestNodeId::Numeric(1101),
+            "ValidSecond",
+            ua::Variant::scalar(ua::Double::new(2.0)),
+        )
+        .variable(TestNodeId::Numeric(1102), "InvalidMiddle", unsupported())
+        .variable(
+            TestNodeId::Numeric(1103),
+            "ValidFourth",
+            ua::Variant::scalar(ua::Double::new(4.0)),
+        )
+        .variable(TestNodeId::Numeric(1104), "InvalidLast", unsupported())
+        .start()?;
+    let targets = [
+        opcua_node(&server, "InvalidFirst", OpcUaNodeClass::Variable)?,
+        opcua_node(&server, "ValidSecond", OpcUaNodeClass::Variable)?,
+        opcua_node(&server, "InvalidMiddle", OpcUaNodeClass::Variable)?,
+        opcua_node(&server, "ValidFourth", OpcUaNodeClass::Variable)?,
+        opcua_node(&server, "InvalidLast", OpcUaNodeClass::Variable)?,
+    ];
+    let batch = OpcUaNodeReadBatch::new(&targets, ua::AttributeId::VALUE);
+    let client = connect_client(&server)?;
+
+    let outcomes = client.read_nodes(&batch).await?;
+    assert_eq!(outcomes.len(), targets.len());
+    let [first, second, middle, fourth, last] = outcomes.as_slice() else {
+        bail!("read outcomes did not retain five positions");
+    };
+    let [_, second_target, _, fourth_target, _] = &targets;
+    assert!(first.is_err());
+    assert_eq!(
+        second
+            .as_ref()
+            .expect("second outcome should decode")
+            .node_id,
+        second_target.node_id
+    );
+    assert!(middle.is_err());
+    assert_eq!(
+        fourth
+            .as_ref()
+            .expect("fourth outcome should decode")
+            .node_id,
+        fourth_target.node_id
+    );
+    assert!(last.is_err());
+
+    client.disconnect().await?;
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn graph_browse_methods_return_test_hierarchy() -> Result<()> {
     let server = TestServer::builder()
         .add_folder(FolderSpec::new(TestNodeId::Numeric(2000), "Sensors"))
         .add_folder(
@@ -321,16 +391,29 @@ async fn browse_node_and_browse_all_return_test_hierarchy() -> Result<()> {
     let sensors_id = opcua_node_id(&server, "Sensors")?;
     let namespace = server.namespace_index();
 
-    let mut immediate_names = client
-        .as_ref()
-        .browse_node(sensors_id.clone())
-        .await?
-        .into_iter()
-        .map(|node| {
+    let sensors_path = OpcUaBrowsePath::from_segments([
+        OpcUaBrowseName::new(0, "Objects".to_owned()),
+        OpcUaBrowseName::new(namespace, "Sensors".to_owned()),
+    ]);
+    let graph = client
+        .browse_from(
+            sensors_id.clone(),
+            sensors_path.clone(),
+            OpcUaBrowseOptions::new(),
+        )
+        .await?;
+    let sensors = graph
+        .roots()
+        .routes()
+        .next()
+        .context("browse_from omitted selected Sensors route")?;
+    let mut immediate_names = sensors
+        .children()
+        .routes()
+        .map(|route| {
             (
-                node.browse_name,
-                node.node_class,
-                node.browse_path.to_string(),
+                route.node().browse_name().clone(),
+                route.node().node_class().clone(),
             )
         })
         .collect::<Vec<_>>();
@@ -340,45 +423,71 @@ async fn browse_node_and_browse_all_return_test_hierarchy() -> Result<()> {
         immediate_names,
         vec![
             (
-                "Flow".to_owned(),
+                OpcUaBrowseName::new(namespace, "Flow".to_owned()),
                 OpcUaNodeClass::Variable,
-                "/2:Flow".to_owned()
             ),
             (
-                "Inner".to_owned(),
+                OpcUaBrowseName::new(namespace, "Inner".to_owned()),
                 OpcUaNodeClass::Object,
-                "/2:Inner".to_owned()
             ),
             (
-                "Temperature".to_owned(),
+                OpcUaBrowseName::new(namespace, "Temperature".to_owned()),
                 OpcUaNodeClass::Variable,
-                "/2:Temperature".to_owned()
             ),
         ],
     );
 
-    let tree = client.as_ref().browse_all(sensors_id.clone(), None).await?;
-    let temperature = tree
-        .iter()
-        .find(|node| node.browse_name == "Temperature")
-        .context("browse_all omitted Temperature")?;
-    assert_eq!(temperature.node_class, OpcUaNodeClass::Variable);
+    let root_graph = client
+        .browse_root(OpcUaBrowseOptions::new().with_max_depth(1))
+        .await?;
     assert!(
-        temperature.children.is_empty(),
+        root_graph
+            .resolve_path(&browse_path(0, &["Objects"]))
+            .routes()
+            .next()
+            .is_some(),
+        "Root-default browse omitted Objects",
+    );
+
+    let exact = client
+        .browse_path(sensors_path.clone(), OpcUaBrowseOptions::new())
+        .await?;
+    let pattern = format!("/Objects/{namespace}:Sensors/**");
+    let leaf_variables = exact.find_all(pattern)?.variables().leaves();
+    assert_eq!(leaf_variables.len(), 4);
+
+    let temperature_path = sensors_path
+        .clone()
+        .with_child(OpcUaBrowseName::new(namespace, "Temperature".to_owned()));
+    let temperature = graph
+        .resolve_path(&temperature_path)
+        .routes()
+        .next()
+        .context("browse graph omitted Temperature")?;
+    assert_eq!(temperature.node().node_class(), &OpcUaNodeClass::Variable);
+    assert!(
+        temperature.children().is_empty(),
         "Temperature has no children in this test server",
     );
-    assert_eq!(temperature.browse_path.to_string(), "/2:Temperature");
+    assert_eq!(temperature.browse_path(), temperature_path);
 
-    let flow = tree
-        .iter()
-        .find(|node| node.browse_name == "Flow")
-        .context("browse_all omitted Flow")?;
-    assert_eq!(flow.node_class, OpcUaNodeClass::Variable);
-    assert!(flow.children.is_empty(), "Flow has no children");
-    assert_eq!(flow.browse_path.to_string(), "/2:Flow");
-    assert_eq!(flow.node_id.namespace(), namespace);
+    let flow_path = sensors_path
+        .clone()
+        .with_child(OpcUaBrowseName::new(namespace, "Flow".to_owned()));
+    let flow = graph
+        .resolve_path(&flow_path)
+        .routes()
+        .next()
+        .context("browse graph omitted Flow")?;
+    assert_eq!(flow.node().node_class(), &OpcUaNodeClass::Variable);
+    assert!(
+        flow.children().is_empty(),
+        "Flow has no children in this test server"
+    );
+    assert_eq!(flow.browse_path(), flow_path);
+    assert_eq!(flow.node().node_id().namespace(), namespace);
     assert_eq!(
-        flow.node_id.kind(),
+        flow.node().node_id().kind(),
         &NodeIdKind::Guid(uuid::Uuid::from_fields(
             0x2233_4455,
             0x6677,
@@ -387,38 +496,56 @@ async fn browse_node_and_browse_all_return_test_hierarchy() -> Result<()> {
         ))
     );
 
-    let inner = tree
-        .iter()
-        .find(|node| node.browse_name == "Inner")
-        .context("browse_all omitted Inner folder")?;
-    assert_eq!(inner.node_class, OpcUaNodeClass::Object);
-    assert_eq!(inner.browse_path.to_string(), "/2:Inner");
+    let inner_path = sensors_path
+        .clone()
+        .with_child(OpcUaBrowseName::new(namespace, "Inner".to_owned()));
 
-    let pressure = inner
-        .children
-        .iter()
-        .find(|node| node.browse_name == "Pressure")
-        .context("browse_all omitted nested Pressure node")?;
-    assert_eq!(pressure.node_class, OpcUaNodeClass::Variable);
-    assert_eq!(pressure.browse_path.to_string(), "/2:Inner/2:Pressure");
+    let inner = graph
+        .resolve_path(&inner_path)
+        .routes()
+        .next()
+        .context("browse graph omitted Inner folder")?;
 
-    let status = inner
-        .children
-        .iter()
-        .find(|node| node.browse_name == "Status")
-        .context("browse_all omitted nested Status node")?;
-    assert_eq!(status.node_class, OpcUaNodeClass::Variable);
-    assert_eq!(status.browse_path.to_string(), "/2:Inner/2:Status");
-    assert_eq!(status.node_id.namespace(), namespace);
+    assert_eq!(inner.node().node_class(), &OpcUaNodeClass::Object);
+    assert_eq!(inner.browse_path(), inner_path);
+
+    let pressure_path = inner_path
+        .clone()
+        .with_child(OpcUaBrowseName::new(namespace, "Pressure".to_owned()));
+
+    let pressure = graph
+        .resolve_path(&pressure_path)
+        .routes()
+        .next()
+        .context("browse graph omitted nested Pressure node")?;
+
+    assert_eq!(pressure.node().node_class(), &OpcUaNodeClass::Variable);
+    assert_eq!(pressure.browse_path(), pressure_path);
+
+    let status_path = inner_path
+        .clone()
+        .with_child(OpcUaBrowseName::new(namespace, "Status".to_owned()));
+
+    let status = graph
+        .resolve_path(&status_path)
+        .routes()
+        .next()
+        .context("browse graph omitted nested Status node")?;
+
+    assert_eq!(status.node().node_class(), &OpcUaNodeClass::Variable);
+    assert_eq!(status.browse_path(), status_path);
+    assert_eq!(status.node().node_id().namespace(), namespace);
     assert_eq!(
-        status.node_id.kind(),
+        status.node().node_id().kind(),
         &NodeIdKind::ByteString(b"inner-status-id".to_vec())
     );
 
-    let (metadata_name, display_name, node_class) = client.read_node_metadata(&sensors_id).await?;
-    assert_eq!(metadata_name.name, "Sensors");
-    assert_eq!(display_name, "Sensors");
-    assert_eq!(node_class, OpcUaNodeClass::Object);
+    let batch = OpcUaNodeReadBatch::new(graph.read_targets(), ua::AttributeId::VALUE);
+    assert_eq!(batch.len(), graph.len());
+
+    assert_eq!(sensors.node().browse_name().name(), "Sensors");
+    assert_eq!(sensors.node().display_name(), "Sensors");
+    assert_eq!(sensors.node().node_class(), &OpcUaNodeClass::Object);
 
     client.disconnect().await?;
     Ok(())


### PR DESCRIPTION
## Summary

This moves relationship state out of individual `OpcUaNode` values and into `OpcUaNodeGraph`, preserving route identity for duplicate paths while keeping node metadata separate from graph topology.

## Type of change

- [ ] Bug fix (`fix`)
- [ ] New feature (`feat`)
- [ ] Breaking change (`feat!` / `fix!`)
- [x] Refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] Chore / tooling (`chore`)

## Verification

_*NOTE: will verify tests once integration is done*_

## Tests

- [x] Unit tests added or updated
- [ ] Existing tests cover this change
- [ ] No tests — explain why:

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(driver): add support for Keysight E36300`)
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] Documentation updated if user-facing behavior changed
- [x] Code follows the style/conventions of the surrounding code

## Notes for reviewers

Still WIP
