### PR TITLE
docs: fix and standardize example scripts

### DIFF
--- a/docs/guides/instrumentation/examples/daq/daq_read_analog_hw_timed.mdx
+++ b/docs/guides/instrumentation/examples/daq/daq_read_analog_hw_timed.mdx
@@ -58,10 +58,10 @@ daq.add_publisher(NominalCorePublisher(dataset_rid=DATASET_RID))
 
 with daq:
     daq.configure_analog_channel(
-        direction=Direction.INPUT, physical_channel=CHANNEL_0, alias=f"ch_0", range_min=0, range_max=5
+        direction=Direction.INPUT, physical_channel=CHANNEL_0, alias="ch_0", range_min=0, range_max=5
     )
     daq.configure_analog_channel(
-        direction=Direction.INPUT, physical_channel=CHANNEL_1, alias=f"ch_1", range_min=0, range_max=5
+        direction=Direction.INPUT, physical_channel=CHANNEL_1, alias="ch_1", range_min=0, range_max=5
     )
 
     daq.configure_ai_sample_rate(sample_rate=100)

--- a/docs/guides/instrumentation/examples/daq/daq_read_analog_hw_timed_no_background.mdx
+++ b/docs/guides/instrumentation/examples/daq/daq_read_analog_hw_timed_no_background.mdx
@@ -56,10 +56,10 @@ daq.add_publisher(NominalCorePublisher(dataset_rid=DATASET_RID))
 
 with daq:
     daq.configure_analog_channel(
-        direction=Direction.INPUT, physical_channel=CHANNEL_0, alias=f"ch_0", range_min=0, range_max=5
+        direction=Direction.INPUT, physical_channel=CHANNEL_0, alias="ch_0", range_min=0, range_max=5
     )
     daq.configure_analog_channel(
-        direction=Direction.INPUT, physical_channel=CHANNEL_1, alias=f"ch_1", range_min=0, range_max=5
+        direction=Direction.INPUT, physical_channel=CHANNEL_1, alias="ch_1", range_min=0, range_max=5
     )
 
     # Set the sample rate but also the number of samples we will fetch each time daq.read_analog() is called.

--- a/docs/guides/instrumentation/examples/daq/daq_read_analog_sw_timed.mdx
+++ b/docs/guides/instrumentation/examples/daq/daq_read_analog_sw_timed.mdx
@@ -58,10 +58,10 @@ daq.add_publisher(NominalCorePublisher(dataset_rid=DATASET_RID))
 
 with daq:
     daq.configure_analog_channel(
-        direction=Direction.INPUT, physical_channel=CHANNEL_0, alias=f"ch_0", range_min=0, range_max=5
+        direction=Direction.INPUT, physical_channel=CHANNEL_0, alias="ch_0", range_min=0, range_max=5
     )
     daq.configure_analog_channel(
-        direction=Direction.INPUT, physical_channel=CHANNEL_1, alias=f"ch_1", range_min=0, range_max=5
+        direction=Direction.INPUT, physical_channel=CHANNEL_1, alias="ch_1", range_min=0, range_max=5
     )
 
     for i in range(5):

--- a/docs/guides/instrumentation/examples/daq/daq_read_digital_line.mdx
+++ b/docs/guides/instrumentation/examples/daq/daq_read_digital_line.mdx
@@ -58,17 +58,17 @@ with daq:
     daq.configure_digital_line(
         direction=Direction.INPUT,
         physical_channel=CHANNEL_0,
-        alias=f"di_0",
+        alias="di_0",
         logic=Logic.HIGH,
     )
     daq.configure_digital_line(
         direction=Direction.INPUT,
         physical_channel=CHANNEL_1,
-        alias=f"di_1",
+        alias="di_1",
         logic=Logic.LOW,
     )
 
     read0 = daq.read_digital_line(channel="di_0")
     read1 = daq.read_digital_line(channel="di_1")
-    print(f"Values: ", read0.latest, read1.latest)
+    print(f"Values: {read0.latest}, {read1.latest}")
 ```

--- a/docs/guides/instrumentation/examples/daq/daq_relays.mdx
+++ b/docs/guides/instrumentation/examples/daq/daq_relays.mdx
@@ -8,7 +8,7 @@ title: "Relay Control for DAQs with relays native to them"
 import time
 
 from instro.daq import InstroDAQ
-from instro.daq.types import DAQVendor, Direction, Logic
+from instro.daq.types import DAQVendor
 from instro.lib.publishers import NominalCorePublisher
 
 # Configuration: Choose your vendor.

--- a/docs/guides/instrumentation/examples/daq/daq_write_analog_sw_timed.mdx
+++ b/docs/guides/instrumentation/examples/daq/daq_write_analog_sw_timed.mdx
@@ -46,10 +46,10 @@ daq.add_publisher(NominalCorePublisher(dataset_rid=DATASET_RID))
 
 with daq:
     daq.configure_analog_channel(
-        direction=Direction.OUTPUT, physical_channel=CHANNEL_0, alias=f"ao_0", range_min=0, range_max=5
+        direction=Direction.OUTPUT, physical_channel=CHANNEL_0, alias="ao_0", range_min=0, range_max=5
     )
     daq.configure_analog_channel(
-        direction=Direction.OUTPUT, physical_channel=CHANNEL_1, alias=f"ao_1", range_min=0, range_max=5
+        direction=Direction.OUTPUT, physical_channel=CHANNEL_1, alias="ao_1", range_min=0, range_max=5
     )
 
     daq.write_analog_value("ao_0", 2.2)

--- a/docs/guides/instrumentation/examples/daq/daq_write_digital_line.mdx
+++ b/docs/guides/instrumentation/examples/daq/daq_write_digital_line.mdx
@@ -52,10 +52,10 @@ daq.add_publisher(NominalCorePublisher(dataset_rid=DATASET_RID))
 
 with daq:
     daq.configure_digital_line(
-        direction=Direction.OUTPUT, physical_channel=CHANNEL_0, alias=f"do_0", logic=Logic.HIGH, logic_level=5.0
+        direction=Direction.OUTPUT, physical_channel=CHANNEL_0, alias="do_0", logic=Logic.HIGH, logic_level=5.0
     )
     daq.configure_digital_line(
-        direction=Direction.OUTPUT, physical_channel=CHANNEL_1, alias=f"do_1", logic=Logic.LOW, logic_level=5.0
+        direction=Direction.OUTPUT, physical_channel=CHANNEL_1, alias="do_1", logic=Logic.LOW, logic_level=5.0
     )
 
     daq.write_digital_line(channel="do_0", data=1)

--- a/docs/guides/instrumentation/examples/eload/eload.mdx
+++ b/docs/guides/instrumentation/examples/eload/eload.mdx
@@ -12,7 +12,7 @@ Demonstrates publishing measurements/commands to a dataset (Nominal Core publish
 import time
 
 from instro.eload import InstroELoad
-from instro.eload.drivers.bk_85xxb import BK85XXB
+from instro.eload.drivers import BK85XXB
 from instro.eload.types import LoadMode
 from instro.lib.publishers import NominalCorePublisher
 from instro.lib.transports import SerialConfig, VisaConfig
@@ -53,10 +53,6 @@ with eload:
     time.sleep(0.5)
 
     eload.set_level(value=1.1)
-
-    time.sleep(0.5)
-
-    eload.output_enable(enable=False)
 
     time.sleep(0.5)
 

--- a/docs/guides/instrumentation/examples/ethernetip/programmatic_config_example.mdx
+++ b/docs/guides/instrumentation/examples/ethernetip/programmatic_config_example.mdx
@@ -32,7 +32,7 @@ from instro.ethernetip import (
     TagDef,
     TimingConfig,
 )
-from instro.lib.types import DeviceInfo
+from instro.lib import DeviceInfo
 
 
 def connection_from_env() -> EtherNetIPConnectionInfo:

--- a/docs/guides/instrumentation/examples/modbus/minimal_example.mdx
+++ b/docs/guides/instrumentation/examples/modbus/minimal_example.mdx
@@ -9,7 +9,7 @@ Start the sim server first:
     python -m instro.modbus.sim_server
 
 Then in another shell:
-    python -m instro.modbus.examples.minimal_example
+    python examples/modbus/minimal_example.py
 """
 
 from pathlib import Path

--- a/docs/guides/instrumentation/examples/psu/psu.mdx
+++ b/docs/guides/instrumentation/examples/psu/psu.mdx
@@ -12,7 +12,7 @@ Demonstrates publishing measurements/commands to a dataset (Nominal Core publish
 import logging
 import time
 
-from instro.lib.nominal import install_nominal_core_log_handler
+from instro.lib import install_nominal_core_log_handler
 from instro.lib.publishers import NominalCorePublisher
 from instro.psu import InstroPSU
 from instro.psu.drivers import SimulatedPSU

--- a/docs/guides/instrumentation/examples/publishers/publish_custom.mdx
+++ b/docs/guides/instrumentation/examples/publishers/publish_custom.mdx
@@ -7,7 +7,7 @@ title: "Publishers: publish custom"
 
 import time
 
-from instro.lib.types import Command, Measurement
+from instro.lib import Command, Measurement
 from instro.psu import InstroPSU
 from instro.psu.drivers import SimulatedPSU
 

--- a/docs/guides/instrumentation/examples/scope/scope_background.mdx
+++ b/docs/guides/instrumentation/examples/scope/scope_background.mdx
@@ -12,11 +12,15 @@ Vrms, Vpp, and Frequency on channel 1 while printing results in a main loop.
 
 from instro.lib.publishers import NominalCorePublisher
 from instro.scope import (
+    AcquisitionMode,
+    Coupling,
     InstroScope,
     ScopeMeasurementType,
+    TriggerMode,
+    TriggerSlope,
+    TriggerType,
 )
 from instro.scope.drivers import Keysight1200X
-from instro.scope.types import AcquisitionMode, Coupling, TriggerMode, TriggerSlope, TriggerType
 
 VISA_RESOURCE = "<visa_resource>"  # Replace with your instrument's VISA resource string.
 DATASET_RID = "<dataset_rid>"  # Replace with your dataset RID.
@@ -28,27 +32,24 @@ scope = InstroScope(
     publishers=[NominalCorePublisher(DATASET_RID)],
 )
 
-try:
-    scope.open()
-
-    # # --- Configure channel 1 ---
+with scope:
+    # --- Configure channel 1 ---
     scope.set_coupling(Coupling.DC, channel=1)
     scope.set_probe_attenuation(1.0, channel=1)
     scope.set_vertical_scale(1.0, channel=1)  # 1 V/div
     scope.set_vertical_offset(0, channel=1)
 
-    # # --- Configure timebase ---
-    scope.set_horizontal_scale(0.01)  # 100 ms/div
+    # --- Configure timebase ---
+    scope.set_horizontal_scale(0.01)  # 10 ms/div
 
-    # # --- Configure acquisition ---
+    # --- Configure acquisition ---
     scope.set_acquisition_mode(AcquisitionMode.NORMAL)
 
-    # # # --- Configure trigger ---
+    # --- Configure trigger ---
     scope.set_trigger_source(channel=1)
-
     scope.set_trigger_type(TriggerType.EDGE)
     scope.set_trigger_slope(TriggerSlope.RISING)
-    scope.set_trigger_level(0)  # 2.5 Volts
+    scope.set_trigger_level(0)  # 0 V
     scope.set_trigger_mode(TriggerMode.NORMAL)
 
     # --- Register background measurements ---
@@ -75,7 +76,4 @@ try:
             break
 
     print("Done")
-
-finally:
-    scope.close()
 ```

--- a/docs/guides/instrumentation/examples/scope/scope_basic.mdx
+++ b/docs/guides/instrumentation/examples/scope/scope_basic.mdx
@@ -10,10 +10,8 @@ settings, capturing a waveform, and taking built-in measurements.
 
 """
 
-import time
-
 from instro.lib.publishers import NominalCorePublisher
-from instro.lib.transports.visa import VisaConfig
+from instro.lib.transports import VisaConfig
 from instro.scope import (
     AcquisitionMode,
     Coupling,
@@ -35,37 +33,34 @@ scope = InstroScope(
     publishers=[NominalCorePublisher(dataset_rid=DATASET_RID)],
 )
 
-try:
-    scope.open()
-
-    # # --- Configure channel 1 ---
+with scope:
+    # --- Configure channel 1 ---
     scope.set_coupling(Coupling.DC, channel=1)
     scope.set_probe_attenuation(1.0, channel=1)
     scope.set_vertical_scale(1, channel=1)  # 1 V/div
     scope.set_vertical_offset(0, channel=1)
 
-    # # --- Configure timebase ---
-    scope.set_horizontal_scale(0.01)  # 100 ms/div
+    # --- Configure timebase ---
+    scope.set_horizontal_scale(0.01)  # 10 ms/div
 
-    # # --- Configure acquisition ---
+    # --- Configure acquisition ---
     scope.set_acquisition_mode(AcquisitionMode.NORMAL)
 
-    # # # --- Configure trigger ---
+    # --- Configure trigger ---
     scope.set_trigger_source(channel=1)
-
     scope.set_trigger_type(TriggerType.EDGE)
     scope.set_trigger_slope(TriggerSlope.RISING)
-    scope.set_trigger_level(0)  # 2.5 Volts
+    scope.set_trigger_level(0)  # 0 V
     scope.set_trigger_mode(TriggerMode.NORMAL)
 
-    # # # --- Acquire and fetch ---
+    # --- Acquire and fetch ---
+    # single() arms the acquisition; fetch_waveform() then blocks until the
+    # trigger fires and the capture completes (up to its timeout).
     scope.single()
-    time.sleep(2)  # Wait for trigger and acquisition
-
     waveform = scope.fetch_waveform(channel=1)
     print(f"Waveform captured: {len(waveform.channel_data)} channel(s)")
 
-    # # # --- Built-in measurements ---
+    # --- Built-in measurements ---
     vpp = scope.measure(ScopeMeasurementType.VPP, channel=1)
     vrms = scope.measure(ScopeMeasurementType.VRMS, channel=1, timeout=10)
     vmax = scope.measure(ScopeMeasurementType.VMAX, channel=1)
@@ -75,17 +70,14 @@ try:
     print(f"Vpp:  {vpp}")
     print(f"Vrms: {vrms}")
     print(f"Vmax: {vmax}")
-    print(f"Vpp:  {vmin}")
-    print(f"Vrms: {freq}")
-    print(f"Vmax: {per}")
+    print(f"Vmin: {vmin}")
+    print(f"Frequency: {freq}")
+    print(f"Period: {per}")
 
-    # # --- Read back settings ---
+    # --- Read back settings ---
     sample_rate = scope.get_sample_rate()
     print(f"Sample rate: {sample_rate}")
 
-    # # # --- Save a screenshot ---
+    # --- Save a screenshot ---
     scope.save_screenshot("capture.png")
-
-finally:
-    scope.close()
 ```

--- a/docs/guides/instrumentation/examples/test_rack_example/test_rack.mdx
+++ b/docs/guides/instrumentation/examples/test_rack_example/test_rack.mdx
@@ -15,7 +15,7 @@ from instro.daq import InstroDAQ
 from instro.daq.drivers import Keysight34980A
 from instro.daq.types import Direction
 from instro.eload import InstroELoad
-from instro.eload.drivers.bk_85xxb import BK85XXB
+from instro.eload.drivers import BK85XXB
 from instro.eload.types import LoadMode
 from instro.lib.transports import SerialConfig, VisaConfig
 from instro.psu import InstroPSU

--- a/examples/daq/daq_read_analog_hw_timed.py
+++ b/examples/daq/daq_read_analog_hw_timed.py
@@ -53,10 +53,10 @@ daq.add_publisher(NominalCorePublisher(dataset_rid=DATASET_RID))
 
 with daq:
     daq.configure_analog_channel(
-        direction=Direction.INPUT, physical_channel=CHANNEL_0, alias=f"ch_0", range_min=0, range_max=5
+        direction=Direction.INPUT, physical_channel=CHANNEL_0, alias="ch_0", range_min=0, range_max=5
     )
     daq.configure_analog_channel(
-        direction=Direction.INPUT, physical_channel=CHANNEL_1, alias=f"ch_1", range_min=0, range_max=5
+        direction=Direction.INPUT, physical_channel=CHANNEL_1, alias="ch_1", range_min=0, range_max=5
     )
 
     daq.configure_ai_sample_rate(sample_rate=100)

--- a/examples/daq/daq_read_analog_hw_timed_no_background.py
+++ b/examples/daq/daq_read_analog_hw_timed_no_background.py
@@ -51,10 +51,10 @@ daq.add_publisher(NominalCorePublisher(dataset_rid=DATASET_RID))
 
 with daq:
     daq.configure_analog_channel(
-        direction=Direction.INPUT, physical_channel=CHANNEL_0, alias=f"ch_0", range_min=0, range_max=5
+        direction=Direction.INPUT, physical_channel=CHANNEL_0, alias="ch_0", range_min=0, range_max=5
     )
     daq.configure_analog_channel(
-        direction=Direction.INPUT, physical_channel=CHANNEL_1, alias=f"ch_1", range_min=0, range_max=5
+        direction=Direction.INPUT, physical_channel=CHANNEL_1, alias="ch_1", range_min=0, range_max=5
     )
 
     # Set the sample rate but also the number of samples we will fetch each time daq.read_analog() is called.

--- a/examples/daq/daq_read_analog_sw_timed.py
+++ b/examples/daq/daq_read_analog_sw_timed.py
@@ -53,10 +53,10 @@ daq.add_publisher(NominalCorePublisher(dataset_rid=DATASET_RID))
 
 with daq:
     daq.configure_analog_channel(
-        direction=Direction.INPUT, physical_channel=CHANNEL_0, alias=f"ch_0", range_min=0, range_max=5
+        direction=Direction.INPUT, physical_channel=CHANNEL_0, alias="ch_0", range_min=0, range_max=5
     )
     daq.configure_analog_channel(
-        direction=Direction.INPUT, physical_channel=CHANNEL_1, alias=f"ch_1", range_min=0, range_max=5
+        direction=Direction.INPUT, physical_channel=CHANNEL_1, alias="ch_1", range_min=0, range_max=5
     )
 
     for i in range(5):

--- a/examples/daq/daq_read_digital_line.py
+++ b/examples/daq/daq_read_digital_line.py
@@ -53,16 +53,16 @@ with daq:
     daq.configure_digital_line(
         direction=Direction.INPUT,
         physical_channel=CHANNEL_0,
-        alias=f"di_0",
+        alias="di_0",
         logic=Logic.HIGH,
     )
     daq.configure_digital_line(
         direction=Direction.INPUT,
         physical_channel=CHANNEL_1,
-        alias=f"di_1",
+        alias="di_1",
         logic=Logic.LOW,
     )
 
     read0 = daq.read_digital_line(channel="di_0")
     read1 = daq.read_digital_line(channel="di_1")
-    print(f"Values: ", read0.latest, read1.latest)
+    print(f"Values: {read0.latest}, {read1.latest}")

--- a/examples/daq/daq_relays.py
+++ b/examples/daq/daq_relays.py
@@ -3,7 +3,7 @@
 import time
 
 from instro.daq import InstroDAQ
-from instro.daq.types import DAQVendor, Direction, Logic
+from instro.daq.types import DAQVendor
 from instro.lib.publishers import NominalCorePublisher
 
 # Configuration: Choose your vendor.

--- a/examples/daq/daq_write_analog_sw_timed.py
+++ b/examples/daq/daq_write_analog_sw_timed.py
@@ -41,10 +41,10 @@ daq.add_publisher(NominalCorePublisher(dataset_rid=DATASET_RID))
 
 with daq:
     daq.configure_analog_channel(
-        direction=Direction.OUTPUT, physical_channel=CHANNEL_0, alias=f"ao_0", range_min=0, range_max=5
+        direction=Direction.OUTPUT, physical_channel=CHANNEL_0, alias="ao_0", range_min=0, range_max=5
     )
     daq.configure_analog_channel(
-        direction=Direction.OUTPUT, physical_channel=CHANNEL_1, alias=f"ao_1", range_min=0, range_max=5
+        direction=Direction.OUTPUT, physical_channel=CHANNEL_1, alias="ao_1", range_min=0, range_max=5
     )
 
     daq.write_analog_value("ao_0", 2.2)

--- a/examples/daq/daq_write_digital_line.py
+++ b/examples/daq/daq_write_digital_line.py
@@ -47,10 +47,10 @@ daq.add_publisher(NominalCorePublisher(dataset_rid=DATASET_RID))
 
 with daq:
     daq.configure_digital_line(
-        direction=Direction.OUTPUT, physical_channel=CHANNEL_0, alias=f"do_0", logic=Logic.HIGH, logic_level=5.0
+        direction=Direction.OUTPUT, physical_channel=CHANNEL_0, alias="do_0", logic=Logic.HIGH, logic_level=5.0
     )
     daq.configure_digital_line(
-        direction=Direction.OUTPUT, physical_channel=CHANNEL_1, alias=f"do_1", logic=Logic.LOW, logic_level=5.0
+        direction=Direction.OUTPUT, physical_channel=CHANNEL_1, alias="do_1", logic=Logic.LOW, logic_level=5.0
     )
 
     daq.write_digital_line(channel="do_0", data=1)

--- a/examples/eload/eload.py
+++ b/examples/eload/eload.py
@@ -7,7 +7,7 @@ Demonstrates publishing measurements/commands to a dataset (Nominal Core publish
 import time
 
 from instro.eload import InstroELoad
-from instro.eload.drivers.bk_85xxb import BK85XXB
+from instro.eload.drivers import BK85XXB
 from instro.eload.types import LoadMode
 from instro.lib.publishers import NominalCorePublisher
 from instro.lib.transports import SerialConfig, VisaConfig
@@ -48,10 +48,6 @@ with eload:
     time.sleep(0.5)
 
     eload.set_level(value=1.1)
-
-    time.sleep(0.5)
-
-    eload.output_enable(enable=False)
 
     time.sleep(0.5)
 

--- a/examples/ethernetip/programmatic_config_example.py
+++ b/examples/ethernetip/programmatic_config_example.py
@@ -27,7 +27,7 @@ from instro.ethernetip import (
     TagDef,
     TimingConfig,
 )
-from instro.lib.types import DeviceInfo
+from instro.lib import DeviceInfo
 
 
 def connection_from_env() -> EtherNetIPConnectionInfo:

--- a/examples/modbus/minimal_example.py
+++ b/examples/modbus/minimal_example.py
@@ -4,7 +4,7 @@ Start the sim server first:
     python -m instro.modbus.sim_server
 
 Then in another shell:
-    python -m instro.modbus.examples.minimal_example
+    python examples/modbus/minimal_example.py
 """
 
 from pathlib import Path

--- a/examples/psu/psu.py
+++ b/examples/psu/psu.py
@@ -7,7 +7,7 @@ Demonstrates publishing measurements/commands to a dataset (Nominal Core publish
 import logging
 import time
 
-from instro.lib.nominal import install_nominal_core_log_handler
+from instro.lib import install_nominal_core_log_handler
 from instro.lib.publishers import NominalCorePublisher
 from instro.psu import InstroPSU
 from instro.psu.drivers import SimulatedPSU

--- a/examples/publishers/publish_custom.py
+++ b/examples/publishers/publish_custom.py
@@ -2,7 +2,7 @@
 
 import time
 
-from instro.lib.types import Command, Measurement
+from instro.lib import Command, Measurement
 from instro.psu import InstroPSU
 from instro.psu.drivers import SimulatedPSU
 

--- a/examples/scope/scope_background.py
+++ b/examples/scope/scope_background.py
@@ -7,11 +7,15 @@ Vrms, Vpp, and Frequency on channel 1 while printing results in a main loop.
 
 from instro.lib.publishers import NominalCorePublisher
 from instro.scope import (
+    AcquisitionMode,
+    Coupling,
     InstroScope,
     ScopeMeasurementType,
+    TriggerMode,
+    TriggerSlope,
+    TriggerType,
 )
 from instro.scope.drivers import Keysight1200X
-from instro.scope.types import AcquisitionMode, Coupling, TriggerMode, TriggerSlope, TriggerType
 
 VISA_RESOURCE = "<visa_resource>"  # Replace with your instrument's VISA resource string.
 DATASET_RID = "<dataset_rid>"  # Replace with your dataset RID.
@@ -23,27 +27,24 @@ scope = InstroScope(
     publishers=[NominalCorePublisher(DATASET_RID)],
 )
 
-try:
-    scope.open()
-
-    # # --- Configure channel 1 ---
+with scope:
+    # --- Configure channel 1 ---
     scope.set_coupling(Coupling.DC, channel=1)
     scope.set_probe_attenuation(1.0, channel=1)
     scope.set_vertical_scale(1.0, channel=1)  # 1 V/div
     scope.set_vertical_offset(0, channel=1)
 
-    # # --- Configure timebase ---
-    scope.set_horizontal_scale(0.01)  # 100 ms/div
+    # --- Configure timebase ---
+    scope.set_horizontal_scale(0.01)  # 10 ms/div
 
-    # # --- Configure acquisition ---
+    # --- Configure acquisition ---
     scope.set_acquisition_mode(AcquisitionMode.NORMAL)
 
-    # # # --- Configure trigger ---
+    # --- Configure trigger ---
     scope.set_trigger_source(channel=1)
-
     scope.set_trigger_type(TriggerType.EDGE)
     scope.set_trigger_slope(TriggerSlope.RISING)
-    scope.set_trigger_level(0)  # 2.5 Volts
+    scope.set_trigger_level(0)  # 0 V
     scope.set_trigger_mode(TriggerMode.NORMAL)
 
     # --- Register background measurements ---
@@ -70,6 +71,3 @@ try:
             break
 
     print("Done")
-
-finally:
-    scope.close()

--- a/examples/scope/scope_basic.py
+++ b/examples/scope/scope_basic.py
@@ -5,10 +5,8 @@ settings, capturing a waveform, and taking built-in measurements.
 
 """
 
-import time
-
 from instro.lib.publishers import NominalCorePublisher
-from instro.lib.transports.visa import VisaConfig
+from instro.lib.transports import VisaConfig
 from instro.scope import (
     AcquisitionMode,
     Coupling,
@@ -30,37 +28,34 @@ scope = InstroScope(
     publishers=[NominalCorePublisher(dataset_rid=DATASET_RID)],
 )
 
-try:
-    scope.open()
-
-    # # --- Configure channel 1 ---
+with scope:
+    # --- Configure channel 1 ---
     scope.set_coupling(Coupling.DC, channel=1)
     scope.set_probe_attenuation(1.0, channel=1)
     scope.set_vertical_scale(1, channel=1)  # 1 V/div
     scope.set_vertical_offset(0, channel=1)
 
-    # # --- Configure timebase ---
-    scope.set_horizontal_scale(0.01)  # 100 ms/div
+    # --- Configure timebase ---
+    scope.set_horizontal_scale(0.01)  # 10 ms/div
 
-    # # --- Configure acquisition ---
+    # --- Configure acquisition ---
     scope.set_acquisition_mode(AcquisitionMode.NORMAL)
 
-    # # # --- Configure trigger ---
+    # --- Configure trigger ---
     scope.set_trigger_source(channel=1)
-
     scope.set_trigger_type(TriggerType.EDGE)
     scope.set_trigger_slope(TriggerSlope.RISING)
-    scope.set_trigger_level(0)  # 2.5 Volts
+    scope.set_trigger_level(0)  # 0 V
     scope.set_trigger_mode(TriggerMode.NORMAL)
 
-    # # # --- Acquire and fetch ---
+    # --- Acquire and fetch ---
+    # single() arms the acquisition; fetch_waveform() then blocks until the
+    # trigger fires and the capture completes (up to its timeout).
     scope.single()
-    time.sleep(2)  # Wait for trigger and acquisition
-
     waveform = scope.fetch_waveform(channel=1)
     print(f"Waveform captured: {len(waveform.channel_data)} channel(s)")
 
-    # # # --- Built-in measurements ---
+    # --- Built-in measurements ---
     vpp = scope.measure(ScopeMeasurementType.VPP, channel=1)
     vrms = scope.measure(ScopeMeasurementType.VRMS, channel=1, timeout=10)
     vmax = scope.measure(ScopeMeasurementType.VMAX, channel=1)
@@ -70,16 +65,13 @@ try:
     print(f"Vpp:  {vpp}")
     print(f"Vrms: {vrms}")
     print(f"Vmax: {vmax}")
-    print(f"Vpp:  {vmin}")
-    print(f"Vrms: {freq}")
-    print(f"Vmax: {per}")
+    print(f"Vmin: {vmin}")
+    print(f"Frequency: {freq}")
+    print(f"Period: {per}")
 
-    # # --- Read back settings ---
+    # --- Read back settings ---
     sample_rate = scope.get_sample_rate()
     print(f"Sample rate: {sample_rate}")
 
-    # # # --- Save a screenshot ---
+    # --- Save a screenshot ---
     scope.save_screenshot("capture.png")
-
-finally:
-    scope.close()

--- a/examples/test_rack_example/test_rack.py
+++ b/examples/test_rack_example/test_rack.py
@@ -10,7 +10,7 @@ from instro.daq import InstroDAQ
 from instro.daq.drivers import Keysight34980A
 from instro.daq.types import Direction
 from instro.eload import InstroELoad
-from instro.eload.drivers.bk_85xxb import BK85XXB
+from instro.eload.drivers import BK85XXB
 from instro.eload.types import LoadMode
 from instro.lib.transports import SerialConfig, VisaConfig
 from instro.psu import InstroPSU


### PR DESCRIPTION
Closes #186.

Verified every script under `examples/` runs correctly as written (all imports resolve against the current source, and every file passes `ruff check` and byte-compiles). Along the way, fixed one output defect and a set of consistency/clarity issues.

## Defect
- `scope/scope_basic.py`: the final measurement print block was scrambled — `vmin`/`freq`/`per` printed under `Vpp`/`Vrms`/`Vmax` labels, and `set_trigger_level(0)` carried a misleading `# 2.5 Volts` comment.

## Reliability / consistency
- `scope_basic.py` & `scope_background.py` used `try/finally` + `open()`; converted to the `with` context manager every other example uses.
- `daq_relays.py` imported `Direction, Logic` but used neither.
- `eload.py` called `output_enable(enable=False)` twice at the end.
- `modbus/minimal_example.py` docstring referenced a non-existent module path (`python -m instro.modbus.examples.minimal_example`).

## Cleanup
- Removed redundant `f""` prefixes on constant strings across several DAQ examples (not caught by CI — ruff enables only isort + pydocstyle, no pyflakes).
- Fixed `print(f"Values: ", ...)` in `daq_read_digital_line.py`.

## Import standardization
- `BK85XXB` now imported from the `instro.eload.drivers` package (matching every other core driver) instead of the deep `instro.eload.drivers.bk_85xxb` path.
- Public cross-category symbols (`Command`, `Measurement`, `DeviceInfo`, `install_nominal_core_log_handler`) now imported from the curated `instro.lib` top-level API.

Left as-is: VISA/serial configs (already uniform under `instro.lib.transports`), DAQ vendor subpackages and i2c `Aardvark` (workspace vendor packages, not re-exported, so deep paths are required), and category-specific types sourced from their owning packages.
