### PR TITLE
chore: remove release-as now that 1.0.0 is released

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -1,6 +1,5 @@
 {
   "include-component-in-tag": true,
-  "release-as": "1.0.0",
   "changelog-sections": [
     {
       "type": "feat",


### PR DESCRIPTION
Closes #196

Final step of the 1.0.0 release flow (#197 → #198 → #199). All eight packages are tagged at 1.0.0, so the pinned `"release-as": "1.0.0"` has done its job — per the release-please manifest docs it isn't removed automatically, and leaving it would pin every future release to 1.0.0.

With this removed (and `bump-minor-pre-major` already gone via #197), release-please computes versions from Conventional Commits with standard semver: `feat!`/`BREAKING CHANGE` → major, `feat` → minor, `fix` → patch.