### PR TITLE
docs: batch clarity fixes from user feedback

### DIFF
--- a/docs/guides/instrumentation/custom-instruments.mdx
+++ b/docs/guides/instrumentation/custom-instruments.mdx
@@ -77,6 +77,10 @@ Any method decorated with `@publish_measurement` must return a `Measurement` (or
 
 The `_package_measurement(channel, value, timestamp, **tags)` helper on `Instrument` does the build for you: it prefixes the channel with `{self.name}.`, coerces the value to `float`, merges in `self.default_tags`, and returns a single-channel `Measurement`.
 
+<Note>
+`_package_measurement` and `_package_command` are stable, supported extension points for `Instrument` subclass authors. The leading underscore marks them as protected (for subclasses, not external callers), which is standard Python. Both are documented on the [Instrument reference page](https://nominal-io.github.io/instro/reference/instrument/).
+</Note>
+
 ```python
 class SimpleTempController(Instrument):
     ...

--- a/docs/guides/instrumentation/installation.mdx
+++ b/docs/guides/instrumentation/installation.mdx
@@ -79,3 +79,5 @@ python:
   packages:
     - instro[daq]
 ```
+
+To stream live `instro` data into a Nominal Connect app, attach a [`NominalConnectPublisher`](/instrumentation/publishers#nominalconnectpublisher) to the instrument.

--- a/docs/guides/instrumentation/publishers.mdx
+++ b/docs/guides/instrumentation/publishers.mdx
@@ -68,8 +68,8 @@ class Publisher(Protocol):
 
 ### Data Types
 
-- **`Measurement`**: Contains data read from the instrument (e.g., analog input readings, voltage measurements). Includes channel data, timestamps, and optional tags.
-- **`Command`**: Represents a command sent to the instrument (e.g., setting voltage, enabling output). Includes channel data, a single timestamp, and optional tags.
+- [**`Measurement`**](https://nominal-io.github.io/instro/reference/types/#instro.lib.types.Measurement): Contains data read from the instrument (e.g., analog input readings, voltage measurements). Includes channel data, timestamps, and optional tags.
+- [**`Command`**](https://nominal-io.github.io/instro/reference/types/#instro.lib.types.Command): Represents a command sent to the instrument (e.g., setting voltage, enabling output). Includes channel data, a single timestamp, and optional tags.
 
 ## Built-in Publishers
 
@@ -114,7 +114,7 @@ The `NominalCorePublisher` includes built-in batching via the Nominal Core Pytho
 
 ### NominalConnectPublisher
 
-Streams real-time data to Nominal Connect for live visualization and monitoring during tests that use the Nominal Connect Desktop Application.
+Streams real-time data to Nominal Connect for live visualization and monitoring during tests that use the Nominal Connect Desktop Application. Nominal Connect apps can also install `instro` for you; see [Using Nominal Connect](/instrumentation/installation#using-nominal-connect).
 
 **Constructor Parameters:**
 
@@ -262,6 +262,8 @@ class Publisher(Protocol):
 
     def close(self): ...
 ```
+
+`publish` runs synchronously, on the same thread as the instrument method that produced the data. That is deliberate: the in-memory channel buffer behind `get_channel` is itself a publisher, and `get_channel`'s blocking semantics rely on samples being in the buffer by the time each background-daemon iteration completes. If publishing were deferred to a background thread by default, a `get_channel` call could miss a sample the daemon just collected. Keep custom `publish` implementations fast; when the sink is slow (network, disk), wrap the publisher in a [`QueuedPublisher`](#queuedpublisher) to opt into background publishing.
 
 ### Example
 This publisher prints to the console every time a `Measurement` is published corresponding to a predefined <Tooltip tip="A named signal for a series of measurements or computed values (example: voltage, pressure, system state).">channel</Tooltip> name.

--- a/docs/guides/instrumentation/publishers.mdx
+++ b/docs/guides/instrumentation/publishers.mdx
@@ -255,20 +255,18 @@ daq = InstroDAQ(
 
 ## Custom Publisher
 
-To create a custom publisher, create a class that implements the following protocol. i.e. has a `publish` and a `close` method.
+To create a custom publisher, create a class that implements the publisher protocol: a `publish` method and a `close` method. The example below prints to the console every time a `Measurement` is published corresponding to a predefined <Tooltip tip="A named signal for a series of measurements or computed values (example: voltage, pressure, system state).">channel</Tooltip> name.
+
 ```python
+from typing import Protocol
+
+from instro.lib.types import Measurement, Command
+
 class Publisher(Protocol):
     def publish(self, data: Measurement | Command, **kwargs): ...
 
     def close(self): ...
-```
 
-`publish` runs synchronously, on the same thread as the instrument method that produced the data. That is deliberate: the in-memory channel buffer behind `get_channel` is itself a publisher, and `get_channel`'s blocking semantics rely on samples being in the buffer by the time each background-daemon iteration completes. If publishing were deferred to a background thread by default, a `get_channel` call could miss a sample the daemon just collected. Keep custom `publish` implementations fast; when the sink is slow (network, disk), wrap the publisher in a [`QueuedPublisher`](#queuedpublisher) to opt into background publishing.
-
-### Example
-This publisher prints to the console every time a `Measurement` is published corresponding to a predefined <Tooltip tip="A named signal for a series of measurements or computed values (example: voltage, pressure, system state).">channel</Tooltip> name.
-```python
-from instro.lib.types import Measurement, Command
 
 class PrintChannelPublisher:
     def __init__(self, channel_name: str):
@@ -286,6 +284,12 @@ class PrintChannelPublisher:
     def close(self):
         pass
 ```
+
+### Publisher execution model
+
+Custom publishers face the classic buffered versus unbuffered I/O tradeoff. By default, publishing is unbuffered: `publish` runs synchronously, on the same thread as the instrument method that produced the data. That is deliberate. The in-memory channel buffer behind `get_channel` is itself a publisher, and `get_channel`'s blocking semantics rely on samples being in the buffer by the time each background-daemon iteration completes. If publishing were deferred to a background thread by default, a `get_channel` call could miss a sample the daemon just collected.
+
+Keep custom `publish` implementations fast. When the sink is slow (network, disk), opt into buffered or background publishing by wrapping the publisher in a [`BasicBufferedPublisher`](#basicbufferedpublisher) or [`QueuedPublisher`](#queuedpublisher).
 
 ## Publisher Wrappers
 

--- a/docs/guides/instrumentation/quickstart.mdx
+++ b/docs/guides/instrumentation/quickstart.mdx
@@ -45,13 +45,17 @@ description: Drive a simulated power supply end-to-end in about five minutes. No
   </Step>
 
   <Step title="Set a voltage and enable the output">
-    Configure channel 1 with a 5 V setpoint and a 1 A current limit, then enable the output.
+    Configure channel 1 with a 5 V setpoint, a 1 A current limit, and overvoltage protection at 5.5 V, then enable the output.
 
     ```python
     psu.set_voltage(5.0, channel=1)
     psu.set_current_limit(1.0, channel=1)
+    psu.set_overvoltage_protection_level(5.5, channel=1)
+    psu.set_overvoltage_protection_enabled(True, channel=1)
     psu.output_enable(True, channel=1)
     ```
+
+    The simulator models protection trips just like a real supply: if the output ever exceeds the OVP threshold, the channel shuts down and `SYST:ERR?` reports the trip.
   </Step>
 
   <Step title="Read a measurement back">
@@ -64,7 +68,7 @@ description: Drive a simulated power supply end-to-end in about five minutes. No
     print(f"I: {current.latest:.3f} A")
     ```
 
-    When you're done, disable the output and close the connection:
+    When you're done, disable the output and close the connection. Turning the output off before disconnecting is standard bench safety, and `close()` does more than drop the socket: it stops the background daemon and flushes any attached publishers.
 
     ```python
     psu.output_enable(False, channel=1)

--- a/docs/reference/src/reference/instrument.md
+++ b/docs/reference/src/reference/instrument.md
@@ -1,3 +1,8 @@
 # Instrument
 
 ::: instro.lib.instrument
+    options:
+      filters:
+        - "!^_"
+        - "^_package_command$"
+        - "^_package_measurement$"


### PR DESCRIPTION
Closes nominal-io/instro#217. Five small fixes from external user feedback:

**(a) Connect cross-links.** `installation.mdx` "Using Nominal Connect" now links to the publishers page's `NominalConnectPublisher` section, and that section links back to the install instructions.

**(b) Custom-publisher guide.** `Measurement`/`Command` link to their reference entries at first mention. Added a paragraph after the Publisher protocol explaining why `publish` is synchronous by default (the channel buffer behind `get_channel` is itself a publisher, and `get_channel`'s blocking semantics need samples in-buffer when the daemon iteration completes) and pointing at `QueuedPublisher` as the opt-in wrapper for slow sinks.

**(c) Quickstart teardown rationale.** One sentence at the teardown step: output-off before disconnect is bench safety; `close()` stops the daemon and flushes publishers, not just the socket.

**(d) Extension points.** `custom-instruments.mdx` now states `_package_command`/`_package_measurement` are stable, supported extension points for subclass authors. Added a per-page mkdocstrings `filters` override on `reference/instrument.md` whitelisting the two methods so the reference page matches. Verified in a local `mkdocs build`: exactly those two underscored members render, nothing else leaks.

**(e) Quickstart protection calls.** `set_overvoltage_protection_level` + `set_overvoltage_protection_enabled` next to `set_current_limit` (the issue's `set_ovp_level`/`ovp_enable` shorthand mapped to the real HAL names). The simulator models trip behavior, noted in the step.

`mint broken-links` flags none of the new links (the 25 pre-existing hits are Windows path-separator false positives on links to pages that exist).