### PR TITLE
chore(docs): add GA4 analytics integration to docs site

### DIFF
--- a/docs/guides/docs.json
+++ b/docs/guides/docs.json
@@ -247,5 +247,10 @@
   },
   "interaction": {
     "drilldown": true
+  },
+  "integrations": {
+    "ga4": {
+      "measurementId": "G-LR7QM29GGQ"
+    }
   }
 }


### PR DESCRIPTION
Closes nominal-io/instro#248

Adds the Mintlify `integrations.ga4` block to `docs/guides/docs.json` with measurement ID `G-LR7QM29GGQ`. Mintlify injects the gtag script automatically on the production deployment.