### PR TITLE
fix(ethernetip): kill cpppo simulator process tree on test teardown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 
 # C extensions
 *.so
+*.pdb
 
 # Distribution / packaging
 .Python

--- a/packages/instro-ethernetip-rs/tests/explicit_session_integration.rs
+++ b/packages/instro-ethernetip-rs/tests/explicit_session_integration.rs
@@ -464,9 +464,10 @@ mod support {
 
         #[cfg(unix)]
         fn kill_process_tree(child: &mut Child) {
-            // The child leads its own process group (see `start`); signal the group.
+            // The child leads its own process group (see `start`); signal the whole
+            // group. `--` keeps the negative pgid from being parsed as an option.
             let _ = Command::new("kill")
-                .args(["-KILL", &format!("-{}", child.id())])
+                .args(["-KILL", "--", &format!("-{}", child.id())])
                 .status();
             let _ = child.kill();
         }

--- a/packages/instro-ethernetip-rs/tests/explicit_session_integration.rs
+++ b/packages/instro-ethernetip-rs/tests/explicit_session_integration.rs
@@ -425,6 +425,8 @@ mod support {
 
     mod cpppo_simulator {
         use std::io::{BufRead, BufReader};
+        #[cfg(unix)]
+        use std::os::unix::process::CommandExt;
         use std::path::PathBuf;
         use std::process::{Child, Command, Stdio};
         use std::sync::mpsc;
@@ -444,25 +446,48 @@ mod support {
 
         impl Drop for Process {
             fn drop(&mut self) {
-                let _ = self.child.kill();
+                kill_process_tree(&mut self.child);
                 let _ = self.child.wait(); // wait for the child to exit completely
             }
+        }
+
+        // `uv run` spawns python as a grandchild, so killing only `self.child`
+        // (the `uv` process) orphans the simulator (INSTRO-418). Kill the tree.
+        #[cfg(windows)]
+        fn kill_process_tree(child: &mut Child) {
+            let _ = Command::new("taskkill")
+                .args(["/F", "/T", "/PID", &child.id().to_string()])
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status();
+        }
+
+        #[cfg(unix)]
+        fn kill_process_tree(child: &mut Child) {
+            // The child leads its own process group (see `start`); signal the group.
+            let _ = Command::new("kill")
+                .args(["-KILL", &format!("-{}", child.id())])
+                .status();
+            let _ = child.kill();
         }
 
         /// Start cpppo with the same tag definition used by live-target tests.
         pub(super) fn start(fixtures: &[TagFixture]) -> (String, Process) {
             let script = script_path();
-            let mut child = Command::new("uv")
+            let mut command = Command::new("uv");
+            command
                 .args(["run", "python"])
                 .arg(&script)
                 .stdin(Stdio::null())
                 .stdout(Stdio::piped())
                 .stderr(Stdio::inherit())
-                .args(tag_args(fixtures))
-                .spawn()
-                .unwrap_or_else(|error| {
-                    panic!("failed to start cpppo simulator process via `uv run python`: {error}")
-                });
+                .args(tag_args(fixtures));
+            // Lead a new process group so teardown can kill the whole tree (INSTRO-418).
+            #[cfg(unix)]
+            command.process_group(0);
+            let mut child = command.spawn().unwrap_or_else(|error| {
+                panic!("failed to start cpppo simulator process via `uv run python`: {error}")
+            });
 
             let endpoint = read_endpoint_from_stdout(&mut child);
             (endpoint, Process { child })


### PR DESCRIPTION
## Summary

The EtherNet/IP Rust integration harness leaks orphaned `cpppo_sim_server.py` processes on every run. On one dev machine, 73 had accumulated over four days, locking `.venv/Scripts/python.exe` and blocking `uv sync`.

## Root cause

`packages/instro-ethernetip-rs/tests/explicit_session_integration.rs` spawns the simulator via `uv run python cpppo_sim_server.py`, so the process tree is three deep:

```
rust test ──> uv ──> python.exe (cpppo_sim_server.py)
```

The `Process` `Drop` impl called `self.child.kill()`, but `self.child` is the **`uv`** process, not the simulator. `std::process::Child::kill()` terminates only that single PID — it does not cascade. So `uv` was killed and the `python.exe` grandchild was orphaned, left spinning in its `while True: time.sleep(1.0)` loop forever (never signaled, so its `finally: server.stop()` never ran).

## Fix: kill the whole tree

- **Windows:** `taskkill /F /T /PID <pid>` (`/T` terminates the tree).
- **Unix (Linux/macOS):** spawn the child into its own process group (`CommandExt::process_group(0)`) and signal the group (`kill -KILL -<pgid>`).

Pure `std`, no new crate dependencies. The `uv run` invocation is kept, so its env-sync guarantee is preserved.

## Testing

- `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` pass.
- Ran `writes_and_reads_first_values_for_configured_scalar_tags` (spawns + tears down a simulator): **0 orphaned `python.exe` before and after**. Pre-fix, that run would have leaked one.
- Unix teardown path is exercised by the ubuntu/macos CI matrix runners.

Fixes INSTRO-418