### PR TITLE
chore: cut 1.0.0 for all packages via release-as

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -1,6 +1,6 @@
 {
   "include-component-in-tag": true,
-  "bump-minor-pre-major": true,
+  "release-as": "1.0.0",
   "changelog-sections": [
     {
       "type": "feat",


### PR DESCRIPTION
Tracking issue: #196 (leave open — it tracks the required follow-up below)

## What

- Add a top-level `"release-as": "1.0.0"` to `.github/release-please-config.json`. On merge, release-please regenerates its release PR to propose **1.0.0 for all eight workspace packages** (`instro`, `instro-daq-labjack`, `instro-daq-mcc`, `instro-daq-ni`, `instro-i2c-aardvark`, `instro-unstable`, `instro-ethernetip`, `instro-contrib`).
- Remove `"bump-minor-pre-major": true`. This setting downgraded breaking changes to minor bumps while packages were pre-1.0, which is what kept us locked to minor revisions. From 1.0.0 on, standard semver applies: `feat!`/`BREAKING CHANGE` → major, `feat` → minor, `fix` → patch.

## Release flow after this merges

1. release-please updates its open release PR to 1.0.0 for every package.
2. Merging that release PR tags all packages at 1.0.0 and triggers the PyPI publish jobs in `release-please-publish.yml` (no changes needed there).
3. **Required follow-up:** remove `"release-as": "1.0.0"` from the config in a small PR, then close #196. Per the [release-please manifest docs](https://github.com/googleapis/release-please/blob/main/docs/manifest-releaser.md), it is not removed automatically — leaving it would pin every subsequent release to 1.0.0.