### PR TITLE
fix(pkg): add instro/__init__.py so tab completion works

### DIFF
--- a/instro/__init__.py
+++ b/instro/__init__.py
@@ -1,0 +1,13 @@
+"""Typed Python API for test-and-measurement instruments."""
+
+# Let workspace packages (instro-contrib, instro-unstable, instro-ethernetip, ...)
+# contribute top-level subpackages under instro.* — without this, turning instro
+# into a regular package below would pin its __path__ to this directory alone
+# and hide those workspace trees. The exact spelling below (rather than
+# `from pkgutil import extend_path; ...`) matters: griffe/mkdocstrings pattern-match
+# this specific idiom to keep treating instro as a mergeable namespace for API docs.
+__path__ = __import__("pkgutil").extend_path(__path__, __name__)
+
+from instro import cli, daq, dmm, eload, i2c, lib, modbus, psu, scope
+
+__all__ = ["cli", "daq", "dmm", "eload", "i2c", "lib", "modbus", "psu", "scope"]


### PR DESCRIPTION
instro had no `__init__.py`, making it an implicit namespace package without attributes until each subpackage was explicitly imported. This meant that `import instro; instro.<TAB>` found no completions in IPython.

Add an `__init__.py` that eagerly imports the always-present subpackages (cli, daq, dmm, etc.).
It uses `pkgutil`'s `extend_path` to keep the namespace packages working.

Needed to be quite careful exactly how `extend_path` was called, because griffe recognizes namespace packages via regex (!).

I suspect many engineers will want to explore this package from the Python terminal / IPython, so I feel like this is an important usability improvement.