### PR TITLE
docs(contrib): document one-release ImportError stub for graduations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -285,9 +285,11 @@ When the maintainers acquire the device and can verify the driver directly:
 
 1. `git mv` the file from `packages/instro-contrib/instro/contrib/<cat>/drivers/<driver>.py` to `instro/<cat>/drivers/<driver>.py`.
 2. Move the entry from `packages/instro-contrib/instro/contrib/<cat>/drivers/__init__.py` to the corresponding `instro/<cat>/drivers/__init__.py`.
-3. Note the graduation in `CHANGELOG.md`.
+3. Leave a stub module at the old path that raises an `ImportError` naming the destination and the graduating release (e.g. `SomeVendorPSU graduated to core in v1.2. Import it from instro.psu.drivers.`). Exclude the stub from the contrib smoke test if needed.
+4. Open a follow-up issue to delete the stub in the next release.
+5. Note the graduation in `CHANGELOG.md`.
 
-The old import path is a hard cutover: consumers pinning `instro-contrib` for that driver should switch to `instro` and update the import to drop `.contrib`.
+The old import path is a hard cutover: consumers pinning `instro-contrib` for that driver should switch to `instro` and update the import to drop `.contrib`. The stub is not a compatibility shim. Old code stays broken; the error just points to the new import path for one release.
 
 ### `instro-unstable`: in-development categories and abstractions
 

--- a/docs/guides/instrumentation/contrib.mdx
+++ b/docs/guides/instrumentation/contrib.mdx
@@ -74,7 +74,16 @@ from instro.contrib.psu.drivers import SomeVendorPSU
 from instro.psu.drivers import SomeVendorPSU
 ```
 
-Graduations are noted in `CHANGELOG.md`. The old `instro.contrib` import path is a hard cutover. There is no compatibility shim.
+Graduations are noted in `CHANGELOG.md`. The old `instro.contrib` import path is a hard cutover. There is no compatibility shim: old code stays broken until the import is updated.
+
+For one release after the graduation, a stub at the old path raises an `ImportError` that names the destination:
+
+```python
+from instro.contrib.psu.drivers import SomeVendorPSU
+# ImportError: SomeVendorPSU graduated to core in v1.2. Import it from instro.psu.drivers.
+```
+
+The stub is deleted in the following release, after which the old import fails with a plain `ImportError`.
 
 ## Contributing a driver
 


### PR DESCRIPTION
Closes nominal-io/instro#221.

Documents the convention that graduating a contrib driver to core leaves a one-release stub at the old `instro.contrib` import path that raises a helpful `ImportError` naming the new location. The hard-cutover policy stands: the stub is not a compatibility shim, old code stays broken, and the stub is deleted one release later.

Per the issue, this is docs-only. No graduation has happened yet; the actual stub ships in whichever PR performs the first graduation.

* `docs/guides/instrumentation/contrib.mdx`: expanded the "Graduation to core" section with the stub behavior and an example error message.
* `CONTRIBUTING.md`: added stub creation (with a note about excluding it from the contrib smoke test, which imports every `instro.contrib` module) and a follow-up deletion issue to the graduation steps.