### PR TITLE
feat(dmm): add Keithley 2750 DMM driver (unstable)

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ pip install "instro[nidaq,contrib]"
 | Category | Class | Vendors |
 |---|---|---|
 | Power Supply | `InstroPSU` | B&K Precision (9115, 914X), Keysight (E36100-series), Rigol (DP800-series), Siglent (SPD3303), TDK Lambda (Genesys), simulated |
-| Multimeter | `InstroDMM` | Agilent 34401A, Keithley 2400 |
+| Multimeter | `InstroDMM` | Agilent 34401A, Keithley 2400, Keithley 2750 (unstable) |
 | Electronic Load | `InstroELoad` | B&K Precision (85xxB-series) |
 | Oscilloscope | `InstroScope` | Keysight (1200X-series), Tektronix (2-series), Siglent (SDS1000X-E) |
 | DAQ | `InstroDAQ` | Keysight 34980A, NI-DAQmx, LabJack T-series, MCC USB-series |

--- a/packages/instro-unstable/instro/unstable/dmm/__init__.py
+++ b/packages/instro-unstable/instro/unstable/dmm/__init__.py
@@ -1,0 +1,1 @@
+"""In-development DMM drivers (unstable)."""

--- a/packages/instro-unstable/instro/unstable/dmm/drivers/__init__.py
+++ b/packages/instro-unstable/instro/unstable/dmm/drivers/__init__.py
@@ -1,0 +1,5 @@
+"""Unstable DMM drivers."""
+
+from instro.unstable.dmm.drivers.keithley_2750 import Keithley2750
+
+__all__ = ["Keithley2750"]

--- a/packages/instro-unstable/instro/unstable/dmm/drivers/keithley_2750.py
+++ b/packages/instro-unstable/instro/unstable/dmm/drivers/keithley_2750.py
@@ -1,0 +1,157 @@
+"""Keithley 2750 Multimeter/Switch System driver (front-panel DMM only).
+
+Supports DC/AC voltage, DC/AC current, and 2- and 4-wire resistance via the
+front-panel INPUT terminals. Switching/scan-card functionality is not covered.
+"""
+
+from __future__ import annotations
+
+from instro.dmm import DMMDriverBase
+from instro.dmm.types import MeasurementFunction
+from instro.lib.transports.visa import VisaConfig, VisaDriver
+
+# :FUNCtion strings the 2750 expects (quoted on the wire). All six DMM functions
+# are supported; the switch/scan-only functions are intentionally omitted.
+_FUNCTION_SCPI: dict[MeasurementFunction, str] = {
+    MeasurementFunction.DC_VOLTAGE: "VOLTage:DC",
+    MeasurementFunction.AC_VOLTAGE: "VOLTage:AC",
+    MeasurementFunction.DC_CURRENT: "CURRent:DC",
+    MeasurementFunction.AC_CURRENT: "CURRent:AC",
+    MeasurementFunction.TWO_WIRE_RESISTANCE: "RESistance",
+    MeasurementFunction.FOUR_WIRE_RESISTANCE: "FRESistance",
+}
+
+
+class Keithley2750(DMMDriverBase):
+    """Keithley 2750 as a front-panel DMM. Integration time is set via NPLC (0.01–60)."""
+
+    def __init__(self, visa_resource: str | VisaConfig) -> None:
+        self._visa = VisaDriver(visa_resource)
+
+    def open(self) -> None:
+        self._visa.open()
+        with self._visa.lock():
+            self._visa.write("*CLS")
+            self._visa.write("*RST")
+            # Reduce a reading to a bare float; the *RST default returns a
+            # unit-suffixed "reading,timestamp,rdng#" string that won't parse.
+            self._visa.write(":FORMat:ELEMents READing")
+            self._check_errors()
+
+    def close(self) -> None:
+        self._visa.close()
+
+    def set_measurement_function(self, function: MeasurementFunction) -> None:
+        """Select ``function`` on the front-panel input."""
+        try:
+            scpi = _FUNCTION_SCPI[function]
+        except KeyError:
+            raise NotImplementedError(f"Keithley 2750 DMM driver does not support {function.name}.") from None
+        self._write_checked(f':FUNCtion "{scpi}"')
+
+    def set_digits(self, n: int) -> None:
+        """Unsupported — :DIGits is display-only on the 2750; use ``set_aperture_nplc`` for resolution."""
+        raise NotImplementedError(
+            "Keithley 2750 :DIGits sets front-panel display resolution only and does not change the "
+            "returned reading; use set_aperture_nplc(...) for measurement resolution."
+        )
+
+    def set_aperture_seconds(self, seconds: float) -> None:
+        """Unsupported — aperture is per-function on the 2750; use ``set_aperture_nplc`` instead."""
+        raise NotImplementedError("Keithley 2750 aperture is per-function; use set_aperture_nplc(...) instead.")
+
+    # --- NPLC, scoped per function ---
+
+    def _set_nplc(self, scpi_root: str, nplc: float, ac_detector: bool = False) -> None:
+        with self._visa.lock():
+            if ac_detector:
+                # AC NPLC control is only honored when the AC detector bandwidth is 300 Hz.
+                self._visa.write(f"{scpi_root}:DETector:BANDwidth 300")
+            self._visa.write(f"{scpi_root}:NPLCycles {nplc:g}")
+            self._check_errors()
+
+    def set_dc_voltage_nplc(self, nplc: float) -> None:
+        self._set_nplc(":SENSe:VOLTage:DC", nplc)
+
+    def set_ac_voltage_nplc(self, nplc: float) -> None:
+        self._set_nplc(":SENSe:VOLTage:AC", nplc, ac_detector=True)
+
+    def set_dc_current_nplc(self, nplc: float) -> None:
+        self._set_nplc(":SENSe:CURRent:DC", nplc)
+
+    def set_ac_current_nplc(self, nplc: float) -> None:
+        self._set_nplc(":SENSe:CURRent:AC", nplc, ac_detector=True)
+
+    def set_two_wire_resistance_nplc(self, nplc: float) -> None:
+        self._set_nplc(":SENSe:RESistance", nplc)
+
+    def set_four_wire_resistance_nplc(self, nplc: float) -> None:
+        self._set_nplc(":SENSe:FRESistance", nplc)
+
+    # --- Range, scoped per function ---
+
+    def _set_range(self, scpi_root: str, value: float | None) -> None:
+        with self._visa.lock():
+            if value is None:
+                self._visa.write(f"{scpi_root}:RANGe:AUTO ON")
+            else:
+                self._visa.write(f"{scpi_root}:RANGe:AUTO OFF")
+                self._visa.write(f"{scpi_root}:RANGe:UPPer {value:g}")
+            self._check_errors()
+
+    def set_dc_voltage_range(self, value: float | None) -> None:
+        self._set_range(":SENSe:VOLTage:DC", value)
+
+    def set_ac_voltage_range(self, value: float | None) -> None:
+        self._set_range(":SENSe:VOLTage:AC", value)
+
+    def set_dc_current_range(self, value: float | None) -> None:
+        self._set_range(":SENSe:CURRent:DC", value)
+
+    def set_ac_current_range(self, value: float | None) -> None:
+        self._set_range(":SENSe:CURRent:AC", value)
+
+    def set_two_wire_resistance_range(self, value: float | None) -> None:
+        self._set_range(":SENSe:RESistance", value)
+
+    def set_four_wire_resistance_range(self, value: float | None) -> None:
+        self._set_range(":SENSe:FRESistance", value)
+
+    # --- Measurements. Function is already selected; :READ? triggers a fresh reading. ---
+
+    def _read_value(self) -> float:
+        with self._visa.lock():
+            response = self._visa.query(":READ?")
+            self._check_errors()
+        return float(response.strip().split(",")[0])
+
+    def measure_dc_voltage(self) -> float:
+        return self._read_value()
+
+    def measure_ac_voltage(self) -> float:
+        return self._read_value()
+
+    def measure_dc_current(self) -> float:
+        return self._read_value()
+
+    def measure_ac_current(self) -> float:
+        return self._read_value()
+
+    def measure_resistance(self) -> float:
+        return self._read_value()
+
+    def measure_four_wire_resistance(self) -> float:
+        return self._read_value()
+
+    def _write_checked(self, command: str) -> None:
+        with self._visa.lock():
+            self._visa.write(command)
+            self._check_errors()
+
+    def _check_errors(self) -> None:
+        err = self._visa.query(":SYSTem:ERRor?")
+        parts = err.strip().split(",", 1)
+        code_str = parts[0] if parts else ""
+        code_val = int(code_str) if code_str.lstrip("-+").isdigit() else -1
+        if code_val != 0:
+            raise RuntimeError(f"Keithley 2750 reported error: {err.strip()}")

--- a/tests/dmm/keithley/test_keithley_2750_software.py
+++ b/tests/dmm/keithley/test_keithley_2750_software.py
@@ -1,0 +1,160 @@
+"""Software tests for the Keithley 2750 front-panel DMM driver (unstable)."""
+
+from collections.abc import Iterator
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from instro.dmm.types import MeasurementFunction
+from instro.lib.transports.visa import VisaConfig
+from instro.unstable.dmm.drivers import Keithley2750
+
+
+@pytest.fixture
+def keithley_visa_cls() -> Iterator[MagicMock]:
+    with patch("instro.unstable.dmm.drivers.keithley_2750.VisaDriver", autospec=True) as driver_cls:
+        yield driver_cls
+
+
+@pytest.fixture
+def keithley_visa(keithley_visa_cls: MagicMock) -> MagicMock:
+    visa = keithley_visa_cls.return_value
+    visa.query.return_value = '0,"No error"'
+    return visa
+
+
+@pytest.fixture
+def keithley(keithley_visa_cls: MagicMock, keithley_visa: MagicMock) -> Keithley2750:
+    return Keithley2750("GPIB0::16::INSTR")
+
+
+def _writes(visa: MagicMock) -> list[str]:
+    return [c.args[0] for c in visa.write.call_args_list]
+
+
+def test_init_builds_visa_from_resource(keithley_visa_cls: MagicMock) -> None:
+    Keithley2750("GPIB0::16::INSTR")
+    keithley_visa_cls.assert_called_once_with("GPIB0::16::INSTR")
+
+
+def test_init_builds_visa_from_config(keithley_visa_cls: MagicMock) -> None:
+    config = VisaConfig(visa_resource="GPIB0::16::INSTR")
+    Keithley2750(config)
+    keithley_visa_cls.assert_called_once_with(config)
+
+
+def test_open_resets_and_sets_reading_element(keithley: Keithley2750, keithley_visa: MagicMock) -> None:
+    keithley.open()
+    keithley_visa.open.assert_called_once_with()
+    writes = _writes(keithley_visa)
+    assert writes == ["*CLS", "*RST", ":FORMat:ELEMents READing"]
+    keithley_visa.query.assert_called_once_with(":SYSTem:ERRor?")
+
+
+def test_close_delegates_to_transport(keithley: Keithley2750, keithley_visa: MagicMock) -> None:
+    keithley.close()
+    keithley_visa.close.assert_called_once_with()
+
+
+@pytest.mark.parametrize(
+    ("function", "expected"),
+    [
+        (MeasurementFunction.DC_VOLTAGE, ':FUNCtion "VOLTage:DC"'),
+        (MeasurementFunction.AC_VOLTAGE, ':FUNCtion "VOLTage:AC"'),
+        (MeasurementFunction.DC_CURRENT, ':FUNCtion "CURRent:DC"'),
+        (MeasurementFunction.AC_CURRENT, ':FUNCtion "CURRent:AC"'),
+        (MeasurementFunction.TWO_WIRE_RESISTANCE, ':FUNCtion "RESistance"'),
+        (MeasurementFunction.FOUR_WIRE_RESISTANCE, ':FUNCtion "FRESistance"'),
+    ],
+)
+def test_set_measurement_function(
+    keithley: Keithley2750, keithley_visa: MagicMock, function: MeasurementFunction, expected: str
+) -> None:
+    keithley.set_measurement_function(function)
+    assert expected in _writes(keithley_visa)
+    keithley_visa.query.assert_called_once_with(":SYSTem:ERRor?")
+
+
+def test_set_digits_unsupported(keithley: Keithley2750) -> None:
+    with pytest.raises(NotImplementedError, match="set_aperture_nplc"):
+        keithley.set_digits(6)
+
+
+def test_set_aperture_seconds_unsupported(keithley: Keithley2750) -> None:
+    with pytest.raises(NotImplementedError, match="set_aperture_nplc"):
+        keithley.set_aperture_seconds(0.1)
+
+
+def test_set_dc_voltage_nplc(keithley: Keithley2750, keithley_visa: MagicMock) -> None:
+    keithley.set_dc_voltage_nplc(2.5)
+    assert ":SENSe:VOLTage:DC:NPLCycles 2.5" in _writes(keithley_visa)
+
+
+def test_set_two_wire_resistance_nplc(keithley: Keithley2750, keithley_visa: MagicMock) -> None:
+    keithley.set_two_wire_resistance_nplc(1)
+    assert ":SENSe:RESistance:NPLCycles 1" in _writes(keithley_visa)
+
+
+def test_set_ac_voltage_nplc_sets_detector_bandwidth_first(keithley: Keithley2750, keithley_visa: MagicMock) -> None:
+    keithley.set_ac_voltage_nplc(5)
+    writes = _writes(keithley_visa)
+    assert writes == [":SENSe:VOLTage:AC:DETector:BANDwidth 300", ":SENSe:VOLTage:AC:NPLCycles 5"]
+
+
+def test_set_ac_current_nplc_sets_detector_bandwidth_first(keithley: Keithley2750, keithley_visa: MagicMock) -> None:
+    keithley.set_ac_current_nplc(1)
+    writes = _writes(keithley_visa)
+    assert writes == [":SENSe:CURRent:AC:DETector:BANDwidth 300", ":SENSe:CURRent:AC:NPLCycles 1"]
+
+
+def test_set_dc_voltage_range_auto(keithley: Keithley2750, keithley_visa: MagicMock) -> None:
+    keithley.set_dc_voltage_range(None)
+    assert ":SENSe:VOLTage:DC:RANGe:AUTO ON" in _writes(keithley_visa)
+
+
+def test_set_dc_voltage_range_manual(keithley: Keithley2750, keithley_visa: MagicMock) -> None:
+    keithley.set_dc_voltage_range(10.0)
+    writes = _writes(keithley_visa)
+    assert ":SENSe:VOLTage:DC:RANGe:AUTO OFF" in writes
+    assert ":SENSe:VOLTage:DC:RANGe:UPPer 10" in writes
+
+
+def test_set_four_wire_resistance_range_manual(keithley: Keithley2750, keithley_visa: MagicMock) -> None:
+    keithley.set_four_wire_resistance_range(1000.0)
+    writes = _writes(keithley_visa)
+    assert ":SENSe:FRESistance:RANGe:AUTO OFF" in writes
+    assert ":SENSe:FRESistance:RANGe:UPPer 1000" in writes
+
+
+@pytest.mark.parametrize(
+    "measure",
+    [
+        "measure_dc_voltage",
+        "measure_ac_voltage",
+        "measure_dc_current",
+        "measure_ac_current",
+        "measure_resistance",
+        "measure_four_wire_resistance",
+    ],
+)
+def test_measure_triggers_read_and_parses(keithley: Keithley2750, keithley_visa: MagicMock, measure: str) -> None:
+    keithley_visa.query.side_effect = ["+1.234560E-03", '0,"No error"']
+    value = getattr(keithley, measure)()
+    assert value == pytest.approx(1.23456e-3)
+    assert keithley_visa.query.call_args_list[0].args[0] == ":READ?"
+
+
+def test_check_errors_passes_on_bare_zero(keithley: Keithley2750, keithley_visa: MagicMock) -> None:
+    keithley_visa.query.return_value = '0,"No error"'
+    keithley._check_errors()
+
+
+def test_check_errors_passes_on_signed_zero(keithley: Keithley2750, keithley_visa: MagicMock) -> None:
+    keithley_visa.query.return_value = '+0,"No error"'
+    keithley._check_errors()
+
+
+def test_check_errors_raises_on_nonzero(keithley: Keithley2750, keithley_visa: MagicMock) -> None:
+    keithley_visa.query.return_value = '-113,"Undefined header"'
+    with pytest.raises(RuntimeError, match="Keithley 2750 reported error"):
+        keithley._check_errors()


### PR DESCRIPTION
Closes #193.

Front-panel DMM support for the Keithley 2750 Multimeter/Switch System: DC/AC voltage, DC/AC current, and 2- and 4-wire resistance. Switching/scan functionality is out of scope. Lands in `instro-unstable` as a new dmm subpackage subclassing the stable core `DMMDriverBase`.

- Per-function NPLC and range for all six functions (AC NPLC sets the 300 Hz detector bandwidth first, as the 2750 requires)
- `set_digits` and `set_aperture_seconds` are unsupported: `:DIGits` is display-only on this instrument and aperture is per-function, so `set_aperture_nplc` is the resolution path
- README supported-devices table updated (marked unstable)

## Testing

- Mocked-transport unit tests in `tests/dmm/keithley/test_keithley_2750_software.py` following the canonical `tests/psu/test_psu_drivers.py` pattern
- Rebased onto current main; full `tests/dmm` suite (96) and `just check` green