### PR TITLE
docs: fix stale contrib install instructions and ELoad set_range example

### DIFF
--- a/docs/guides/instrumentation/contrib.mdx
+++ b/docs/guides/instrumentation/contrib.mdx
@@ -14,7 +14,19 @@ If a driver is in `instro-contrib`, that means: it type-checks, it has a unit te
 
 ## Install
 
-`instro-contrib` is not yet published as its own distribution. For now, depend on it via a workspace install or a Git ref to this repo. A published release will arrive alongside `instro`'s PyPI publication.
+`instro-contrib` is published on PyPI and installed via the `contrib` extra:
+
+```bash
+$ uv add "instro[contrib]"
+```
+
+or with pip:
+
+```bash
+(.venv) $ pip install "instro[contrib]"
+```
+
+It's also included in the `all` extra. See [Installation](/instrumentation/installation#additional-packages) for the full list of extras.
 
 ## Import path
 

--- a/docs/guides/instrumentation/eload.mdx
+++ b/docs/guides/instrumentation/eload.mdx
@@ -50,6 +50,8 @@ Electronic loads can operate in four modes:
 **Mode Configuration Required**
 
 The operating mode must be set using `set_mode()` before you can configure the level or range. Not all electronic loads support all four modes. Consult your instrument's manual.
+
+`set_range()` applies to CC and CV modes only; CP and CR are auto-ranged from the level value (on the `BK85XXB` driver, calling `set_range()` in CP or CR mode raises `NotImplementedError`).
 </Note>
 
 ## Creating an InstroELoad Instance
@@ -160,9 +162,8 @@ eload.open()
 # Start background daemon
 eload.start()
 
-# Configure constant power mode
+# Configure constant power mode (CP and CR are auto-ranged, so no set_range call)
 eload.set_mode(LoadMode.CP, channel=1)
-eload.set_range(100.0, channel=1)  # Set range for up to 100W
 eload.set_level(25.0, channel=1)   # Draw 25W
 eload.output_enable(True, channel=1)
 
@@ -244,7 +245,7 @@ Every measurement/command call produces a channel keyed under `{name}.{descripto
 | `close()` | Disconnect from electronic load and close all publishers |
 | `set_mode(mode, channel=1)` | Set operating mode (CC, CV, CR, or CP) |
 | `set_level(value, channel=1, curr_limit=None)` | Set the operating level (A, V, Ω, or W depending on mode) |
-| `set_range(value, channel=1)` | Set the operating range for auto-ranging |
+| `set_range(value, channel=1)` | Set the operating range (CC/CV modes only; CP/CR are auto-ranged) |
 | `set_slewrate(direction, rate, channel=1)` | Set current slew rate in A/μs |
 | `output_enable(enable, channel=1)` | Enable (True) or disable (False) the load input |
 | `short_output(enable, channel=1)` | Short the load channel (occurs immediately) |
@@ -395,6 +396,11 @@ class BK85XXB(ELoadDriverBase):
         self._visa.write(f"{loadmode_to_unit(mode)} {value}")
 
     def set_range(self, mode: LoadMode, value: float, channel: int) -> None:
+        # The 85xx series only exposes :RANGe for CC and CV; CP/CR are auto-ranged.
+        if mode not in (LoadMode.CC, LoadMode.CV):
+            raise NotImplementedError(
+                f"BK85XXB only exposes :RANGe for CC and CV; {mode.value} is auto-ranged from the level value"
+            )
         self._visa.write(f"{loadmode_to_unit(mode)}:RANGe {value}")
 
     def set_slewrate(self, direction: SlewRateDirection, rate: float, channel: int) -> None:


### PR DESCRIPTION
## What

Fixes the two High-severity findings from a docs-vs-code audit. Docs-only; no code touched.

### `docs(contrib): fix stale install instructions`
`contrib.mdx` claimed `instro-contrib` was unpublished and told users to depend on it via a workspace/Git install. It's actually on PyPI (v0.1.1) and pulled in by the `contrib` extra — `installation.mdx` already says so, so the two pages contradicted each other. Replaced the Install section with the `instro[contrib]` extra instructions.

### `docs(eload): correct set_range example for CC/CV-only support`
The `BK85XXB` driver raises `NotImplementedError` for `set_range` in any mode other than CC/CV (`instro/eload/drivers/bk_85xxb.py:50-54`). The guide's background-daemon example called `set_range` while in CP mode (would throw at runtime), and the embedded driver example wrote `:RANGe` unconditionally. This PR:
- drops the `set_range` call from the CP-mode example (CP/CR are auto-ranged),
- adds the CC/CV guard to the embedded `BK85XXB` example to match the real driver,
- documents the CC/CV-only restriction in the modes note and method-reference table.

## Testing

Docs-only (`.mdx`), so `just check` / `just test` are unaffected.

Closes #181
