### PR TITLE
feat(cli): add --version listing installed instro packages

### DIFF
--- a/docs/guides/instrumentation/cli.mdx
+++ b/docs/guides/instrumentation/cli.mdx
@@ -5,9 +5,30 @@ description: Command-line tools for working with instro
 
 `instro` ships a command-line interface for inspecting and discovering instruments on your bench.
 
+## Running the CLI
+
+The CLI comes with the `instro` package — see [Installation](/instrumentation/installation) for adding it to your project. In a project that has `instro` installed, run commands with `uv run`:
+
+```bash
+uv run instro discover
+```
+
+To try a command once without installing anything, `uvx` runs it in a throwaway environment:
+
+```bash
+uvx instro discover
+```
+
+Or put `instro` on your PATH permanently so you can call it from anywhere:
+
+```bash
+uv tool install instro
+instro discover
+```
+
 ## instro --version
 
-Prints the installed version of the core `instro` package followed by every optional workspace package (`instro-contrib`, `instro-unstable`, `instro-ethernetip`, `instro-daq-ni`, `instro-daq-labjack`, `instro-daq-mcc`, `instro-i2c-aardvark`). Packages that are not installed are marked `not installed` with the `pip install "instro[<extra>]"` command that provides them.
+Prints the installed version of the core `instro` package followed by every optional workspace package (`instro-contrib`, `instro-unstable`, `instro-ethernetip`, `instro-daq-ni`, `instro-daq-labjack`, `instro-daq-mcc`, `instro-i2c-aardvark`). Packages that are not installed are marked `not installed` with the `pip install "instro[<extra>]"` command that provides them — see [Additional Packages](/instrumentation/installation#additional-packages) for what each extra covers.
 
 ```bash
 instro --version
@@ -18,18 +39,6 @@ The full roster is printed on purpose: attach the output to bug reports as an en
 ## instro discover
 
 Scans all available VISA resources and serial ports, queries each instrument for its identity, and prints a summary table.
-Run the discover CLI using 'uv'. Use the discovery command once, creating a throwaway isolated environment:
-
-```bash
-uv run instro discover
-```
-
-Or install `instro` so it lives on your PATH and you can call it from anywhere:
-
-```bash
-uv tool install instro
-instro discover
-```
 
 To force a specific VISA backend, pass `--backend`:
 

--- a/docs/guides/instrumentation/cli.mdx
+++ b/docs/guides/instrumentation/cli.mdx
@@ -5,6 +5,16 @@ description: Command-line tools for working with instro
 
 `instro` ships a command-line interface for inspecting and discovering instruments on your bench.
 
+## instro --version
+
+Prints the installed version of the core `instro` package followed by every optional workspace package (`instro-contrib`, `instro-unstable`, `instro-ethernetip`, `instro-daq-ni`, `instro-daq-labjack`, `instro-daq-mcc`, `instro-i2c-aardvark`). Packages that are not installed are marked `not installed` with the `pip install "instro[<extra>]"` command that provides them.
+
+```bash
+instro --version
+```
+
+The full roster is printed on purpose: attach the output to bug reports as an environment summary.
+
 ## instro discover
 
 Scans all available VISA resources and serial ports, queries each instrument for its identity, and prints a summary table.

--- a/docs/guides/instrumentation/cli.mdx
+++ b/docs/guides/instrumentation/cli.mdx
@@ -19,7 +19,7 @@ To try a command once without installing anything, `uvx` runs it in a throwaway 
 uvx instro discover
 ```
 
-Or put `instro` on your PATH permanently so you can call it from anywhere:
+`uvx` can be slow when it triggers a fresh install of `instro`'s full dependency tree. For regular use, put `instro` on your PATH instead so you can call it from anywhere:
 
 ```bash
 uv tool install instro

--- a/instro/cli/main.py
+++ b/instro/cli/main.py
@@ -1,17 +1,55 @@
+import importlib.metadata
+from typing import Annotated
+
 import typer
 
 from instro.cli.discover import discover
 
+_WORKSPACE_PACKAGES = (
+    ("instro-contrib", "contrib"),
+    ("instro-unstable", "unstable"),
+    ("instro-ethernetip", "ethernetip"),
+    ("instro-daq-ni", "nidaq"),
+    ("instro-daq-labjack", "labjack"),
+    ("instro-daq-mcc", "mccdaq"),
+    ("instro-i2c-aardvark", "aardvark"),
+)
+
 app = typer.Typer()
 
 
+def _version_callback(value: bool) -> None:
+    if not value:
+        return
+    typer.echo(f"instro {importlib.metadata.version('instro')}")
+    for package, extra in _WORKSPACE_PACKAGES:
+        try:
+            typer.echo(f"{package} {importlib.metadata.version(package)}")
+        except importlib.metadata.PackageNotFoundError:
+            typer.echo(f'{package} not installed (pip install "instro[{extra}]")')
+    raise typer.Exit()
+
+
 @app.callback()
-def main() -> None:
+def main(
+    version: Annotated[
+        bool,
+        typer.Option(
+            "--version",
+            callback=_version_callback,
+            is_eager=True,
+            help="Show installed instro package versions and exit.",
+        ),
+    ] = False,
+) -> None:
     pass
 
 
 @app.command("discover")
-def discover_cmd(backend: str = typer.Option(None, help="pyvisa backend, e.g. '@py' or '@ivi'")) -> None:
+def discover_cmd(
+    backend: Annotated[str | None, typer.Option(help="pyvisa backend, e.g. '@py' or '@ivi'")] = None,
+) -> None:
+    """Scan VISA resources and serial ports for instruments and print a summary table."""
     discover(backend=backend)
 
 

--- a/tests/cli/test_version.py
+++ b/tests/cli/test_version.py
@@ -1,0 +1,36 @@
+import importlib.metadata
+from unittest.mock import patch
+
+from typer.testing import CliRunner
+
+from instro.cli.main import _WORKSPACE_PACKAGES, app
+
+runner = CliRunner()
+
+
+def test_version_lists_core_and_every_workspace_package():
+    result = runner.invoke(app, ["--version"])
+    assert result.exit_code == 0
+    assert result.output.startswith("instro ")
+    for package, _ in _WORKSPACE_PACKAGES:
+        assert package in result.output
+
+
+def test_version_marks_missing_packages_with_extra_hint():
+    def fake_version(name: str) -> str:
+        if name == "instro-daq-ni":
+            raise importlib.metadata.PackageNotFoundError(name)
+        return "1.2.3"
+
+    with patch("importlib.metadata.version", side_effect=fake_version):
+        result = runner.invoke(app, ["--version"])
+    assert result.exit_code == 0
+    assert 'instro-daq-ni not installed (pip install "instro[nidaq]")' in result.output
+    assert "instro-contrib 1.2.3" in result.output
+
+
+def test_version_is_eager_and_skips_commands():
+    with patch("instro.cli.main.discover") as mock_discover:
+        result = runner.invoke(app, ["--version"])
+    assert result.exit_code == 0
+    mock_discover.assert_not_called()


### PR DESCRIPTION
Closes #211.

There was no way to ask the CLI what version is installed.

## Changes

- **Eager `--version` option** on the typer callback in `instro/cli/main.py`: prints the core `instro` version, then every workspace package (`instro-contrib`, `instro-unstable`, `instro-ethernetip`, `instro-daq-ni`, `instro-daq-labjack`, `instro-daq-mcc`, `instro-i2c-aardvark`) via `importlib.metadata.version`. Missing packages are marked `not installed` with the matching `pip install "instro[<extra>]"` hint (most specific extra per package: `nidaq`, `labjack`, `mccdaq`, `aardvark`, `ethernetip`, `contrib`, `unstable`). Version lookup happens lazily in the callback so plain `instro discover` pays no metadata-resolution cost.
- Full-roster output is deliberate: it doubles as the environment dump we ask for when triaging bug reports (documented in `cli.mdx`).
- Adopt typer's `Annotated` option style in `main.py` and type the discover `backend` option honestly as `str | None` (was `str = typer.Option(None, ...)`).
- Add a help line to the `discover` command.

## Example output

```
instro 1.0.1
instro-contrib 1.0.0
instro-unstable 1.0.0
instro-ethernetip 1.0.0
instro-daq-ni 0.7.1
instro-daq-labjack 0.7.1
instro-daq-mcc 0.5.1
instro-i2c-aardvark 0.2.1
```

In a bare install (core wheel only), each optional package shows e.g. `instro-daq-ni not installed (pip install "instro[nidaq]")` — verified for real in a fresh venv.

## Testing

- 3 new `CliRunner` tests in `tests/cli/test_version.py`: full roster listed, missing package rendered with the right extra hint, and eagerness (`--version` never invokes a command).
- Verified end-to-end in the dev venv (all packages listed with real versions) and in a bare venv with only the core wheel (all seven marked not-installed with correct hints).
- `just check` green.