### PR TITLE
chore(contrib): add scope category scaffold and category __init__ docstrings

### DIFF
--- a/packages/instro-contrib/instro/contrib/daq/__init__.py
+++ b/packages/instro-contrib/instro/contrib/daq/__init__.py
@@ -1,0 +1,1 @@
+"""Community-contributed data acquisition (DAQ) drivers."""

--- a/packages/instro-contrib/instro/contrib/dmm/__init__.py
+++ b/packages/instro-contrib/instro/contrib/dmm/__init__.py
@@ -1,0 +1,1 @@
+"""Community-contributed digital multimeter (DMM) drivers."""

--- a/packages/instro-contrib/instro/contrib/eload/__init__.py
+++ b/packages/instro-contrib/instro/contrib/eload/__init__.py
@@ -1,0 +1,1 @@
+"""Community-contributed electronic load (E-Load) drivers."""

--- a/packages/instro-contrib/instro/contrib/i2c/__init__.py
+++ b/packages/instro-contrib/instro/contrib/i2c/__init__.py
@@ -1,0 +1,1 @@
+"""Community-contributed I2C drivers."""

--- a/packages/instro-contrib/instro/contrib/psu/__init__.py
+++ b/packages/instro-contrib/instro/contrib/psu/__init__.py
@@ -1,0 +1,1 @@
+"""Community-contributed power supply (PSU) drivers."""

--- a/packages/instro-contrib/instro/contrib/scope/__init__.py
+++ b/packages/instro-contrib/instro/contrib/scope/__init__.py
@@ -1,0 +1,1 @@
+"""Community-contributed oscilloscope (scope) drivers."""

--- a/packages/instro-contrib/instro/contrib/scope/drivers/__init__.py
+++ b/packages/instro-contrib/instro/contrib/scope/drivers/__init__.py
@@ -1,0 +1,3 @@
+"""Community-contributed scope drivers."""
+
+__all__: list[str] = []


### PR DESCRIPTION
## Summary

Pre-seed an empty `contrib/scope/` scaffold so a scope-driver contributor has the same ready landing spot the other contrib categories already provide, and give the previously-empty category `__init__` files a one-line docstring for consistency with core.

Core has 6 driver categories (`daq, dmm, eload, i2c, psu, scope`); contrib was missing the `scope` scaffold:

```
core:    daq  dmm  eload  i2c  psu  scope
contrib: daq  dmm  eload  i2c  psu       ← scope missing
```

## Changes

* Add `packages/instro-contrib/instro/contrib/scope/__init__.py` and `.../scope/drivers/__init__.py`, mirroring the `dmm`/`eload` scaffold (empty `__all__`, no `pkgutil.extend_path` — scope has no vendor package).
* Add one-line module docstrings to the empty `daq/dmm/eload/i2c/psu` category `__init__.py` files.

## Testing

* `just check` — ruff format, mypy (67 files clean), ruff lint all pass.
* `pytest tests/contrib` — 27/27 pass; the contrib smoke test auto-discovered and imported the new `scope` module.

No behavior change; no new driver.

Closes nominal-io/instro#189