### PR TITLE
docs(contributing): clarify targeted test coverage guidance

### DIFF
--- a/.agents/skills/add-instrument-driver/SKILL.md
+++ b/.agents/skills/add-instrument-driver/SKILL.md
@@ -15,19 +15,19 @@ over shared mixins/factories.
 ## Prerequisites — gather before writing code
 
 1. **The programming reference.** A path to a PDF/doc/HTML file, or a URL. If the
-   user hasn't provided one, ask for it — do not guess SCPI commands or API code 
+   user hasn't provided one, ask for it — do not guess SCPI commands or API code
    from model knowledge.
 2. **Vendor and model** (e.g. "Siglent SPD3303"). Confirm the exact model family
    the driver should cover; SCPI surfaces and APIs are often shared across a series.
-3. **Category.** One of `psu`, `dmm`, `eload`, `daq`, `i2c`, `modbus`, `scope`, `ethernetip`. 
+3. **Category.** One of `psu`, `dmm`, `eload`, `daq`, `i2c`, `modbus`, `scope`, `ethernetip`.
    Infer from the instrument type; confirm with the user if ambiguous.
 4. **Tracking issue + branch.** Per `AGENTS.md`, no untracked work. Confirm an
    issue exists (or create one) and branch off `main` named after it
    (e.g. `issue-142-siglent-spd-driver`).
 5. **Core vs. contrib.** Default to **core** (`instro/<category>/drivers/`) if
    the user is a maintainer, otherwise use **contrib**
-   (`packages/instro-contrib/instro/contrib/<category>/drivers/`). Some instruments 
-   only exist in **unstable** (`packages/instro-unstable/`). See `CONTRIBUTING.md` for the bar. 
+   (`packages/instro-contrib/instro/contrib/<category>/drivers/`). Some instruments
+   only exist in **unstable** (`packages/instro-unstable/`). See `CONTRIBUTING.md` for the bar.
    Ask if unclear.
 
 ## Step 1 — Extract a structured command spec from the manual
@@ -153,6 +153,13 @@ categories keep driver tests in a single top-level file (e.g. `scope` →
 to find the right file. The canonical pattern is in
 `tests/psu/test_psu_drivers.py`:
 
+- Keep tests targeted: cover each driver invariant or edge case with the least
+  necessary complexity. Do not add redundant matrices, broad helper layers, or
+  rewrites whose main effect is making tests look like candidates for shared
+  behavior. Do not add tests just to increase coverage numbers or case counts.
+  You're _almost definitely_ working on a feature/bugfix that needs test
+  coverage, make sure that the tests that you write are actually testing what
+  you think they are.
 - Patch the driver's `VisaDriver` reference with `autospec=True`:
   `patch("instro.<category>.drivers.<vendor>_<model>.VisaDriver", autospec=True)`.
 - Provide fixtures for the patched class and instance; default

--- a/.claude/skills/add-instrument-driver/SKILL.md
+++ b/.claude/skills/add-instrument-driver/SKILL.md
@@ -21,19 +21,19 @@ over shared mixins/factories.
 ## Prerequisites — gather before writing code
 
 1. **The programming reference.** A path to a PDF/doc/HTML file, or a URL. If the
-   user hasn't provided one, ask for it — do not guess SCPI commands or API code 
+   user hasn't provided one, ask for it — do not guess SCPI commands or API code
    from model knowledge.
 2. **Vendor and model** (e.g. "Siglent SPD3303"). Confirm the exact model family
    the driver should cover; SCPI surfaces and APIs are often shared across a series.
-3. **Category.** One of `psu`, `dmm`, `eload`, `daq`, `i2c`, `modbus`, `scope`, `ethernetip`. 
+3. **Category.** One of `psu`, `dmm`, `eload`, `daq`, `i2c`, `modbus`, `scope`, `ethernetip`.
    Infer from the instrument type; confirm with the user if ambiguous.
 4. **Tracking issue + branch.** Per `AGENTS.md`, no untracked work. Confirm an
    issue exists (or create one) and branch off `main` named after it
    (e.g. `issue-142-siglent-spd-driver`).
 5. **Core vs. contrib.** Default to **core** (`instro/<category>/drivers/`) if
    the user is a maintainer, otherwise use **contrib**
-   (`packages/instro-contrib/instro/contrib/<category>/drivers/`). Some instruments 
-   only exist in **unstable** (`packages/instro-unstable/`). See `CONTRIBUTING.md` for the bar. 
+   (`packages/instro-contrib/instro/contrib/<category>/drivers/`). Some instruments
+   only exist in **unstable** (`packages/instro-unstable/`). See `CONTRIBUTING.md` for the bar.
    Ask if unclear.
 
 ## Step 1 — Extract a structured command spec from the manual
@@ -159,6 +159,13 @@ categories keep driver tests in a single top-level file (e.g. `scope` →
 to find the right file. The canonical pattern is in
 `tests/psu/test_psu_drivers.py`:
 
+- Keep tests targeted: cover each driver invariant or edge case with the least
+  necessary complexity. Do not add redundant matrices, broad helper layers, or
+  rewrites whose main effect is making tests look like candidates for shared
+  behavior. Do not add tests just to increase coverage numbers or case counts.
+  You're _almost definitely_ working on a feature or bugfix that _does_ need
+  test coverage; make sure that the tests that you write are actually testing
+  what you think they are.
 - Patch the driver's `VisaDriver` reference with `autospec=True`:
   `patch("instro.<category>.drivers.<vendor>_<model>.VisaDriver", autospec=True)`.
 - Provide fixtures for the patched class and instance; default

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,6 +40,7 @@ If `just check` and `just test` both pass, CI will pass.
 - **No comments unless the *why* is non-obvious.** Don't restate what the code does.
 - **Type hints required** on all public methods. `mypy` is enforced.
 - **`ruff format` and `ruff check` are enforced.** Run `just check` before pushing.
+- **Targeted unit tests.** Cover the invariant or edge case under test with the least necessary complexity. Prefer a few high-signal tests over redundant matrices, test-only abstractions, or rewrites that manufacture shared behavior. Don't add tests just to increase coverage numbers or case counts; every test needs a real reason to exist. Bug-fix PRs (`fix(...): ...`) should usually add regression coverage or explain why no new test is practical.
 - **Scope discipline.** Keep PRs focused on the work at hand. If you find something unrelated, open a separate GitHub issue rather than expanding the PR.
 - **Docs ship with the code.** This repo contains its own docs (`README.md`, `CONTRIBUTING.md`, `docs/guides/`, `docs/reference/`, and this file). When a change is user-visible or alters conventions, update the relevant docs in the same PR: see [Documentation](#documentation) below.
 
@@ -57,7 +58,7 @@ Use `instro/psu/drivers/bk_9115.py` as the reference. The shape is:
 3. Implement `open`, `close`, and the category-required methods.
 4. Add per-driver `_write_checked` / `_check_errors` helpers if the device supports `SYST:ERR?`. Do **not** extract these to a shared mixin (see Patterns below).
 5. Register in `instro/<category>/drivers/__init__.py` (both the import and `__all__`).
-6. Add tests in `tests/<category>/test_<category>_drivers.py`. The canonical pattern is in `tests/psu/test_psu_drivers.py`: patch the driver's `VisaDriver` reference with `autospec=True`, assert wire-level commands.
+6. Add targeted tests in `tests/<category>/test_<category>_drivers.py`. The canonical pattern is in `tests/psu/test_psu_drivers.py`: patch the driver's `VisaDriver` reference with `autospec=True`, assert wire-level commands, and avoid redundant matrices, coverage-count padding, or shared helpers that obscure the behavior under test.
 
 ## How to add a community driver
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -193,6 +193,10 @@ Individual commits should follow the same Conventional Commits format. Each comm
 
 Every PR must pass `just check` and `just test`. CI will run these automatically. If you've added a new driver, ship a unit test against a mocked transport (see existing tests under `tests/psu/`, `tests/dmm/`, etc. for the pattern: patch `VisaDriver` (or whatever transport your driver composes) with `autospec=True` and assert the wire-level commands).
 
+Write unit tests to cover the invariant or edge case under test with the least necessary complexity. Prefer targeted, high-signal cases overly broad redundant matrices, heavily abstracted helpers, or rewrites whose main effect is making tests look shareable. Don't add tests simply to increase line coverage or the number of executed cases. You're going to be working features/bug-fixes that have a clear reason test, so make sure that your tests are meaningfully addressing the real needs for test coverage. Shared test helpers are fine when they remove duplication without hiding what behavior each test proves. A large, complicated test suite that repeats the same assertion in different shapes is almost as unhelpful as no coverage.
+
+Bug fixes should usually add regression coverage. A PR titled `fix(...): ...` should include at least one new test that would have failed before the fix, or a convincing explanation in the PR description for why new coverage is not practical or useful.
+
 ### Documentation
 
 Docs live in this repo, so they ship in the same PR as the code change. If your change is user-visible or alters how contributors work, update the relevant files on the same branch:


### PR DESCRIPTION
## Summary

Clarifies that tests should target real invariants and edge cases instead of broad redundant matrices, coverage-count padding, or helper layers that hide the behavior being proved.

Mirrors that guidance across contributor docs, agent instructions, and both add-instrument-driver skill copies so generated driver work follows the same testing expectations.

## Type of change

- [ ] Bug fix (`fix`)
- [ ] New feature (`feat`)
- [ ] Breaking change (`feat!` / `fix!`)
- [ ] Refactor (`refactor`)
- [x] Documentation (`docs`)
- [ ] Chore / tooling (`chore`)

## Verification

- `git diff --check origin/main...HEAD`
- `just check`

## Tests

- [ ] Unit tests added or updated
- [ ] Existing tests cover this change
- [x] No tests — documentation-only contributor guidance change.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(driver): add support for Keysight E36300`)
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] Documentation updated if user-facing behavior changed
- [x] Code follows the style/conventions of the surrounding code

## Notes for reviewers

The same guidance is intentionally duplicated in the Claude and Codex add-instrument-driver skills.