### PR TITLE
feat(instrument): add channel_names property

### DIFF
--- a/instro/lib/instrument.py
+++ b/instro/lib/instrument.py
@@ -335,6 +335,23 @@ class Instrument:
 
         return None
 
+    @property
+    def channel_names(self) -> tuple[str, ...]:
+        """Return an insertion-ordered snapshot of all published channel names.
+
+        Names are complete after one full daemon iteration: {name}.loop_time publishes
+        every iteration, so call get_channel("loop_time", wait_for_new_samples=True)
+        then read channel_names to ensure the complete set has arrived.
+
+        Raises:
+            RuntimeError: No background buffer; ``start()`` was not called.
+        """
+        if self._background_thread and self._background_thread.is_alive():
+            assert self._channel_buffer
+            return self._channel_buffer.channel_names
+
+        raise RuntimeError("No channel buffer exists. Ensure start() was called on this instrument.")
+
     def _background_daemon_loop(self):
         """Daemon loop: run registered functions every ``background_interval``, publish loop timing."""
         while not self._background_stop_event.is_set():

--- a/instro/lib/publishers/channel_buffer.py
+++ b/instro/lib/publishers/channel_buffer.py
@@ -183,6 +183,17 @@ class ChannelBufferPublisher(ABC):
             self._total_added_count.clear()
 
     @property
+    def channel_names(self) -> tuple[str, ...]:
+        """Return an insertion-ordered snapshot of all channel names currently in the buffer.
+
+        Names are complete after one full daemon iteration: {name}.loop_time publishes
+        every iteration, so call get_channel("loop_time", wait_for_new_samples=True)
+        then read channel_names to ensure the complete set has arrived.
+        """
+        with self._condition:
+            return tuple(self._values)
+
+    @property
     @abstractmethod
     def size_bytes(self) -> int:
         """Return the current memory in bytes."""

--- a/tests/lib/test_instrumentation.py
+++ b/tests/lib/test_instrumentation.py
@@ -104,3 +104,40 @@ def test_context_manager_closes_on_exception():
     except RuntimeError:
         pass
     assert calls == ["close"]
+
+
+def test_channel_names_raises_when_daemon_not_running():
+    instrument = Instrument(name="test")
+    try:
+        _ = instrument.channel_names
+        assert False, "Expected RuntimeError"
+    except RuntimeError as e:
+        assert "No channel buffer exists" in str(e)
+
+
+def test_channel_names_returns_empty_initially():
+    instrument = _make_publishing_instrument()
+    try:
+        instrument.start()
+        # Wait for at least one publication cycle
+        time.sleep(0.05)
+        assert isinstance(instrument.channel_names, tuple)
+        # Should have at least loop_time and daemon_work_time
+        assert len(instrument.channel_names) >= 2
+        assert "ut.loop_time" in instrument.channel_names
+        assert "ut.daemon_work_time" in instrument.channel_names
+    finally:
+        instrument.stop()
+
+
+def test_channel_names_includes_published_channels():
+    instrument = _make_publishing_instrument()
+    try:
+        instrument.start()
+        # Wait for the custom channel to be published
+        instrument.get_channel("ut.v", wait_for_new_samples=True, timeout=2.0)
+        names = instrument.channel_names
+        assert "ut.v" in names
+        assert "ut.loop_time" in names
+    finally:
+        instrument.stop()


### PR DESCRIPTION
Closes #214 

## Summary

Commit 1:

Add Instrument.channel_names and ChannelBufferPublisher.channel_names properties to discover what channels an instrument publishes without knowing names in advance. Returns an insertion-ordered tuple snapshot of channel names; raises RuntimeError if the background daemon is not running (matching get_channel behavior).

Names are complete after one full daemon iteration: loop_time publishes every iteration, so get_channel("loop_time", wait_for_new_samples=True) then read channel_names to ensure the complete set has arrived.

Adds three test cases verifying the property behavior: that it raises when the daemon is not running, returns expected channels after daemon start, and includes both infrastructure channels (loop_time, daemon_work_time) and user measurements.

Commit 2:
adds a snapshot publisher which lists ALL channels that the instrument has ever presented. Works similarly to the channel value dequeue but doesn't cache values


## Type of change

- [ ] Bug fix (`fix`)
- [x] New feature (`feat`)
- [ ] Breaking change (`feat!` / `fix!`)
- [ ] Refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] Chore / tooling (`chore`)

## Verification

_How did you verify this change works? Provide evidence the reviewer can evaluate without reproducing your setup — e.g. test output, screenshots, logs, repro steps + result. If the change is hardware-specific and you don't have the device, say so._

## Tests

- [x] Unit tests added or updated
- [ ] Existing tests cover this change
- [ ] No tests — explain why:

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(driver): add support for Keysight E36300`)
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] Documentation updated if user-facing behavior changed
- [x] Code follows the style/conventions of the surrounding code

## Notes for reviewers

_Optional — call out specific files, edge cases, or decisions you'd like eyes on._
