### PR TITLE
feat(cli): report backend and interface coverage in discover

### DIFF
--- a/docs/guides/instrumentation/cli.mdx
+++ b/docs/guides/instrumentation/cli.mdx
@@ -24,8 +24,8 @@ instro discover
 To force a specific VISA backend, pass `--backend`:
 
 ```bash
-uv run instro discover --backend @py
-uv run instro discover --backend @ivi
+uv run instro discover --backend=@py
+uv run instro discover --backend "@ivi"
 ```
 
 <Note>

--- a/docs/guides/instrumentation/cli.mdx
+++ b/docs/guides/instrumentation/cli.mdx
@@ -34,6 +34,8 @@ The `@ivi` backend finds an available IVI-compliant backend on your system e.g. 
 
 ### Output
 
+Before scanning, the command prints which VISA backend is active (`@ivi`, or `@py` when no IVI VISA is installed). On the `@py` backend it also lists any interfaces the scan cannot cover — for example `GPIB: unavailable — gpib_ctypes is installed but could not locate the gpib library (install NI-488.2 or linux-gpib)` — so you know when an empty result reflects a missing library rather than an empty bench. These notes are informational; the scan still runs and the command exits 0.
+
 The command groups results into up to three tables.
 
 **Recognized devices** — instruments with a known driver. The table shows the VISA resource address, instrument category, and the `instro` driver class to use.
@@ -42,7 +44,7 @@ The command groups results into up to three tables.
 
 **Unrecognized devices** — instruments that responded to `*IDN?` but did not match any known driver. The raw IDN response is shown so you can identify the device.
 
-If no devices are found at all, the command prints a single error panel.
+If no devices are found at all, the command prints a single error panel; on the `@py` backend the panel repeats any unavailable interfaces.
 
 ### Using a recognized device
 

--- a/instro/cli/discover.py
+++ b/instro/cli/discover.py
@@ -95,7 +95,7 @@ def discover(backend: str | None = None) -> None:
     console.print()
 
     serial_devices = [
-        ((p.device, p.manufacturer, p.product), "serial - configure manually")
+        ((p.device, p.manufacturer, p.product or "unknown"), "serial - configure manually")
         for p in list_ports.comports()
         if p.description != "n/a"
     ]

--- a/instro/cli/discover.py
+++ b/instro/cli/discover.py
@@ -6,7 +6,7 @@ from rich.panel import Panel
 from rich.table import Table
 from serial.tools import list_ports
 
-from instro.lib.transports.visa import TimeoutConfig, VisaConfig, VisaDriver
+from instro.lib.transports.visa import TimeoutConfig, VisaConfig, VisaDriver, _open_resource_manager
 
 MARK = "⟢"
 GREEN = "#4ADE80"
@@ -15,6 +15,15 @@ FOREGROUND = "#FFFFFF"
 FOREGROUND_MUTED = "#A3A3A3"
 FOREGROUND_ERROR = "#B91C1C"
 BORDER = "#333333"
+
+
+_INTERFACE_HINTS = {
+    "GPIB": "install NI-488.2 or linux-gpib",
+    "USB": "install libusb",
+    "ASRL": "install pyserial",
+}
+
+_INTERFACE_SUFFIXES = (" INSTR", " INTFC", " SOCKET", " RAW")
 
 
 _IDN_MAP = {
@@ -32,30 +41,64 @@ _IDN_MAP = {
 }
 
 
+def _degraded_interfaces(rm: pyvisa.ResourceManager) -> list[tuple[str, str]]:
+    """Return (interface family, reason) for pyvisa-py interfaces that are not Available."""
+    get_debug_info = getattr(rm.visalib, "get_debug_info", None)
+    if get_debug_info is None:
+        return []
+    degraded: dict[str, str] = {}
+    for key, value in get_debug_info().items():
+        if not key.endswith(_INTERFACE_SUFFIXES):
+            continue
+        lines = value if isinstance(value, list) else str(value).splitlines()
+        reason = lines[0].strip() if lines else ""
+        if reason.startswith("Available"):
+            continue
+        degraded.setdefault(key.split(" ", 1)[0], reason.rstrip("."))
+    return sorted(degraded.items())
+
+
+def _degraded_line(family: str, reason: str) -> str:
+    hint = _INTERFACE_HINTS.get(family)
+    suffix = f" ({hint})" if hint else ""
+    return f"{family}: unavailable — {reason}{suffix}"
+
+
+def _backend_label(active_backend: str, used_py_fallback: bool) -> str:
+    if active_backend == "@ivi":
+        return "@ivi (system IVI VISA)"
+    if active_backend == "@py":
+        return "@py (pyvisa-py — no IVI VISA found)" if used_py_fallback else "@py (pyvisa-py)"
+    return active_backend
+
+
+def _no_devices_panel(degraded: list[tuple[str, str]]) -> Panel:
+    body = f"   [bold {FOREGROUND_ERROR}]NO DEVICES FOUND[/]"
+    for family, reason in degraded:
+        body += f"\n   [dim]{_degraded_line(family, reason)}[/]"
+    return Panel(body, border_style=FOREGROUND_ERROR)
+
+
 def discover(backend: str | None = None) -> None:
     """Scan for SCPI devices and print a discovery table."""
     console = Console()
     width = console.width
     console.print(Panel(f"[bold {FOREGROUND}]{MARK} INSTRO — DISCOVER[/]", border_style=BORDER))
-    console.print("\nScanning VISA resources ... \n", style="dim")
-    active_backend: str
+
+    rm, active_backend, used_py_fallback = _open_resource_manager(backend)
+    degraded = _degraded_interfaces(rm) if active_backend == "@py" else []
+
+    console.print("\nScanning VISA resources ... ", style="dim")
+    console.print(f"   backend: {_backend_label(active_backend, used_py_fallback)}", style="dim")
+    for family, reason in degraded:
+        console.print(f"   {_degraded_line(family, reason)}", style="dim")
+    console.print()
 
     serial_devices = [
         ((p.device, p.manufacturer, p.product), "serial - configure manually")
         for p in list_ports.comports()
         if p.description != "n/a"
     ]
-
-    if backend is not None:
-        rm = pyvisa.ResourceManager(backend)
-        active_backend = backend
-    else:
-        try:
-            rm = pyvisa.ResourceManager("@ivi")
-            active_backend = "@ivi"
-        except Exception:
-            rm = pyvisa.ResourceManager("@py")
-            active_backend = "@py"
 
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
@@ -65,7 +108,7 @@ def discover(backend: str | None = None) -> None:
     unsupported_devices: list[tuple[str, str]] = []
 
     if not resources and not serial_devices:
-        console.print(Panel(f"   [bold {FOREGROUND_ERROR}]NO DEVICES FOUND[/]", border_style=FOREGROUND_ERROR))
+        console.print(_no_devices_panel(degraded))
         return
 
     for resource in resources:
@@ -109,7 +152,7 @@ def discover(backend: str | None = None) -> None:
             driver.close()
 
     if not supported_devices and not unsupported_devices and not serial_devices:
-        console.print(Panel(f"   [bold {FOREGROUND_ERROR}]NO DEVICES FOUND[/]", border_style=FOREGROUND_ERROR))
+        console.print(_no_devices_panel(degraded))
     else:
         if supported_devices:
             table = Table(

--- a/instro/lib/transports/visa.py
+++ b/instro/lib/transports/visa.py
@@ -152,7 +152,7 @@ class VisaDriver:
             # pyvisa caches one ResourceManager per backend and shares it across every
             # driver in the process; closing it would kill all other drivers' sessions.
             # pyvisa closes it via its own atexit handler.
-            rm, used_py_fallback = _open_resource_manager(cfg.visa_backend)
+            rm, _, used_py_fallback = _open_resource_manager(cfg.visa_backend)
             inst: pyvisa.resources.MessageBasedResource | None = None
             try:
                 inst = typing.cast(
@@ -288,25 +288,25 @@ class VisaDriver:
         return self._inst
 
 
-def _open_resource_manager(backend: str | None) -> tuple[pyvisa.ResourceManager, bool]:
-    """Open a ResourceManager, returning (rm, used_py_fallback). Unset backend uses ``@ivi`` and falls back to ``@py``; an explicit backend is used as-is."""
-    if backend is not None:
-        return pyvisa.ResourceManager(backend), False
-    try:
-        return pyvisa.ResourceManager(DEFAULT_VISA_BACKEND), False
-    except (OSError, pyvisa.errors.Error) as exc:
-        logger.debug(
-            "VISA backend %s unavailable (%s); falling back to %s",
-            DEFAULT_VISA_BACKEND,
-            exc,
-            FALLBACK_VISA_BACKEND,
-        )
-        # gpib_ctypes warns at @py construction when the GPIB C library is missing;
-        # irrelevant unless the resource being opened is GPIB, which fails at
-        # open_resource with its own actionable error.
-        with warnings.catch_warnings():
-            warnings.filterwarnings("ignore", message=".*GPIB.*")
-            return pyvisa.ResourceManager(FALLBACK_VISA_BACKEND), True
+def _open_resource_manager(backend: str | None) -> tuple[pyvisa.ResourceManager, str, bool]:
+    """Open a ResourceManager, returning (rm, active_backend, used_py_fallback). Unset backend uses ``@ivi`` and falls back to ``@py``; an explicit backend is used as-is."""
+    # gpib_ctypes warns at @py construction when the GPIB C library is missing;
+    # irrelevant unless the resource being opened is GPIB, which fails at
+    # open_resource with its own actionable error.
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", message=".*GPIB.*")
+        if backend is not None:
+            return pyvisa.ResourceManager(backend), backend, False
+        try:
+            return pyvisa.ResourceManager(DEFAULT_VISA_BACKEND), DEFAULT_VISA_BACKEND, False
+        except (OSError, pyvisa.errors.Error) as exc:
+            logger.debug(
+                "VISA backend %s unavailable (%s); falling back to %s",
+                DEFAULT_VISA_BACKEND,
+                exc,
+                FALLBACK_VISA_BACKEND,
+            )
+            return pyvisa.ResourceManager(FALLBACK_VISA_BACKEND), FALLBACK_VISA_BACKEND, True
 
 
 def _is_missing_backend_error(exc: BaseException) -> bool:

--- a/tests/cli/test_discover.py
+++ b/tests/cli/test_discover.py
@@ -1,4 +1,5 @@
 import importlib
+import warnings
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -8,6 +9,17 @@ from instro.cli.discover import _IDN_MAP
 from instro.cli.main import app
 
 runner = CliRunner()
+
+_GPIB_DEGRADED_DEBUG_INFO = {
+    "Version": "0.8.1",
+    "ASRL INSTR": "Available via PySerial (3.5)",
+    "GPIB INSTR": "Available ",
+    "GPIB INTFC": [
+        "gpib_ctypes is installed but could not locate the gpib library.",
+        "Please manually load it using:",
+        "  gpib_ctypes.gpib.gpib._load_lib(filename)",
+    ],
+}
 
 
 @pytest.mark.parametrize("category,class_name", set(_IDN_MAP.values()))
@@ -30,6 +42,64 @@ def test_discover_empty_bench():
             mock_lp.comports.return_value = []
             result = runner.invoke(app, ["discover"])
     assert result.exit_code == 0
+
+
+def test_discover_reports_ivi_backend():
+    mock_rm = _rm_mock(())
+    with patch("instro.cli.discover.pyvisa.ResourceManager", side_effect=[mock_rm]):
+        with patch("instro.cli.discover.list_ports") as mock_lp:
+            mock_lp.comports.return_value = []
+            result = runner.invoke(app, ["discover"])
+    assert "backend: @ivi" in result.output
+    mock_rm.visalib.get_debug_info.assert_not_called()
+
+
+def test_discover_py_fallback_reports_degraded_interfaces():
+    mock_rm = _rm_mock(())
+    mock_rm.visalib.get_debug_info.return_value = _GPIB_DEGRADED_DEBUG_INFO
+    with patch("instro.cli.discover.pyvisa.ResourceManager", side_effect=[OSError("no IVI backend"), mock_rm]):
+        with patch("instro.cli.discover.list_ports") as mock_lp:
+            mock_lp.comports.return_value = []
+            result = runner.invoke(app, ["discover"])
+    assert result.exit_code == 0
+    assert "backend: @py" in result.output
+    assert "GPIB: unavailable" in result.output
+    assert "linux-gpib" in result.output
+    assert "ASRL" not in result.output.replace("ASRL1", "")
+    assert result.output.count("NO DEVICES FOUND") == 1
+    assert result.output.count("GPIB: unavailable") == 2  # coverage line + NO DEVICES panel
+
+
+def test_discover_explicit_py_backend_reports_degraded_interfaces():
+    mock_rm = _rm_mock(("USB0::0x1234::0x5678::INSTR",))
+    mock_rm.visalib.get_debug_info.return_value = _GPIB_DEGRADED_DEBUG_INFO
+    with patch("instro.cli.discover.pyvisa.ResourceManager", side_effect=[mock_rm]):
+        with patch("instro.cli.discover.list_ports") as mock_lp:
+            with patch("instro.cli.discover.VisaDriver") as mock_driver_cls:
+                mock_lp.comports.return_value = []
+                mock_driver_cls.return_value.query.return_value = "UNKNOWN VENDOR,XYZ,000,1.0"
+                result = runner.invoke(app, ["discover", "--backend", "@py"])
+    assert result.exit_code == 0
+    assert "backend: @py" in result.output
+    assert result.output.count("GPIB: unavailable") == 1  # devices found: no panel repeat
+    assert "UNRECOGNIZED" in result.output
+
+
+def test_discover_suppresses_gpib_warning_at_construction():
+    mock_rm = _rm_mock(())
+
+    def _warn_then_return(*args, **kwargs):
+        warnings.warn("GPIB library not found. Please manually load it.", UserWarning, stacklevel=1)
+        return mock_rm
+
+    with patch("instro.cli.discover.pyvisa.ResourceManager", side_effect=_warn_then_return):
+        with patch("instro.cli.discover.list_ports") as mock_lp:
+            mock_lp.comports.return_value = []
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter("always")
+                result = runner.invoke(app, ["discover", "--backend", "@py"])
+    assert result.exit_code == 0
+    assert caught == []
 
 
 def test_discover_mixed_bench():

--- a/tests/cli/test_discover.py
+++ b/tests/cli/test_discover.py
@@ -142,11 +142,16 @@ def test_discover_two_supported_one_unsupported_one_serial():
     mock_port.manufacturer = "Arduino LLC"
     mock_port.product = "Arduino Uno"
     mock_port.description = "Arduino Uno"
+    mock_port_no_product = MagicMock()
+    mock_port_no_product.device = "COM3"
+    mock_port_no_product.manufacturer = None
+    mock_port_no_product.product = None
+    mock_port_no_product.description = "USB Serial Port (COM3)"
 
     with patch("instro.cli.discover.pyvisa.ResourceManager", side_effect=[mock_rm, Exception(), mock_rm]):
         with patch("instro.cli.discover.list_ports") as mock_lp:
             with patch("instro.cli.discover.VisaDriver") as mock_driver_cls:
-                mock_lp.comports.return_value = [mock_port]
+                mock_lp.comports.return_value = [mock_port, mock_port_no_product]
                 mock_driver_cls.return_value.query.side_effect = [
                     "KEITHLEY INSTRUMENTS,2400,12345,C30",
                     "AGILENT TECHNOLOGIES,34401A,MY12345,10.4",
@@ -160,3 +165,5 @@ def test_discover_two_supported_one_unsupported_one_serial():
     assert result.output.count("Keithley2400") == 1
     assert result.output.count("Agilent34401A") == 1
     assert "Arduino Uno" in result.output
+    assert "COM3" in result.output
+    assert "unknown" in result.output


### PR DESCRIPTION
Closes #210.

`instro discover` printed a raw gpib_ctypes UserWarning mid-banner when no native GPIB library was present (the existing suppression only wrapped `list_resources()`, but the warning fires at `ResourceManager("@py")` construction), and the `@ivi` → `@py` fallback was completely silent.

## Changes

- **Consolidated ResourceManager construction** on `instro.lib.transports.visa._open_resource_manager` (prior art: #192). The GPIB warning filter now covers all construction paths — including an explicit `visa_backend="@py"` on the library path, which previously still leaked — and the helper returns the active backend. The discover CLI depends on it instead of duplicating it.
- **Backend line**: discover prints the active backend dim under the scan header — `@ivi (system IVI VISA)`, `@py (pyvisa-py)`, or `@py (pyvisa-py — no IVI VISA found)` when the fallback fired.
- **Interface coverage on `@py`**: reads `rm.visalib.get_debug_info()` and renders each non-Available interface family as a dim one-liner with an install hint, e.g. `GPIB: unavailable — gpib_ctypes is installed but could not locate the gpib library (install NI-488.2 or linux-gpib)`.
- **NO DEVICES FOUND panel** repeats the degraded interfaces, where a missing library most plausibly explains the empty result.

Informative, not an error: the scan continues and the exit code stays 0.

## Testing

- 5 new mocked CLI tests (backend line, degraded rendering on fallback and explicit `@py`, panel repetition, construction-time warning suppression); existing visa driver warning-scoping tests pass unchanged.
- Verified end-to-end on real paths: `@ivi` and `@py` natively on macOS against a Tektronix MSO24 over USB (scope found on both backends, GPIB coverage line shown on `@py`, no warning leak), and the no-IVI fallback in a `python:3.12-slim` container using this branch's wheel (fallback label + coverage line + panel mention, no raw warning).
- `just check` green.