### PR TITLE
docs(reference): auto-generate vendor driver lists via mkdocs-macros

### DIFF
--- a/docs/reference/main.py
+++ b/docs/reference/main.py
@@ -1,0 +1,37 @@
+"""mkdocs-macros module: auto-generated vendor driver lists for the Instruments pages."""
+
+import importlib
+import inspect
+from pathlib import Path
+
+REPO_BLOB_URL = "https://github.com/nominal-io/instro/blob/main"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _driver_classes(category: str) -> list[type]:
+    module = importlib.import_module(f"instro.{category}.drivers")
+    base = next(getattr(module, name) for name in module.__all__ if name.endswith("DriverBase"))
+    return [
+        obj
+        for name in module.__all__
+        if inspect.isclass(obj := getattr(module, name)) and obj is not base and issubclass(obj, base)
+    ]
+
+
+def driver_list(category: str) -> str:
+    """Render one heading + one-line summary per concrete driver in instro.<category>.drivers."""
+    classes = _driver_classes(category)
+    if not classes:
+        return "*No vendor drivers ship in the core `instro` package for this category.*"
+
+    entries = []
+    for cls in classes:
+        summary = (inspect.getdoc(cls) or "").strip().splitlines()[:1]
+        source = Path(inspect.getfile(cls)).resolve().relative_to(REPO_ROOT)
+        link = f"{REPO_BLOB_URL}/{source}"
+        entries.append(f"### {cls.__name__}\n\n{summary[0] if summary else ''} ([source]({link}))")
+    return "\n\n".join(entries)
+
+
+def define_env(env):
+    env.macro(driver_list)

--- a/docs/reference/mkdocs.yml
+++ b/docs/reference/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: "instro SDK"
 repo_url: "https://github.com/nominal-io/instro"
 repo_name: "nominal-io/instro"
 site_dir: site
-watch: [mkdocs.yml, ../../README.md, ../../CHANGELOG.md, ../../instro, ../../packages]
+watch: [mkdocs.yml, main.py, ../../README.md, ../../CHANGELOG.md, ../../instro, ../../packages]
 copyright: Copyright &copy; Nominal, Inc.
 edit_uri: edit/main/docs/reference/
 docs_dir: src
@@ -103,6 +103,7 @@ markdown_extensions:
 
 plugins:
   - search
+  - macros
   - mkdocstrings:
       handlers:
         python:

--- a/docs/reference/src/instruments/daq.md
+++ b/docs/reference/src/instruments/daq.md
@@ -26,8 +26,4 @@
 
 ## Vendor Drivers
 
-### Keysight 34980A
-
-::: instro.daq.drivers.keysight_34980a
-    options:
-      heading_level: 4
+{{ driver_list("daq") }}

--- a/docs/reference/src/instruments/dmm.md
+++ b/docs/reference/src/instruments/dmm.md
@@ -14,14 +14,4 @@
 
 ## Vendor Drivers
 
-### Keithley 2400
-
-::: instro.dmm.drivers.keithley_2400
-    options:
-      heading_level: 4
-
-### Agilent 34401A
-
-::: instro.dmm.drivers.agilent_a34401a
-    options:
-      heading_level: 4
+{{ driver_list("dmm") }}

--- a/docs/reference/src/instruments/eload.md
+++ b/docs/reference/src/instruments/eload.md
@@ -14,8 +14,4 @@
 
 ## Vendor Drivers
 
-### BK 85XXB
-
-::: instro.eload.drivers.bk_85xxb
-    options:
-      heading_level: 4
+{{ driver_list("eload") }}

--- a/docs/reference/src/instruments/i2c.md
+++ b/docs/reference/src/instruments/i2c.md
@@ -11,3 +11,7 @@
 ## Driver Interface
 
 ::: instro.i2c.I2CDriverBase
+
+## Vendor Drivers
+
+{{ driver_list("i2c") }}

--- a/docs/reference/src/instruments/psu.md
+++ b/docs/reference/src/instruments/psu.md
@@ -10,44 +10,4 @@
 
 ## Vendor Drivers
 
-### BK Precision 9115 (Single Channel)
-
-::: instro.psu.drivers.bk_9115
-    options:
-      heading_level: 4
-
-### BK Precision 914X (Multi Channel)
-
-::: instro.psu.drivers.bk_914x
-    options:
-      heading_level: 4
-
-### Keysight E36100
-
-::: instro.psu.drivers.keysight_e36100
-    options:
-      heading_level: 4
-
-### Rigol DP800
-
-::: instro.psu.drivers.rigol_dp800
-    options:
-      heading_level: 4
-
-### Siglent SPD3303
-
-::: instro.psu.drivers.siglent_spd3303
-    options:
-      heading_level: 4
-
-### TDK Lambda Genesys
-
-::: instro.psu.drivers.tdk_lambda_genesys
-    options:
-      heading_level: 4
-
-### Simulated
-
-::: instro.psu.drivers.simulated
-    options:
-      heading_level: 4
+{{ driver_list("psu") }}

--- a/docs/reference/src/instruments/scope.md
+++ b/docs/reference/src/instruments/scope.md
@@ -14,20 +14,4 @@
 
 ## Vendor Drivers
 
-### Keysight 1200X
-
-::: instro.scope.drivers.keysight_1200x
-    options:
-      heading_level: 4
-
-### Siglent SDS1000X-E
-
-::: instro.scope.drivers.siglent_sds1000x_e
-    options:
-      heading_level: 4
-
-### Tektronix 2 Series MSO
-
-::: instro.scope.drivers.tektronix_2series
-    options:
-      heading_level: 4
+{{ driver_list("scope") }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,6 +69,7 @@ dev = [
     "mkdocs-material>=9.7.0",
     "mkdocstrings>=0.30.1",
     "mkdocstrings-python>=1.19.0",
+    "mkdocs-macros-plugin>=1.3.7",
     "types-requests>=2.32.4.20250913",
     "types-pyserial>=3.0",
     "instro-ethernetip",

--- a/uv.lock
+++ b/uv.lock
@@ -319,7 +319,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -437,6 +437,15 @@ wheels = [
 ]
 
 [[package]]
+name = "hjson"
+version = "3.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/e5/0b56d723a76ca67abadbf7fb71609fb0ea7e6926e94fcca6c65a85b36a0e/hjson-3.1.0.tar.gz", hash = "sha256:55af475a27cf83a7969c808399d7bccdec8fb836a07ddbd574587593b9cdcf75", size = 40541, upload-time = "2022-08-13T02:53:01.919Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/7f/13cd798d180af4bf4c0ceddeefba2b864a63c71645abc0308b768d67bb81/hjson-3.1.0-py3-none-any.whl", hash = "sha256:65713cdcf13214fb554eb8b4ef803419733f4f5e551047c9b711098ab7186b89", size = 54018, upload-time = "2022-08-13T02:52:59.899Z" },
+]
+
+[[package]]
 name = "idna"
 version = "3.18"
 source = { registry = "https://pypi.org/simple" }
@@ -474,7 +483,7 @@ wheels = [
 
 [[package]]
 name = "instro"
-version = "1.0.1"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastavro", extra = ["snappy"] },
@@ -536,6 +545,7 @@ dev = [
     { name = "instro-ethernetip" },
     { name = "instro-unstable" },
     { name = "mkdocs" },
+    { name = "mkdocs-macros-plugin" },
     { name = "mkdocs-material" },
     { name = "mkdocstrings" },
     { name = "mkdocstrings-python" },
@@ -589,6 +599,7 @@ dev = [
     { name = "instro-ethernetip", editable = "packages/instro-ethernetip" },
     { name = "instro-unstable", editable = "packages/instro-unstable" },
     { name = "mkdocs", specifier = ">=1.6.1" },
+    { name = "mkdocs-macros-plugin", specifier = ">=1.3.7" },
     { name = "mkdocs-material", specifier = ">=9.7.0" },
     { name = "mkdocstrings", specifier = ">=0.30.1" },
     { name = "mkdocstrings-python", specifier = ">=1.19.0" },
@@ -686,7 +697,7 @@ requires-dist = [
 
 [[package]]
 name = "instro-unstable"
-version = "1.0.0"
+version = "1.1.0"
 source = { editable = "packages/instro-unstable" }
 dependencies = [
     { name = "instro" },
@@ -962,6 +973,27 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/98/f5/ed29cd50067784976f25ed0ed6fcd3c2ce9eb90650aa3b2796ddf7b6870b/mkdocs_get_deps-0.2.0.tar.gz", hash = "sha256:162b3d129c7fad9b19abfdcb9c1458a651628e4b1dea628ac68790fb3061c60c", size = 10239, upload-time = "2023-11-20T17:51:09.981Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9f/d4/029f984e8d3f3b6b726bd33cafc473b75e9e44c0f7e80a5b29abc466bdea/mkdocs_get_deps-0.2.0-py3-none-any.whl", hash = "sha256:2bf11d0b133e77a0dd036abeeb06dec8775e46efa526dc70667d8863eefc6134", size = 9521, upload-time = "2023-11-20T17:51:08.587Z" },
+]
+
+[[package]]
+name = "mkdocs-macros-plugin"
+version = "1.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hjson" },
+    { name = "jinja2" },
+    { name = "mkdocs" },
+    { name = "packaging" },
+    { name = "pathspec" },
+    { name = "python-dateutil" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "super-collections" },
+    { name = "termcolor" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/92/15/e6a44839841ebc9c5872fa0e6fad1c3757424e4fe026093b68e9f386d136/mkdocs_macros_plugin-1.5.0.tar.gz", hash = "sha256:12aa45ce7ecb7a445c66b9f649f3dd05e9b92e8af6bc65e4acd91d26f878c01f", size = 37730, upload-time = "2025-11-13T08:08:55.545Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/62/9fffba5bb9ed3d31a932ad35038ba9483d59850256ee0fea7f1187173983/mkdocs_macros_plugin-1.5.0-py3-none-any.whl", hash = "sha256:c10fabd812bf50f9170609d0ed518e54f1f0e12c334ac29141723a83c881dd6f", size = 44626, upload-time = "2025-11-13T08:08:53.878Z" },
 ]
 
 [[package]]
@@ -1888,12 +1920,33 @@ wheels = [
 ]
 
 [[package]]
+name = "super-collections"
+version = "0.6.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "hjson" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/de/a0c3d1244912c260638f0f925e190e493ccea37ecaea9bbad7c14413b803/super_collections-0.6.2.tar.gz", hash = "sha256:0c8d8abacd9fad2c7c1c715f036c29f5db213f8cac65f24d45ecba12b4da187a", size = 31315, upload-time = "2025-09-30T00:37:08.067Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/43/47c7cf84b3bd74a8631b02d47db356656bb8dff6f2e61a4c749963814d0d/super_collections-0.6.2-py3-none-any.whl", hash = "sha256:291b74d26299e9051d69ad9d89e61b07b6646f86a57a2f5ab3063d206eee9c56", size = 16173, upload-time = "2025-09-30T00:37:07.104Z" },
+]
+
+[[package]]
 name = "tabulate"
 version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ec/fe/802052aecb21e3797b8f7902564ab6ea0d60ff8ca23952079064155d1ae1/tabulate-0.9.0.tar.gz", hash = "sha256:0095b12bf5966de529c0feb1fa08671671b3368eec77d7ef7ab114be2c068b3c", size = 81090, upload-time = "2022-10-06T17:21:48.54Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/40/44/4a5f08c96eb108af5cb50b41f76142f0afa346dfa99d5296fe7202a11854/tabulate-0.9.0-py3-none-any.whl", hash = "sha256:024ca478df22e9340661486f85298cff5f6dcdba14f3813e8830015b9ed1948f", size = 35252, upload-time = "2022-10-06T17:21:44.262Z" },
+]
+
+[[package]]
+name = "termcolor"
+version = "3.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/46/79/cf31d7a93a8fdc6aa0fbb665be84426a8c5a557d9240b6239e9e11e35fc5/termcolor-3.3.0.tar.gz", hash = "sha256:348871ca648ec6a9a983a13ab626c0acce02f515b9e1983332b17af7979521c5", size = 14434, upload-time = "2025-12-29T12:55:21.882Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/33/d1/8bb87d21e9aeb323cc03034f5eaf2c8f69841e40e4853c2627edf8111ed3/termcolor-3.3.0-py3-none-any.whl", hash = "sha256:cf642efadaf0a8ebbbf4bc7a31cec2f9b5f21a9f726f4ccbb08192c9c26f43a5", size = 7734, upload-time = "2025-12-29T12:55:20.718Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The per-vendor driver blocks were maintained by hand, and already out of sync with the code (e.g. psu.md was missing KeysightN5700).

Replace with a driver_list() macro (docs/reference/main.py) that inspects `instro.<category>.drivers.__all__` to build a list dynamically.

Perhaps closes https://github.com/nominal-io/instro/issues/215