### PR TITLE
feat(publishers): add jsonl format and deprecate the array-JSON writer

### DIFF
--- a/docs/guides/docs.json
+++ b/docs/guides/docs.json
@@ -143,6 +143,7 @@
               "instrumentation/examples/publishers/publish_buffered",
               "instrumentation/examples/publishers/publish_custom",
               "instrumentation/examples/publishers/publish_file",
+              "instrumentation/examples/publishers/publish_jsonl",
               "instrumentation/examples/publishers/publish_queued"
             ]
           },

--- a/docs/guides/instrumentation/examples/publishers/publish_jsonl.mdx
+++ b/docs/guides/instrumentation/examples/publishers/publish_jsonl.mdx
@@ -1,0 +1,50 @@
+---
+title: "Publishers: publish JSONL"
+---
+
+```python publish_jsonl.py
+"""Example: Publishers: publish JSONL.
+
+Demonstrates publishing measurements to a newline-delimited JSON file (FilePublisher).
+
+Start the simulated PSU first:
+    python -m instro.psu.scpi_sim_server
+
+Then in another shell:
+    python examples/publishers/publish_jsonl.py
+"""
+
+import time
+
+from instro.lib.publishers import FilePublisher
+from instro.psu import InstroPSU
+from instro.psu.drivers import SimulatedPSU
+
+VISA_RESOURCE = "TCPIP0::127.0.0.1::5025::SOCKET"
+
+file_publisher = FilePublisher(directory="./captures", format="jsonl", custom_file_name="psu_capture")
+
+psu = InstroPSU(
+    name="myPSU",
+    driver=SimulatedPSU(VISA_RESOURCE),
+    num_channels=2,
+    publishers=[file_publisher],
+)
+
+with psu:
+    psu.set_current_limit(0.2, channel=1)
+    psu.output_enable(True, channel=1)
+
+    # Voltage sweep. Every command and measurement is appended to the
+    # capture file as one complete JSON line.
+    for v in range(5):
+        psu.set_voltage(v, channel=1)
+        time.sleep(0.5)
+        psu.get_voltage(channel=1)
+        psu.get_current(channel=1)
+
+    psu.output_enable(False, channel=1)
+
+print(f"Wrote {file_publisher.file_path}:")
+print(file_publisher.file_path.read_text(), end="")
+```

--- a/docs/guides/instrumentation/overview.mdx
+++ b/docs/guides/instrumentation/overview.mdx
@@ -243,6 +243,6 @@ These are the publishers available out of the box.
 
 - `NominalCorePublisher`: sends data to a Nominal Core dataset
 - `NominalConnectPublisher`: sends data to a Nominal Connect client
-- `FilePublisher`: writes data to a local file in Avro, CSV, or JSON
+- `FilePublisher`: writes data to a local file in Avro, CSV, or JSON Lines
 
 `BasicBufferedPublisher` and `QueuedPublisher` wrap any of the above to add in-memory batching or non-blocking background delivery. See [Publishers](/instrumentation/publishers) for configuration and examples.

--- a/docs/guides/instrumentation/publishers.mdx
+++ b/docs/guides/instrumentation/publishers.mdx
@@ -149,7 +149,7 @@ def main(client: connect_python.Client):
 
 ### FilePublisher
 
-Writes measurements and commands to a local file in Avro, CSV, or JSON format. Useful for data capture in offline or air-gapped environments, for post-run upload to Nominal Core, and for inspecting raw data while debugging.
+Writes measurements and commands to a local file in Avro, CSV, or JSON Lines format. Useful for data capture in offline or air-gapped environments, for post-run upload to Nominal Core, and for inspecting raw data while debugging.
 
 **When to use:**
 - You're running tests on a system without access to Nominal Core or Connect
@@ -161,7 +161,7 @@ Writes measurements and commands to a local file in Avro, CSV, or JSON format. U
 ```python
 FilePublisher(
     directory: str | Path,                            # Directory where the file will be written
-    format: Literal["json", "csv", "avro"] = "avro",  # Output file format
+    format: Literal["json", "jsonl", "csv", "avro"] = "avro",  # Output file format
     custom_file_name: str | None = None,              # Optional base name (no extension)
 )
 ```
@@ -172,7 +172,8 @@ If `custom_file_name` is not provided, the output file is named `measurements-YY
 
 - **`avro`** (default): Compact binary format with snappy compression. Uses the same schema as Nominal Core ingest, so captured files can be uploaded after the fact without transformation. Recommended for production captures.
 - **`csv`**: One row per `(timestamp, channel, value, tags)` tuple. Good for quick inspection in spreadsheet tools.
-- **`json`**: Appends each publish to a JSON array. Convenient for debugging small runs, but not recommended for high-rate data: the entire file is re-read and rewritten on every publish call, so the cost of a capture grows quadratically (O(n^2)) with the number of records.
+- **`jsonl`**: Newline-delimited JSON, one record per publish. Recommended when you want human-readable output: each record is appended and flushed in constant time, and every flushed line is a complete record, so a crash mid-run leaves a readable file.
+- **`json`** (deprecated): Appends each publish to a single JSON array. The entire file is re-read and rewritten on every publish call, so the cost of a capture grows quadratically (O(n^2)) with the number of records. Constructing a `FilePublisher` with `format="json"` emits a `DeprecationWarning`; use `jsonl` instead — records carry identical fields.
 
 **Example:**
 

--- a/docs/guides/instrumentation/publishers.mdx
+++ b/docs/guides/instrumentation/publishers.mdx
@@ -173,7 +173,7 @@ If `custom_file_name` is not provided, the output file is named `measurements-YY
 - **`avro`** (default): Compact binary format with snappy compression. Uses the same schema as Nominal Core ingest, so captured files can be uploaded after the fact without transformation. Recommended for production captures.
 - **`csv`**: One row per `(timestamp, channel, value, tags)` tuple. Good for quick inspection in spreadsheet tools.
 - **`jsonl`**: Newline-delimited JSON, one record per publish. Recommended when you want human-readable output: each record is appended and flushed in constant time, and every flushed line is a complete record, so a crash mid-run leaves a readable file.
-- **`json`** (deprecated): Appends each publish to a single JSON array. The entire file is re-read and rewritten on every publish call, so the cost of a capture grows quadratically (O(n^2)) with the number of records. Constructing a `FilePublisher` with `format="json"` emits a `DeprecationWarning`; use `jsonl` instead — records carry identical fields.
+- **`json`** (deprecated): Appends each publish to a single JSON array. The entire file is re-read and rewritten on every publish call, so the cost of a capture grows quadratically (O(n^2)) with the number of records. Constructing a `FilePublisher` with `format="json"` emits a `DeprecationWarning`; use `jsonl` instead, since records carry identical fields.
 
 **Example:**
 

--- a/examples/publishers/publish_jsonl.py
+++ b/examples/publishers/publish_jsonl.py
@@ -1,0 +1,44 @@
+"""Example: Publishers: publish JSONL.
+
+Demonstrates publishing measurements to a newline-delimited JSON file (FilePublisher).
+
+Start the simulated PSU first:
+    python -m instro.psu.scpi_sim_server
+
+Then in another shell:
+    python examples/publishers/publish_jsonl.py
+"""
+
+import time
+
+from instro.lib.publishers import FilePublisher
+from instro.psu import InstroPSU
+from instro.psu.drivers import SimulatedPSU
+
+VISA_RESOURCE = "TCPIP0::127.0.0.1::5025::SOCKET"
+
+file_publisher = FilePublisher(directory="./captures", format="jsonl", custom_file_name="psu_capture")
+
+psu = InstroPSU(
+    name="myPSU",
+    driver=SimulatedPSU(VISA_RESOURCE),
+    num_channels=2,
+    publishers=[file_publisher],
+)
+
+with psu:
+    psu.set_current_limit(0.2, channel=1)
+    psu.output_enable(True, channel=1)
+
+    # Voltage sweep. Every command and measurement is appended to the
+    # capture file as one complete JSON line.
+    for v in range(5):
+        psu.set_voltage(v, channel=1)
+        time.sleep(0.5)
+        psu.get_voltage(channel=1)
+        psu.get_current(channel=1)
+
+    psu.output_enable(False, channel=1)
+
+print(f"Wrote {file_publisher.file_path}:")
+print(file_publisher.file_path.read_text(), end="")

--- a/instro/lib/publishers/files.py
+++ b/instro/lib/publishers/files.py
@@ -2,6 +2,7 @@
 
 import csv
 import json
+import math
 import warnings
 from datetime import datetime
 from pathlib import Path
@@ -133,17 +134,31 @@ class JsonFileWriter:
         pass
 
 
+def _json_safe(value: Any) -> Any:
+    if isinstance(value, float) and not math.isfinite(value):
+        return None
+    if isinstance(value, dict):
+        return {k: _json_safe(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_json_safe(v) for v in value]
+    return value
+
+
 class JsonlFileWriter:
     """Handles newline-delimited JSON writing with a persistent file handle."""
 
     def __init__(self, file_path: Path):
         self.file_path = file_path
-        self.file_path.parent.mkdir(parents=True, exist_ok=True)
+        self._ensure_file_exists()
         self._file = open(self.file_path, "a")
 
+    def _ensure_file_exists(self):
+        """Create directory if it doesn't exist."""
+        self.file_path.parent.mkdir(parents=True, exist_ok=True)
+
     def write(self, data: Measurement | Command):
-        """Append data as one JSON line."""
-        self._file.write(json.dumps(data.__dict__) + "\n")
+        """Append data as one JSON line, mapping non-finite floats to null."""
+        self._file.write(json.dumps(_json_safe(data.__dict__), allow_nan=False) + "\n")
         self._file.flush()
 
     def open(self):
@@ -151,8 +166,7 @@ class JsonlFileWriter:
 
     def close(self):
         """Close the file writer."""
-        if self._file and not self._file.closed:
-            self._file.close()
+        self._file.close()
 
 
 class CsvFileWriter:

--- a/instro/lib/publishers/files.py
+++ b/instro/lib/publishers/files.py
@@ -1,7 +1,8 @@
-"""File-based publishers (JSON, CSV, Avro)."""
+"""File-based publishers (JSON, JSONL, CSV, Avro)."""
 
 import csv
 import json
+import warnings
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Literal, Protocol
@@ -25,14 +26,14 @@ class FilePublisher:
     def __init__(
         self,
         directory: str | Path,
-        format: Literal["json", "csv", "avro"] = "avro",
+        format: Literal["json", "jsonl", "csv", "avro"] = "avro",
         custom_file_name: str | None = None,
     ):
         """Write Measurement/Command data to a file.
 
         Args:
             directory: Output directory.
-            format: ``"json"``, ``"csv"``, or ``"avro"`` (default).
+            format: ``"jsonl"``, ``"csv"``, ``"avro"`` (default), or ``"json"`` (deprecated).
             custom_file_name: Filename without extension; defaults to ``measurements-<UTC-timestamp>``.
         """
         self.directory = Path(directory)
@@ -56,7 +57,15 @@ class FilePublisher:
 
         # Initialize appropriate writer based on format
         if format == "json":
+            warnings.warn(
+                'FilePublisher format="json" rewrites the whole file on every publish and is deprecated; '
+                'use format="jsonl" instead.',
+                DeprecationWarning,
+                stacklevel=2,
+            )
             self._writer = JsonFileWriter(self.file_path)
+        elif format == "jsonl":
+            self._writer = JsonlFileWriter(self.file_path)
         elif format == "csv":
             self._writer = CsvFileWriter(self.file_path)
         elif format == "avro":
@@ -122,6 +131,28 @@ class JsonFileWriter:
     def close(self):
         """Close the file writer."""
         pass
+
+
+class JsonlFileWriter:
+    """Handles newline-delimited JSON writing with a persistent file handle."""
+
+    def __init__(self, file_path: Path):
+        self.file_path = file_path
+        self.file_path.parent.mkdir(parents=True, exist_ok=True)
+        self._file = open(self.file_path, "a")
+
+    def write(self, data: Measurement | Command):
+        """Append data as one JSON line."""
+        self._file.write(json.dumps(data.__dict__) + "\n")
+        self._file.flush()
+
+    def open(self):
+        pass
+
+    def close(self):
+        """Close the file writer."""
+        if self._file and not self._file.closed:
+            self._file.close()
 
 
 class CsvFileWriter:

--- a/tests/lib/test_file_publisher.py
+++ b/tests/lib/test_file_publisher.py
@@ -54,6 +54,22 @@ def test_jsonl_record_shape_matches_json_writer(tmp_path):
     assert jsonl_record == json_record
 
 
+def test_jsonl_maps_non_finite_floats_to_null(tmp_path):
+    publisher = FilePublisher(directory=tmp_path, format="jsonl", custom_file_name="capture")
+
+    publisher.publish(
+        Measurement(
+            channel_data={"channel_a": [float("nan"), float("inf"), float("-inf"), 1.5]},
+            timestamps=[100, 200, 300, 400],
+            tags=None,
+        )
+    )
+    publisher.close()
+
+    record = json.loads((tmp_path / "capture.jsonl").read_text())
+    assert record["channel_data"]["channel_a"] == [None, None, None, 1.5]
+
+
 def test_jsonl_each_line_is_complete_before_close(tmp_path):
     publisher = FilePublisher(directory=tmp_path, format="jsonl", custom_file_name="capture")
 

--- a/tests/lib/test_file_publisher.py
+++ b/tests/lib/test_file_publisher.py
@@ -1,0 +1,98 @@
+"""Unit tests for FilePublisher JSONL support and JSON deprecation."""
+
+import json
+import warnings
+
+import pytest
+
+from instro.lib.publishers import FilePublisher
+from instro.lib.types import Command, Measurement
+
+
+def _measurement() -> Measurement:
+    return Measurement(
+        channel_data={"channel_a": [1.0, 2.0]},
+        timestamps=[100, 200],
+        tags={"unit": "volts"},
+    )
+
+
+def _command() -> Command:
+    return Command(channel_data={"channel_b": 5.0}, timestamp=300, tags=None)
+
+
+def test_jsonl_writes_one_json_object_per_line(tmp_path):
+    publisher = FilePublisher(directory=tmp_path, format="jsonl", custom_file_name="capture")
+
+    publisher.publish(_measurement())
+    publisher.publish(_command())
+    publisher.close()
+
+    lines = (tmp_path / "capture.jsonl").read_text().splitlines()
+    assert len(lines) == 2
+    assert json.loads(lines[0]) == {
+        "channel_data": {"channel_a": [1.0, 2.0]},
+        "timestamps": [100, 200],
+        "tags": {"unit": "volts"},
+    }
+    assert json.loads(lines[1]) == {"channel_data": {"channel_b": 5.0}, "timestamp": 300, "tags": None}
+
+
+def test_jsonl_record_shape_matches_json_writer(tmp_path):
+    jsonl_publisher = FilePublisher(directory=tmp_path, format="jsonl", custom_file_name="capture")
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        json_publisher = FilePublisher(directory=tmp_path, format="json", custom_file_name="capture")
+
+    jsonl_publisher.publish(_measurement())
+    json_publisher.publish(_measurement())
+    jsonl_publisher.close()
+    json_publisher.close()
+
+    jsonl_record = json.loads((tmp_path / "capture.jsonl").read_text())
+    json_record = json.loads((tmp_path / "capture.json").read_text())[0]
+    assert jsonl_record == json_record
+
+
+def test_jsonl_each_line_is_complete_before_close(tmp_path):
+    publisher = FilePublisher(directory=tmp_path, format="jsonl", custom_file_name="capture")
+
+    publisher.publish(_measurement())
+
+    content = (tmp_path / "capture.jsonl").read_text()
+    assert content.endswith("\n")
+    json.loads(content)
+
+
+def test_jsonl_close_closes_file_handle(tmp_path):
+    publisher = FilePublisher(directory=tmp_path, format="jsonl", custom_file_name="capture")
+
+    publisher.close()
+
+    assert publisher._writer._file.closed
+    publisher.close()  # idempotent
+
+
+def test_json_format_emits_deprecation_warning(tmp_path):
+    with pytest.warns(DeprecationWarning, match="jsonl"):
+        FilePublisher(directory=tmp_path, format="json", custom_file_name="capture")
+
+
+def test_json_format_still_writes_array(tmp_path):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        publisher = FilePublisher(directory=tmp_path, format="json", custom_file_name="capture")
+
+    publisher.publish(_measurement())
+    publisher.publish(_command())
+    publisher.close()
+
+    records = json.loads((tmp_path / "capture.json").read_text())
+    assert isinstance(records, list)
+    assert len(records) == 2
+
+
+def test_jsonl_does_not_warn(tmp_path):
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        FilePublisher(directory=tmp_path, format="jsonl", custom_file_name="capture")


### PR DESCRIPTION
Closes nominal-io/instro#212

## What

* Adds `format="jsonl"` to `FilePublisher`, backed by a new `JsonlFileWriter` that opens its file handle once in `__init__` (append text mode, like `AvroFileWriter`) and writes one `json.dumps(data.__dict__)` line + flush per publish — O(1) per measurement, and every flushed line is a complete record, so a crash mid-run leaves a readable `.jsonl` file.
* Records carry the exact same fields as the existing array-JSON writer, so consumers switching formats see identical shapes (covered by a test comparing the two writers' output).
* `format="json"` keeps working exactly as before but now emits a `DeprecationWarning` pointing at `jsonl`; removal is deferred to a future major release.
* Docs: the publishers guide now recommends `jsonl` for human-readable captures and marks `json` as deprecated with the O(n^2) rationale; the overview page mentions JSON Lines.

## Testing

* New `tests/lib/test_file_publisher.py`: line-per-record output, record-shape parity with the JSON writer, per-publish flush (file complete before `close()`), idempotent `close()`, `DeprecationWarning` on `format="json"`, no warning on `jsonl`, and the legacy array format still working.
* `just check` and the full unit suite (1022 passed) are green.