### PR TITLE
fix(visa): quiet pyvisa-py fallback on the healthy path

### DIFF
--- a/instro/lib/transports/visa.py
+++ b/instro/lib/transports/visa.py
@@ -9,6 +9,7 @@ import logging
 import socket
 import threading
 import typing
+import warnings
 
 import pyvisa
 from pyvisa.constants import InterfaceType
@@ -151,7 +152,7 @@ class VisaDriver:
             # pyvisa caches one ResourceManager per backend and shares it across every
             # driver in the process; closing it would kill all other drivers' sessions.
             # pyvisa closes it via its own atexit handler.
-            rm = _open_resource_manager(cfg.visa_backend)
+            rm, used_py_fallback = _open_resource_manager(cfg.visa_backend)
             inst: pyvisa.resources.MessageBasedResource | None = None
             try:
                 inst = typing.cast(
@@ -163,6 +164,13 @@ class VisaDriver:
                 if inst is not None:
                     with contextlib.suppress(Exception):
                         inst.close()
+                if used_py_fallback:
+                    logger.warning(
+                        "Failed to open %s on the pyvisa-py (@py) fallback backend (no IVI VISA "
+                        "found). If this instrument needs a vendor VISA library, install NI-VISA "
+                        "or set visa_backend explicitly.",
+                        cfg.visa_resource,
+                    )
                 raise
 
             self._inst = inst
@@ -281,20 +289,24 @@ class VisaDriver:
         return self._inst
 
 
-def _open_resource_manager(backend: str | None) -> pyvisa.ResourceManager:
-    """Open a ResourceManager. An unset backend uses ``@ivi`` and falls back to ``@py``; an explicit backend is used as-is."""
+def _open_resource_manager(backend: str | None) -> tuple[pyvisa.ResourceManager, bool]:
+    """Open a ResourceManager, returning (rm, used_py_fallback). Unset backend uses ``@ivi`` and falls back to ``@py``; an explicit backend is used as-is."""
     if backend is not None:
-        return pyvisa.ResourceManager(backend)
+        return pyvisa.ResourceManager(backend), False
     try:
-        return pyvisa.ResourceManager(DEFAULT_VISA_BACKEND)
+        return pyvisa.ResourceManager(DEFAULT_VISA_BACKEND), False
     except (OSError, pyvisa.errors.Error) as exc:
-        logger.warning(
+        logger.debug(
             "VISA backend %s unavailable (%s); falling back to %s",
             DEFAULT_VISA_BACKEND,
             exc,
             FALLBACK_VISA_BACKEND,
         )
-        return pyvisa.ResourceManager(FALLBACK_VISA_BACKEND)
+        # pyvisa-py warns at construction about optional backends it can't load (e.g. GPIB);
+        # irrelevant unless the resource being opened needs one, so muffle it here.
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            return pyvisa.ResourceManager(FALLBACK_VISA_BACKEND), True
 
 
 def _configure_resource(

--- a/instro/lib/transports/visa.py
+++ b/instro/lib/transports/visa.py
@@ -12,7 +12,7 @@ import typing
 import warnings
 
 import pyvisa
-from pyvisa.constants import InterfaceType
+from pyvisa.constants import VI_ERROR_LIBRARY_NFOUND, InterfaceType
 from pyvisa.constants import Parity as VisaParity
 
 logger = logging.getLogger(__name__)
@@ -160,15 +160,14 @@ class VisaDriver:
                     rm.open_resource(cfg.visa_resource),
                 )
                 _configure_resource(inst, cfg)
-            except Exception:
+            except Exception as exc:
                 if inst is not None:
                     with contextlib.suppress(Exception):
                         inst.close()
-                if used_py_fallback:
+                if used_py_fallback and _is_missing_backend_error(exc):
                     logger.warning(
-                        "Failed to open %s on the pyvisa-py (@py) fallback backend (no IVI VISA "
-                        "found). If this instrument needs a vendor VISA library, install NI-VISA "
-                        "or set visa_backend explicitly.",
+                        "The pyvisa-py (@py) fallback backend (no IVI VISA found) cannot serve "
+                        "%s. Install NI-VISA or set visa_backend explicitly.",
                         cfg.visa_resource,
                     )
                 raise
@@ -302,11 +301,22 @@ def _open_resource_manager(backend: str | None) -> tuple[pyvisa.ResourceManager,
             exc,
             FALLBACK_VISA_BACKEND,
         )
-        # pyvisa-py warns at construction about optional backends it can't load (e.g. GPIB);
-        # irrelevant unless the resource being opened needs one, so muffle it here.
+        # gpib_ctypes warns at @py construction when the GPIB C library is missing;
+        # irrelevant unless the resource being opened is GPIB, which fails at
+        # open_resource with its own actionable error.
         with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
+            warnings.filterwarnings("ignore", message=".*GPIB.*")
             return pyvisa.ResourceManager(FALLBACK_VISA_BACKEND), True
+
+
+def _is_missing_backend_error(exc: BaseException) -> bool:
+    """True when an open failure means the backend can't serve the resource class, not that the device is unreachable."""
+    if isinstance(exc, pyvisa.errors.VisaIOError):
+        return exc.error_code == VI_ERROR_LIBRARY_NFOUND
+    # pyvisa-py signals "no session class for this resource" (unsupported class, or its
+    # optional library is missing, e.g. GPIB) as ValueError; ordinary connection
+    # failures surface as VisaIOError/OSError/plain Exception.
+    return isinstance(exc, ValueError)
 
 
 def _configure_resource(

--- a/instro/lib/transports/visa.py
+++ b/instro/lib/transports/visa.py
@@ -316,7 +316,7 @@ def _is_missing_backend_error(exc: BaseException) -> bool:
     # pyvisa-py signals "no session class for this resource" (unsupported class, or its
     # optional library is missing, e.g. GPIB) as ValueError; ordinary connection
     # failures surface as VisaIOError/OSError/plain Exception.
-    return isinstance(exc, ValueError)
+    return isinstance(exc, ValueError) and "No class registered" in str(exc)
 
 
 def _configure_resource(

--- a/tests/lib/test_visa_driver.py
+++ b/tests/lib/test_visa_driver.py
@@ -7,6 +7,7 @@ import logging
 import socket
 import threading
 import time
+import warnings
 from types import SimpleNamespace
 from unittest.mock import MagicMock, call, patch
 
@@ -164,7 +165,7 @@ def test_open_falls_back_to_py_when_ivi_library_not_found(mock_pyvisa):
     assert driver.is_open is True
 
 
-def test_open_warns_when_resource_fails_on_py_fallback(mock_pyvisa, caplog):
+def test_open_warns_when_py_fallback_lacks_library_for_resource(mock_pyvisa, caplog):
     rm_class, rm_instance, _ = mock_pyvisa
     rm_class.side_effect = [OSError("no IVI backend"), rm_instance]
     err = pyvisa.errors.VisaIOError(VI_ERROR_LIBRARY_NFOUND)
@@ -177,6 +178,57 @@ def test_open_warns_when_resource_fails_on_py_fallback(mock_pyvisa, caplog):
 
     assert "pyvisa-py (@py) fallback" in caplog.text
     assert driver.is_open is False
+
+
+def test_open_warns_when_py_fallback_has_no_session_class_for_resource(mock_pyvisa, caplog):
+    rm_class, rm_instance, _ = mock_pyvisa
+    rm_class.side_effect = [OSError("no IVI backend"), rm_instance]
+    # pyvisa-py raises ValueError for a resource class it can't serve (e.g. GPIB
+    # without the C library: "gpib_ctypes is installed but could not locate ...").
+    rm_instance.open_resource.side_effect = ValueError("No class registered for gpib, INSTR")
+    driver = _make_driver()
+
+    with caplog.at_level(logging.WARNING, logger="instro.lib.transports.visa"):
+        with pytest.raises(ValueError, match="No class registered"):
+            driver.open()
+
+    assert "pyvisa-py (@py) fallback" in caplog.text
+    assert driver.is_open is False
+
+
+def test_open_does_not_warn_for_ordinary_failure_on_py_fallback(mock_pyvisa, caplog):
+    rm_class, rm_instance, _ = mock_pyvisa
+    rm_class.side_effect = [OSError("no IVI backend"), rm_instance]
+    # Device off / wrong IP on @py surfaces as a plain Exception, not a backend gap.
+    rm_instance.open_resource.side_effect = Exception("could not connect: -1073807339")
+    driver = _make_driver()
+
+    with caplog.at_level(logging.WARNING, logger="instro.lib.transports.visa"):
+        with pytest.raises(Exception, match="could not connect"):
+            driver.open()
+
+    assert caplog.records == []
+    assert driver.is_open is False
+
+
+def test_py_fallback_muffles_gpib_warning_but_not_others(mock_pyvisa):
+    rm_class, rm_instance, _ = mock_pyvisa
+
+    def construct(backend: str) -> MagicMock:
+        if backend == "@ivi":
+            raise OSError("no IVI backend")
+        warnings.warn("GPIB library not found. Please manually load it using _load_lib(filename).")
+        warnings.warn("unrelated pyvisa-py warning")
+        return rm_instance
+
+    rm_class.side_effect = construct
+    driver = _make_driver()
+
+    with pytest.warns(UserWarning, match="unrelated pyvisa-py warning") as caught:
+        driver.open()
+
+    assert driver.is_open is True
+    assert not any("GPIB" in str(w.message) for w in caught)
 
 
 def test_open_does_not_warn_when_explicit_backend_fails(mock_pyvisa, caplog):

--- a/tests/lib/test_visa_driver.py
+++ b/tests/lib/test_visa_driver.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import logging
 import socket
 import threading
 import time
@@ -138,15 +139,17 @@ def test_open_uses_ivi_backend_by_default(mock_pyvisa):
     rm_class.assert_called_once_with("@ivi")
 
 
-def test_open_falls_back_to_py_when_ivi_backend_missing(mock_pyvisa):
+def test_open_falls_back_to_py_when_ivi_backend_missing(mock_pyvisa, caplog):
     rm_class, rm_instance, _ = mock_pyvisa
     rm_class.side_effect = [OSError("Could not locate a VISA implementation"), rm_instance]
     driver = _make_driver()
 
-    driver.open()
+    with caplog.at_level(logging.WARNING, logger="instro.lib.transports.visa"):
+        driver.open()
 
     assert rm_class.call_args_list == [call("@ivi"), call("@py")]
     assert driver.is_open is True
+    assert caplog.records == []  # a successful fallback is a healthy path: no warning
 
 
 def test_open_falls_back_to_py_when_ivi_library_not_found(mock_pyvisa):
@@ -159,6 +162,33 @@ def test_open_falls_back_to_py_when_ivi_library_not_found(mock_pyvisa):
 
     assert rm_class.call_args_list == [call("@ivi"), call("@py")]
     assert driver.is_open is True
+
+
+def test_open_warns_when_resource_fails_on_py_fallback(mock_pyvisa, caplog):
+    rm_class, rm_instance, _ = mock_pyvisa
+    rm_class.side_effect = [OSError("no IVI backend"), rm_instance]
+    err = pyvisa.errors.VisaIOError(VI_ERROR_LIBRARY_NFOUND)
+    rm_instance.open_resource.side_effect = err
+    driver = _make_driver()
+
+    with caplog.at_level(logging.WARNING, logger="instro.lib.transports.visa"):
+        with pytest.raises(pyvisa.errors.VisaIOError):  # original type preserved, not wrapped
+            driver.open()
+
+    assert "pyvisa-py (@py) fallback" in caplog.text
+    assert driver.is_open is False
+
+
+def test_open_does_not_warn_when_explicit_backend_fails(mock_pyvisa, caplog):
+    _, rm_instance, _ = mock_pyvisa
+    rm_instance.open_resource.side_effect = RuntimeError("device offline")
+    driver = _make_driver(_make_config(visa_backend="@py"))
+
+    with caplog.at_level(logging.WARNING, logger="instro.lib.transports.visa"):
+        with pytest.raises(RuntimeError, match="device offline"):
+            driver.open()
+
+    assert caplog.records == []  # explicit backend, no fallback: no fallback hint
 
 
 @pytest.mark.parametrize("backend", ["@ivi", "@py", "@sim"])


### PR DESCRIPTION
Closes nominal-io/instro#191

## Problem

When no IVI VISA is installed, `VisaDriver` falls back to the pyvisa-py (`@py`) backend — a healthy path, since the repo ships every `@py` dependency. But it produced noise on **every** `open()`:

1. Our own `logger.warning("... falling back to @py")`. pyvisa doesn't cache a failed `@ivi` load, so this fired on every `open()`, for every instrument.
2. gpib_ctypes' `warnings.warn("GPIB library not found. ...")` at `@py` construction — irrelevant unless the resource needs GPIB.

Neither indicates a problem with the connection actually being made (typically a TCPIP SOCKET, which `@py` serves fine).

## Change

* Downgrade the fallback log `warning` -> `debug`.
* Muffle only the GPIB construction-time warning (`filterwarnings(message=".*GPIB.*")`) around the `@py` `ResourceManager(...)` construction; other warnings still propagate.
* When a resource fails to open *while on the* `@py` *fallback*, log one actionable warning (install NI-VISA / set `visa_backend`) — but only when the failure means `@py` can't serve that resource class, not for ordinary failures (device off, wrong IP). Empirically (pyvisa-py 0.8.1), a capability gap surfaces as `ValueError` ("No class registered for ..." / "gpib_ctypes is installed but could not locate the gpib library"), while connection failures surface as plain `Exception`/`VisaIOError`; we gate on `ValueError` plus `VisaIOError(VI_ERROR_LIBRARY_NFOUND)` for robustness. The exception is re-raised **bare** so the original type is preserved (`discover.py` catches `VisaIOError` specifically).

Net effect: silence on the healthy no-IVI path and on ordinary connection failures; one clear line only when a resource genuinely can't be served by `@py`.

## Tests

`tests/lib/test_visa_driver.py`:

* No warning on a successful fallback.
* Warning logged **and** original exception type propagates when `@py` lacks the library (`VI_ERROR_LIBRARY_NFOUND`) or session class (`ValueError`) for the resource.
* No warning for an ordinary connection failure on the fallback.
* No hint when an explicit backend fails (no fallback occurred).
* GPIB construction warning muffled; unrelated warnings still propagate.

Verified end-to-end against the real pyvisa-py stack (IVI load intercepted to force the fallback): GPIB/VXI opens warn once and raise the original error; a wrong-IP TCPIP open is silent.

`just check` and the full unit suite (1015 passed) are green.