### PR TITLE
chore: remove py-lab-hal references

### DIFF
--- a/instro/lib/instrument.py
+++ b/instro/lib/instrument.py
@@ -1,6 +1,3 @@
-# This code is derived from concepts in the py-lab-hal codebase (Apache 2.0 licensed)
-# Original py-lab-hal repository: https://github.com/google/py-lab-hal
-
 """Base instrument interface and background daemon support."""
 
 import functools

--- a/instro/lib/nominal.py
+++ b/instro/lib/nominal.py
@@ -1,6 +1,3 @@
-# This code is derived from concepts in the py-lab-hal codebase (Apache 2.0 licensed)
-# Original py-lab-hal repository: https://github.com/google/py-lab-hal
-
 """Nominal Core integration helpers: client/dataset resolution and Measurement shaping."""
 
 from __future__ import annotations

--- a/instro/lib/publishers/publisher.py
+++ b/instro/lib/publishers/publisher.py
@@ -1,6 +1,3 @@
-# This code is derived from concepts in the py-lab-hal codebase (Apache 2.0 licensed)
-# Original py-lab-hal repository: https://github.com/google/py-lab-hal
-
 """Publisher protocol and buffering wrappers."""
 
 import abc

--- a/instro/lib/types.py
+++ b/instro/lib/types.py
@@ -1,6 +1,3 @@
-# This code is derived from concepts in the py-lab-hal codebase (Apache 2.0 licensed)
-# Original py-lab-hal repository: https://github.com/google/py-lab-hal
-
 """Shared types: runtime dataclasses (Measurement/Command) and cross-protocol Pydantic configs."""
 
 from __future__ import annotations


### PR DESCRIPTION
Closes nominal-io/instro#194

We no longer depend on anything from `py-lab-hal`. This removes the derived-from attribution header comments from the four files under `instro/lib/`:

* `instro/lib/types.py`
* `instro/lib/instrument.py`
* `instro/lib/nominal.py`
* `instro/lib/publishers/publisher.py`

A repo-wide grep confirms no remaining references.

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)