### PR TITLE
test(psu): verifying Rigol-DP832A

### DIFF
--- a/tests/psu/rigol/test_rigol_dp800_hardware.py
+++ b/tests/psu/rigol/test_rigol_dp800_hardware.py
@@ -5,11 +5,15 @@ from __future__ import annotations
 import time
 from collections.abc import Iterator
 from dataclasses import dataclass
+from datetime import timedelta
 
 import pytest
+from nominal.core import EventType, NominalClient
 
 from instro.lib.exceptions import FeatureNotSupportedError
+from instro.lib.publishers import NominalCorePublisher
 from instro.lib.transports import VisaConfig
+from instro.lib.types import Measurement
 from instro.psu.drivers.rigol_dp800 import RigolDP800
 
 pytestmark = pytest.mark.hardware
@@ -23,6 +27,14 @@ pytestmark = pytest.mark.hardware
 VISA_RESOURCE = "TCPIP0::IP_ADDRESS::INSTR"
 VISA_BACKEND = "@ivi"
 INVALID_CHANNEL = 4
+
+# ---------------------------------------------------------------------------
+# Nominal Core configuration — edit before running.
+# ---------------------------------------------------------------------------
+# Set DATASET_RID to a Nominal dataset RID to stream readings and test events to
+# Nominal Core. Leave as None to skip all Nominal publishing (tests still run normally).
+DATASET_RID: str | None = None
+NOMINAL_PROFILE = "default"
 
 
 @dataclass(frozen=True)
@@ -71,6 +83,82 @@ CHANNELS = [
 ]
 
 
+# ---------------------------------------------------------------------------
+# Nominal Core helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_client() -> NominalClient:
+    return NominalClient.from_profile(NOMINAL_PROFILE)
+
+
+class _EventRecorder:
+    """Collects test events during execution, then creates them on a Nominal asset."""
+
+    def __init__(self) -> None:
+        self._client: NominalClient | None = None
+        self._events: list[dict] = []
+
+    def begin(self) -> None:
+        self._client = _get_client()
+
+    def record_event(
+        self,
+        name: str,
+        start_ns: int,
+        end_ns: int,
+        passed: bool,
+        description: str = "",
+    ) -> None:
+        self._events.append({
+            "name": name,
+            "start_ns": start_ns,
+            "end_ns": end_ns,
+            "passed": passed,
+            "description": description,
+        })
+
+    def finish(self) -> None:
+        assert self._client is not None
+        asset = self._client.get_or_create_asset_by_properties(
+            properties={"device_type": "Rigol DP800-series PSU", "purpose": "hardware-test"},
+            name="Rigol DP800-series PSU",
+            description="Rigol DP800 PSU under test",
+            labels=["rigol-dp800", "hardware-test"],
+        )
+        for evt in self._events:
+            duration_ns = evt["end_ns"] - evt["start_ns"]
+            self._client.create_event(
+                name=evt["name"],
+                type=EventType.SUCCESS if evt["passed"] else EventType.ERROR,
+                start=evt["start_ns"],
+                duration=timedelta(microseconds=duration_ns / 1_000),
+                description=evt["description"],
+                assets=[asset],
+                properties={"status": "PASS" if evt["passed"] else "FAIL"},
+                labels=["dp800-test"],
+            )
+
+
+_recorder = _EventRecorder()
+_publisher: NominalCorePublisher | None = None
+
+
+def _stream(channel: str, value: float) -> None:
+    """Stream a single scalar reading to Nominal Core. No-op when DATASET_RID is None."""
+    if _publisher is None:
+        return
+    _publisher.publish(Measurement(
+        timestamps=[time.time_ns()],
+        channel_data={channel: [value]},
+    ))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
 def _shutdown_outputs(driver: RigolDP800) -> None:
     for channel_config in CHANNELS:
         driver.output_enable(False, channel=channel_config.channel)
@@ -82,6 +170,28 @@ def _reset_driver(driver: RigolDP800) -> None:
     time.sleep(0.25)
     driver._visa.write("*CLS")
     driver._check_errors()
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module", autouse=True)
+def nominal_session() -> Iterator[None]:
+    global _publisher
+    if DATASET_RID:
+        _recorder.begin()
+        _publisher = NominalCorePublisher(dataset_rid=DATASET_RID)
+    yield
+    if _publisher is not None:
+        _publisher.close()
+        _publisher = None
+    if DATASET_RID:
+        try:
+            _recorder.finish()
+        except Exception as exc:
+            print(f"\n*** Failed to create Nominal events: {exc} ***")
 
 
 @pytest.fixture(scope="module")
@@ -108,6 +218,34 @@ def reset_before_each_test(driver: RigolDP800) -> None:
     _reset_driver(driver)
 
 
+@pytest.fixture(autouse=True)
+def record_test_event(request: pytest.FixtureRequest) -> Iterator[None]:
+    if not DATASET_RID:
+        yield
+        return
+    start_ns = time.time_ns()
+    passed = True
+    exc_str = ""
+    try:
+        yield
+    except Exception as exc:
+        passed = False
+        exc_str = str(exc)
+        raise
+    finally:
+        description = request.node.nodeid
+        if exc_str:
+            description += f"\n\nError: {exc_str}"
+        _recorder.record_event(
+            request.node.name, start_ns, time.time_ns(), passed=passed, description=description
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
 def test_query_status(driver: RigolDP800) -> None:
     status = driver.query_status()
 
@@ -128,7 +266,9 @@ def test_set_voltage(driver: RigolDP800, channel_config: ChannelConfig) -> None:
         driver.output_enable(True, channel=channel_config.channel)
         time.sleep(1)
 
-        assert driver.get_voltage(channel=channel_config.channel) == pytest.approx(
+        voltage = driver.get_voltage(channel=channel_config.channel)
+        _stream(f"ch{channel_config.channel}.voltage_v", voltage)
+        assert voltage == pytest.approx(
             channel_config.programmed_voltage,
             abs=channel_config.voltage_readback_tolerance,
         )
@@ -145,6 +285,7 @@ def test_get_voltage(driver: RigolDP800, channel_config: ChannelConfig) -> None:
         time.sleep(1)
 
         voltage = driver.get_voltage(channel=channel_config.channel)
+        _stream(f"ch{channel_config.channel}.voltage_v", voltage)
 
         assert voltage == pytest.approx(
             channel_config.programmed_voltage,
@@ -162,7 +303,9 @@ def test_set_current_limit(driver: RigolDP800, channel_config: ChannelConfig) ->
         driver.output_enable(True, channel=channel_config.channel)
         time.sleep(1)
 
-        assert driver.get_current(channel=channel_config.channel) == pytest.approx(
+        current = driver.get_current(channel=channel_config.channel)
+        _stream(f"ch{channel_config.channel}.current_a", current)
+        assert current == pytest.approx(
             0.0,
             abs=channel_config.current_readback_tolerance,
         )
@@ -179,6 +322,7 @@ def test_get_current(driver: RigolDP800, channel_config: ChannelConfig) -> None:
         time.sleep(1)
 
         current = driver.get_current(channel=channel_config.channel)
+        _stream(f"ch{channel_config.channel}.current_a", current)
 
         assert current == pytest.approx(
             0.0,
@@ -194,24 +338,32 @@ def test_output_enable(driver: RigolDP800, channel_config: ChannelConfig) -> Non
     driver.set_voltage(channel_config.programmed_voltage, channel=channel_config.channel)
     try:
         driver.output_enable(True, channel=channel_config.channel)
-        assert driver.get_output_status(channel=channel_config.channel) is True
+        state_on = driver.get_output_status(channel=channel_config.channel)
+        _stream(f"ch{channel_config.channel}.output_enabled", float(state_on))
+        assert state_on is True
 
         driver.output_enable(False, channel=channel_config.channel)
-        assert driver.get_output_status(channel=channel_config.channel) is False
+        state_off = driver.get_output_status(channel=channel_config.channel)
+        _stream(f"ch{channel_config.channel}.output_enabled", float(state_off))
+        assert state_off is False
     finally:
         driver.output_enable(False, channel=channel_config.channel)
 
 
 @pytest.mark.parametrize("channel_config", CHANNELS, ids=lambda config: f"channel_{config.channel}")
 def test_get_output_status(driver: RigolDP800, channel_config: ChannelConfig) -> None:
-    assert driver.get_output_status(channel=channel_config.channel) is False
+    state_initial = driver.get_output_status(channel=channel_config.channel)
+    _stream(f"ch{channel_config.channel}.output_enabled", float(state_initial))
+    assert state_initial is False
 
     driver.set_current_limit(channel_config.programmed_current_limit, channel=channel_config.channel)
     driver.set_voltage(channel_config.programmed_voltage, channel=channel_config.channel)
     try:
         driver.output_enable(True, channel=channel_config.channel)
 
-        assert driver.get_output_status(channel=channel_config.channel) is True
+        state_on = driver.get_output_status(channel=channel_config.channel)
+        _stream(f"ch{channel_config.channel}.output_enabled", float(state_on))
+        assert state_on is True
     finally:
         driver.output_enable(False, channel=channel_config.channel)
 
@@ -220,9 +372,9 @@ def test_get_output_status(driver: RigolDP800, channel_config: ChannelConfig) ->
 def test_set_overvoltage_protection_level(driver: RigolDP800, channel_config: ChannelConfig) -> None:
     driver.set_overvoltage_protection_level(channel_config.ovp_level, channel=channel_config.channel)
 
-    assert driver.get_overvoltage_protection_level(channel=channel_config.channel) == pytest.approx(
-        channel_config.ovp_level
-    )
+    level = driver.get_overvoltage_protection_level(channel=channel_config.channel)
+    _stream(f"ch{channel_config.channel}.ovp_level_v", level)
+    assert level == pytest.approx(channel_config.ovp_level)
 
 
 @pytest.mark.parametrize("channel_config", CHANNELS, ids=lambda config: f"channel_{config.channel}")
@@ -230,6 +382,7 @@ def test_get_overvoltage_protection_level(driver: RigolDP800, channel_config: Ch
     driver.set_overvoltage_protection_level(channel_config.ovp_level, channel=channel_config.channel)
 
     level = driver.get_overvoltage_protection_level(channel=channel_config.channel)
+    _stream(f"ch{channel_config.channel}.ovp_level_v", level)
 
     assert level == pytest.approx(channel_config.ovp_level)
 
@@ -238,60 +391,29 @@ def test_get_overvoltage_protection_level(driver: RigolDP800, channel_config: Ch
 def test_set_overvoltage_protection_enabled(driver: RigolDP800, channel_config: ChannelConfig) -> None:
     driver.set_overvoltage_protection_level(channel_config.ovp_level, channel=channel_config.channel)
     driver.set_overvoltage_protection_enabled(True, channel=channel_config.channel)
-    assert driver.get_overvoltage_protection_enabled(channel=channel_config.channel) is True
+    state_on = driver.get_overvoltage_protection_enabled(channel=channel_config.channel)
+    _stream(f"ch{channel_config.channel}.ovp_enabled", float(state_on))
+    assert state_on is True
 
     driver.set_overvoltage_protection_enabled(False, channel=channel_config.channel)
-    assert driver.get_overvoltage_protection_enabled(channel=channel_config.channel) is False
+    state_off = driver.get_overvoltage_protection_enabled(channel=channel_config.channel)
+    _stream(f"ch{channel_config.channel}.ovp_enabled", float(state_off))
+    assert state_off is False
 
 
 @pytest.mark.parametrize("channel_config", CHANNELS, ids=lambda config: f"channel_{config.channel}")
 def test_get_overvoltage_protection_enabled(driver: RigolDP800, channel_config: ChannelConfig) -> None:
     driver.set_overvoltage_protection_level(channel_config.ovp_level, channel=channel_config.channel)
     driver.set_overvoltage_protection_enabled(False, channel=channel_config.channel)
-    assert driver.get_overvoltage_protection_enabled(channel=channel_config.channel) is False
+    state_off = driver.get_overvoltage_protection_enabled(channel=channel_config.channel)
+    _stream(f"ch{channel_config.channel}.ovp_enabled", float(state_off))
+    assert state_off is False
 
     driver.set_overvoltage_protection_enabled(True, channel=channel_config.channel)
 
-    assert driver.get_overvoltage_protection_enabled(channel=channel_config.channel) is True
-
-
-@pytest.mark.parametrize("channel_config", CHANNELS, ids=lambda config: f"channel_{config.channel}")
-def test_set_overcurrent_protection_level(driver: RigolDP800, channel_config: ChannelConfig) -> None:
-    driver.set_overcurrent_protection_level(channel_config.ocp_level, channel=channel_config.channel)
-
-    assert driver.get_overcurrent_protection_level(channel=channel_config.channel) == pytest.approx(
-        channel_config.ocp_level
-    )
-
-
-@pytest.mark.parametrize("channel_config", CHANNELS, ids=lambda config: f"channel_{config.channel}")
-def test_get_overcurrent_protection_level(driver: RigolDP800, channel_config: ChannelConfig) -> None:
-    driver.set_overcurrent_protection_level(channel_config.ocp_level, channel=channel_config.channel)
-
-    level = driver.get_overcurrent_protection_level(channel=channel_config.channel)
-
-    assert level == pytest.approx(channel_config.ocp_level)
-
-
-@pytest.mark.parametrize("channel_config", CHANNELS, ids=lambda config: f"channel_{config.channel}")
-def test_set_overcurrent_protection_enabled(driver: RigolDP800, channel_config: ChannelConfig) -> None:
-    driver.set_overcurrent_protection_level(channel_config.ocp_level, channel=channel_config.channel)
-    driver.set_overcurrent_protection_enabled(True, channel=channel_config.channel)
-    assert driver.get_overcurrent_protection_enabled(channel=channel_config.channel) is True
-
-    driver.set_overcurrent_protection_enabled(False, channel=channel_config.channel)
-    assert driver.get_overcurrent_protection_enabled(channel=channel_config.channel) is False
-
-
-@pytest.mark.parametrize("channel_config", CHANNELS, ids=lambda config: f"channel_{config.channel}")
-def test_get_overcurrent_protection_enabled(driver: RigolDP800, channel_config: ChannelConfig) -> None:
-    driver.set_overcurrent_protection_level(channel_config.ocp_level, channel=channel_config.channel)
-    driver.set_overcurrent_protection_enabled(False, channel=channel_config.channel)
-    assert driver.get_overcurrent_protection_enabled(channel=channel_config.channel) is False
-
-    driver.set_overcurrent_protection_enabled(True, channel=channel_config.channel)
-
-    assert driver.get_overcurrent_protection_enabled(channel=channel_config.channel) is True
+    state_on = driver.get_overvoltage_protection_enabled(channel=channel_config.channel)
+    _stream(f"ch{channel_config.channel}.ovp_enabled", float(state_on))
+    assert state_on is True
 
 
 def test_set_overvoltage_protection_delay_unsupported(driver: RigolDP800) -> None:
@@ -305,6 +427,54 @@ def test_get_overvoltage_protection_delay_unsupported(driver: RigolDP800) -> Non
 
 
 @pytest.mark.parametrize("channel_config", CHANNELS, ids=lambda config: f"channel_{config.channel}")
+def test_set_overcurrent_protection_level(driver: RigolDP800, channel_config: ChannelConfig) -> None:
+    driver.set_overcurrent_protection_level(channel_config.ocp_level, channel=channel_config.channel)
+
+    level = driver.get_overcurrent_protection_level(channel=channel_config.channel)
+    _stream(f"ch{channel_config.channel}.ocp_level_a", level)
+    assert level == pytest.approx(channel_config.ocp_level)
+
+
+@pytest.mark.parametrize("channel_config", CHANNELS, ids=lambda config: f"channel_{config.channel}")
+def test_get_overcurrent_protection_level(driver: RigolDP800, channel_config: ChannelConfig) -> None:
+    driver.set_overcurrent_protection_level(channel_config.ocp_level, channel=channel_config.channel)
+
+    level = driver.get_overcurrent_protection_level(channel=channel_config.channel)
+    _stream(f"ch{channel_config.channel}.ocp_level_a", level)
+
+    assert level == pytest.approx(channel_config.ocp_level)
+
+
+@pytest.mark.parametrize("channel_config", CHANNELS, ids=lambda config: f"channel_{config.channel}")
+def test_set_overcurrent_protection_enabled(driver: RigolDP800, channel_config: ChannelConfig) -> None:
+    driver.set_overcurrent_protection_level(channel_config.ocp_level, channel=channel_config.channel)
+    driver.set_overcurrent_protection_enabled(True, channel=channel_config.channel)
+    state_on = driver.get_overcurrent_protection_enabled(channel=channel_config.channel)
+    _stream(f"ch{channel_config.channel}.ocp_enabled", float(state_on))
+    assert state_on is True
+
+    driver.set_overcurrent_protection_enabled(False, channel=channel_config.channel)
+    state_off = driver.get_overcurrent_protection_enabled(channel=channel_config.channel)
+    _stream(f"ch{channel_config.channel}.ocp_enabled", float(state_off))
+    assert state_off is False
+
+
+@pytest.mark.parametrize("channel_config", CHANNELS, ids=lambda config: f"channel_{config.channel}")
+def test_get_overcurrent_protection_enabled(driver: RigolDP800, channel_config: ChannelConfig) -> None:
+    driver.set_overcurrent_protection_level(channel_config.ocp_level, channel=channel_config.channel)
+    driver.set_overcurrent_protection_enabled(False, channel=channel_config.channel)
+    state_off = driver.get_overcurrent_protection_enabled(channel=channel_config.channel)
+    _stream(f"ch{channel_config.channel}.ocp_enabled", float(state_off))
+    assert state_off is False
+
+    driver.set_overcurrent_protection_enabled(True, channel=channel_config.channel)
+
+    state_on = driver.get_overcurrent_protection_enabled(channel=channel_config.channel)
+    _stream(f"ch{channel_config.channel}.ocp_enabled", float(state_on))
+    assert state_on is True
+
+
+@pytest.mark.parametrize("channel_config", CHANNELS, ids=lambda config: f"channel_{config.channel}")
 def test_set_remote_sense_enabled(driver: RigolDP800, channel_config: ChannelConfig) -> None:
     if not channel_config.supports_remote_sense:
         with pytest.raises(RuntimeError, match="Rigol DP800-series PSU reported error"):
@@ -313,11 +483,15 @@ def test_set_remote_sense_enabled(driver: RigolDP800, channel_config: ChannelCon
 
     try:
         driver.set_remote_sense_enabled(True, channel=channel_config.channel)
-        assert driver.get_remote_sense_enabled(channel=channel_config.channel) is True
+        state_on = driver.get_remote_sense_enabled(channel=channel_config.channel)
+        _stream(f"ch{channel_config.channel}.remote_sense_enabled", float(state_on))
+        assert state_on is True
     finally:
         driver.set_remote_sense_enabled(False, channel=channel_config.channel)
 
-    assert driver.get_remote_sense_enabled(channel=channel_config.channel) is False
+    state_off = driver.get_remote_sense_enabled(channel=channel_config.channel)
+    _stream(f"ch{channel_config.channel}.remote_sense_enabled", float(state_off))
+    assert state_off is False
 
 
 @pytest.mark.parametrize("channel_config", CHANNELS, ids=lambda config: f"channel_{config.channel}")
@@ -328,12 +502,16 @@ def test_get_remote_sense_enabled(driver: RigolDP800, channel_config: ChannelCon
         return
 
     driver.set_remote_sense_enabled(False, channel=channel_config.channel)
-    assert driver.get_remote_sense_enabled(channel=channel_config.channel) is False
+    state_off = driver.get_remote_sense_enabled(channel=channel_config.channel)
+    _stream(f"ch{channel_config.channel}.remote_sense_enabled", float(state_off))
+    assert state_off is False
 
     try:
         driver.set_remote_sense_enabled(True, channel=channel_config.channel)
 
-        assert driver.get_remote_sense_enabled(channel=channel_config.channel) is True
+        state_on = driver.get_remote_sense_enabled(channel=channel_config.channel)
+        _stream(f"ch{channel_config.channel}.remote_sense_enabled", float(state_on))
+        assert state_on is True
     finally:
         driver.set_remote_sense_enabled(False, channel=channel_config.channel)
 

--- a/tests/psu/rigol/test_rigol_dp800_hardware.py
+++ b/tests/psu/rigol/test_rigol_dp800_hardware.py
@@ -33,7 +33,7 @@ INVALID_CHANNEL = 4
 # ---------------------------------------------------------------------------
 # Set DATASET_RID to a Nominal dataset RID to stream readings and test events to
 # Nominal Core. Leave as None to skip all Nominal publishing (tests still run normally).
-DATASET_RID: str | None = None
+DATASET_RID = None
 NOMINAL_PROFILE = "default"
 
 
@@ -110,13 +110,15 @@ class _EventRecorder:
         passed: bool,
         description: str = "",
     ) -> None:
-        self._events.append({
-            "name": name,
-            "start_ns": start_ns,
-            "end_ns": end_ns,
-            "passed": passed,
-            "description": description,
-        })
+        self._events.append(
+            {
+                "name": name,
+                "start_ns": start_ns,
+                "end_ns": end_ns,
+                "passed": passed,
+                "description": description,
+            }
+        )
 
     def finish(self) -> None:
         assert self._client is not None
@@ -148,10 +150,12 @@ def _stream(channel: str, value: float) -> None:
     """Stream a single scalar reading to Nominal Core. No-op when DATASET_RID is None."""
     if _publisher is None:
         return
-    _publisher.publish(Measurement(
-        timestamps=[time.time_ns()],
-        channel_data={channel: [value]},
-    ))
+    _publisher.publish(
+        Measurement(
+            timestamps=[time.time_ns()],
+            channel_data={channel: [value]},
+        )
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -236,9 +240,7 @@ def record_test_event(request: pytest.FixtureRequest) -> Iterator[None]:
         description = request.node.nodeid
         if exc_str:
             description += f"\n\nError: {exc_str}"
-        _recorder.record_event(
-            request.node.name, start_ns, time.time_ns(), passed=passed, description=description
-        )
+        _recorder.record_event(request.node.name, start_ns, time.time_ns(), passed=passed, description=description)
 
 
 # ---------------------------------------------------------------------------
@@ -247,6 +249,9 @@ def record_test_event(request: pytest.FixtureRequest) -> Iterator[None]:
 
 
 def test_query_status(driver: RigolDP800) -> None:
+    idn = driver._visa.query("*IDN?")
+    print(f"\nIDN: {idn.strip()}")
+
     status = driver.query_status()
 
     assert set(status) == {f"ch{channel_config.channel}" for channel_config in CHANNELS}


### PR DESCRIPTION
## INSTRO-351: Verifying the Rigol DP800 Series Driver

Verifying the Rigol DP800 driver against the physical Rigol DP832A PSU model. Includes validation photos of tests as well as the two scripts 
used to run the tests.

### Tested instrument

- **Model:** Rigol DP832A (serial: DP8B26AM00234)
- **Firmware version:** 00.01.19
- **Channels under test:** 3 (CH1, CH2, CH3 — all configured with `supports_remote_sense=False`)

### Test configuration

| Parameter | Value |
|---|---|
| Programmed voltage | 1.0 V |
| Programmed current limit | 0.1 A |
| OVP level | 5.0 V |
| OCP level | 0.5 A |
| Voltage readback tolerance | ±0.15 V |
| Current readback tolerance | ±0.02 A |

### Coverage — 41 software + 57 hardware tests, all passing

**Software tests** use a mocked `VisaDriver` transport (`unittest.mock.patch(..., autospec=True)`). No hardware required.

| Group | Tests | Methods |
|---|---|---|
| Lifecycle / init | 4 | `__init__` accepts `str` and `VisaConfig`; `open` caches per-channel limits via `MIN`/`MAX` queries; `close` delegates to VISA |
| Voltage | 2 | `set_voltage` — `:SOURn:VOLT` per channel; `get_voltage` — `:MEAS:VOLT? CHn` |
| Current | 2 | `set_current_limit` — `:SOURn:CURR`; `get_current` — `:MEAS:CURR? CHn` |
| Output enable | 2 | `output_enable` — `:OUTP CHn,ON\|OFF`; `get_output_status` — parses `ON`/`OFF` to `bool` |
| Overvoltage protection | 5 | `set/get_overvoltage_protection_level`, `set/get_overvoltage_protection_enabled`; delay raises `FeatureNotSupportedError` (not in DP800 spec) |
| Overcurrent protection | 4 | `set/get_overcurrent_protection_level` — `:SOURn:CURR:PROT`; `set/get_overcurrent_protection_enabled` |
| Remote sense | 4 | `set_remote_sense_enabled` — `:OUTP:SENS CHn,ON\|OFF`; `get_remote_sense_enabled` raises `FeatureNotSupportedError` on `NONE` response |
| Cached range guards | 13 | 8 parametrized cases reject out-of-range values (voltage, current, OVP, OCP at both edges) without writing to the instrument; 4 accept exact maximums; invalid channel surfaces instrument error |
| Error handling | 5 | `check_errors` accepts `0` and `+0`; raises on non-zero; `_write_checked` and `_query_checked` both surface SCPI error strings |

**Hardware tests** are `@pytest.mark.hardware` and parametrized across all 3 channels via `ChannelConfig`.

| Group | Tests | Methods |
|---|---|---|
| Device status | 1 | `query_status` — all 3 channels present; `enable` is `False`; `mode` is valid; `OVP`/`OCP` are `bool` |
| Voltage | 6 | `set_voltage` + `get_voltage` × 3 channels — readback within ±0.15 V after 1 s settle |
| Current | 6 | `set_current_limit` + `get_current` × 3 channels — unloaded current within ±0.02 A |
| Output enable | 6 | `output_enable` + `get_output_status` × 3 channels — ON/OFF round-trip |
| Overvoltage protection | 14 | `set/get_ovp_level` × 3 + `set/get_ovp_enabled` × 3 + `set/get_ovp_delay` unsupported (non-parametrized) × 2 |
| Overcurrent protection | 12 | `set/get_ocp_level` × 3 + `set/get_ocp_enabled` × 3 |
| Remote sense | 6 | All 3 channels have `supports_remote_sense=False` — `set_remote_sense_enabled` raises `RuntimeError` (instrument rejects it); `get_remote_sense_enabled` raises `FeatureNotSupportedError` |
| Error / range guards | 6 | `check_errors` raises after bogus write; `set_voltage`, `set_current_limit`, `set_ovp_level`, `set_ocp_level` all raise `ValueError` at out-of-range values; invalid channel raises instrument error |

### Validation
<img width="1140" height="705" alt="rigol psu software tests passing" src="https://github.com/user-attachments/assets/ca151dd2-e137-4f15-8141-d5afbc9e2e46" />
<img width="1255" height="731" alt="rigol psu hardware tests passing" src="https://github.com/user-attachments/assets/85789d3c-ad51-4bd6-879d-cb7292a7b23f" />
<img width="1657" height="797" alt="rigol psu annotated hardware tests" src="https://github.com/user-attachments/assets/c03ecfe6-8a09-4e12-b541-52f4eb916c2b" />


### Notes
- `get_remote_sense_enabled` raises `FeatureNotSupportedError` on `NONE` response; the hardware suite exercises this via the `supports_remote_sense=False` path on all three channels.
- Expected machine errors on `test_invalid_channel_raises_instrument_error` and `test_check_errors_raises_after_instrument_error`.

### Checks

- `just check` - All checks passed
- `just test` - 1080 tests pass