### PR TITLE
docs(reference): render vendor drivers and single-source device table

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ pip install "instro[nidaq,contrib]"
 
 ## Supported devices
 
+<!-- --8<-- [start:supported-devices] -->
 | Category | Class | Vendors |
 |---|---|---|
 | Power Supply | `InstroPSU` | B&K Precision (9115, 914X), Keysight (E36100-series), Rigol (DP800-series), Siglent (SPD3303), TDK Lambda (Genesys), simulated |
@@ -96,6 +97,7 @@ pip install "instro[nidaq,contrib]"
 | I2C | `I2CInterface` | Total Phase Aardvark |
 | Modbus | `ModbusDevice` | Any Modbus TCP / RTU device |
 | EtherNet/IP | `EtherNetIPDevice` | Allen-Bradley / CompactLogix-class PLCs |
+<!-- --8<-- [end:supported-devices] -->
 
 Don't see your vendor? Drivers the maintainers can't test directly land in [`instro-contrib`](./packages/instro-contrib/).
 Install them with `instro[contrib]`. See [`CONTRIBUTING.md`](./CONTRIBUTING.md) for the verification expectations.

--- a/docs/guides/instrumentation/overview.mdx
+++ b/docs/guides/instrumentation/overview.mdx
@@ -199,15 +199,15 @@ This makes it easy to ensure measurements and state changes are consistently rec
 
 ### Instrument Types
 
-These are the instrument types available out of the box.
+These are the instrument types available out of the box. The [SDK reference](https://nominal-io.github.io/instro/instruments/) documents the full API for each type, including the vendor driver classes.
 
-- `InstroPSU`: programmable Power Supplies
-- `InstroDAQ`: data Acquisition devices
-- `InstroELoad`: electronic Loads
-- `InstroDMM`: digital Multimeters
+- `InstroPSU`: programmable power supply units
+- `InstroDAQ`: data acquisition systems
+- `InstroELoad`: electronic loads
+- `InstroDMM`: digital multimeters
 - `InstroScope`: oscilloscopes
-- `I2CInterface`: I2C master for communicating to peripherals on an I2C bus
-- `ModbusDevice`: Modbus register/coil device (TCP or RTU)
+- `I2CInterface`: I2C bus communication devices
+- `ModbusDevice`: Modbus register/coil devices (TCP or RTU)
 - `EtherNetIPDevice`: EtherNet/IP and CIP devices, via `instro.ethernetip` (install with `instro[ethernetip]`)
 
 ### Drivers
@@ -220,6 +220,7 @@ These are the vendor/model-specific drivers available out of the box.
   - Siglent
   - Rigol
   - TDK Lambda
+  - Simulated (no hardware required)
 - `InstroDAQ`
   - National Instruments (NI)
   - LabJack T-Series
@@ -231,6 +232,7 @@ These are the vendor/model-specific drivers available out of the box.
   - Total Phase Aardvark
 - `InstroDMM`
   - Keithley 2400
+  - Keithley 2750 (unstable)
   - Agilent/HP/Keysight 34401A
 - `InstroScope`
   - Keysight 1200X

--- a/docs/reference/mkdocs.yml
+++ b/docs/reference/mkdocs.yml
@@ -106,6 +106,11 @@ plugins:
   - mkdocstrings:
       handlers:
         python:
+          paths:
+            - ../../packages/instro-daq-ni
+            - ../../packages/instro-daq-labjack
+            - ../../packages/instro-daq-mcc
+            - ../../packages/instro-i2c-aardvark
           inventories:
             - https://docs.python.org/3/objects.inv
           options:

--- a/docs/reference/src/index.md
+++ b/docs/reference/src/index.md
@@ -3,6 +3,9 @@
 The `instro` SDK provides a unified Python interface for controlling lab instruments,
 collecting measurements, and publishing data to [Nominal](https://nominal.io).
 
+This site is the API reference. For installation, quickstarts, and per-instrument
+guides, see the [instro documentation](https://instro.nominal.io).
+
 ## Overview
 
 The SDK is organized into several key components:
@@ -13,7 +16,8 @@ The SDK is organized into several key components:
 
 - **Instruments**: High-level, vendor-agnostic interfaces for common instrument types:
   [DAQ](instruments/daq.md), [DMM](instruments/dmm.md), [PSU](instruments/psu.md),
-  [Electronic Load](instruments/eload.md), and [I2C](instruments/i2c.md).
+  [Electronic Load](instruments/eload.md), [Scope](instruments/scope.md), and
+  [I2C](instruments/i2c.md).
 
 - **Protocols**: Config-driven clients for direct hardware communication via standard
   wire protocols: [Modbus](protocols/modbus.md) and
@@ -31,4 +35,5 @@ The SDK is organized into several key components:
 | Section | Description |
 |---------|-------------|
 | [Library](reference/instrument.md) | `Instrument`, `Measurement`, `Command`, and base types |
+| [User guides](https://instro.nominal.io) | Installation, quickstarts, and per-instrument guides |
 | [Changelog](changelog.md) | Release history and version changes |

--- a/docs/reference/src/instruments/daq.md
+++ b/docs/reference/src/instruments/daq.md
@@ -1,5 +1,7 @@
 # DAQ (Data Acquisition)
 
+Errors raised by these methods are documented in [Exceptions](../reference/exceptions.md).
+
 ## Interface
 
 ::: instro.daq.InstroDAQ
@@ -29,5 +31,23 @@
 ### Keysight 34980A
 
 ::: instro.daq.drivers.keysight_34980a
+    options:
+      heading_level: 4
+
+### NI-DAQmx
+
+::: instro.daq.drivers.ni.nidaq
+    options:
+      heading_level: 4
+
+### LabJack T-series
+
+::: instro.daq.drivers.labjack.t_series
+    options:
+      heading_level: 4
+
+### MCC USB-series
+
+::: instro.daq.drivers.mcc.mccdaq
     options:
       heading_level: 4

--- a/docs/reference/src/instruments/dmm.md
+++ b/docs/reference/src/instruments/dmm.md
@@ -1,5 +1,7 @@
 # DMM (Digital Multimeter)
 
+Errors raised by these methods are documented in [Exceptions](../reference/exceptions.md).
+
 ## Interface
 
 ::: instro.dmm.InstroDMM

--- a/docs/reference/src/instruments/eload.md
+++ b/docs/reference/src/instruments/eload.md
@@ -1,5 +1,7 @@
 # Electronic Load
 
+Errors raised by these methods are documented in [Exceptions](../reference/exceptions.md).
+
 ## Interface
 
 ::: instro.eload.InstroELoad

--- a/docs/reference/src/instruments/i2c.md
+++ b/docs/reference/src/instruments/i2c.md
@@ -1,5 +1,7 @@
 # I2C
 
+Errors raised by these methods are documented in [Exceptions](../reference/exceptions.md).
+
 ## Interface
 
 ::: instro.i2c.I2CInterface
@@ -11,3 +13,11 @@
 ## Driver Interface
 
 ::: instro.i2c.I2CDriverBase
+
+## Vendor Drivers
+
+### Total Phase Aardvark
+
+::: instro.i2c.drivers.totalphase.aardvark
+    options:
+      heading_level: 4

--- a/docs/reference/src/instruments/index.md
+++ b/docs/reference/src/instruments/index.md
@@ -13,4 +13,15 @@ instruments. Each instrument type defines a standard API that works across multi
 | [`I2CInterface`](i2c.md) | I2C bus communication devices |
 
 Each instrument page includes the interface, configuration types, driver base classes,
-and vendor-specific driver implementations.
+and vendor-specific driver implementations. Errors raised by instrument methods are
+documented in [Exceptions](../reference/exceptions.md).
+
+## Supported devices
+
+The table below is included verbatim from the repository README, so the two can't drift.
+
+--8<-- "README.md:supported-devices"
+
+The Modbus and EtherNet/IP rows are covered under [Protocols](../protocols/index.md).
+Community-contributed drivers are documented in the
+[instro-contrib guide](https://instro.nominal.io/instrumentation/contrib) rather than this reference.

--- a/docs/reference/src/instruments/psu.md
+++ b/docs/reference/src/instruments/psu.md
@@ -1,5 +1,7 @@
 # PSU (Power Supply Unit)
 
+Errors raised by these methods are documented in [Exceptions](../reference/exceptions.md).
+
 ## Interface
 
 ::: instro.psu.InstroPSU

--- a/docs/reference/src/instruments/scope.md
+++ b/docs/reference/src/instruments/scope.md
@@ -1,5 +1,7 @@
 # Scope (Oscilloscope)
 
+Errors raised by these methods are documented in [Exceptions](../reference/exceptions.md).
+
 ## Interface
 
 ::: instro.scope.InstroScope


### PR DESCRIPTION
Closes #215

## Summary

Makes the API reference (nominal-io.github.io/instro) complete and drift-proof, per the plan in #215:

1. **Render vendor drivers** — `instruments/daq.md` now renders the NI-DAQmx, LabJack T-series, and MCC drivers; `instruments/i2c.md` renders the Aardvark driver. mkdocstrings gets `paths:` entries pointing at the `packages/*` source trees so griffe reads them statically (the docs build can't install the vendor packages; `mcculw` is Windows-only).
2. **Single-source the supported-devices table** — the README table is wrapped in `--8<--` snippet markers and included verbatim in `instruments/index.md`. One table, two renderings, no drift.
3. **Cross-link the two doc sites** — the reference index links to instro.nominal.io; the guides' overview links to the reference. Reconciled the instrument-types list in `overview.mdx` in the same pass.
4. **Exceptions discoverability** — each instrument page opens with a link to the existing `reference/exceptions.md` page. No nav restructure.

Contrib drivers stay out of the reference; the contrib guide page remains their definitive home.

## Type of change

- [ ] Bug fix (`fix`)
- [ ] New feature (`feat`)
- [ ] Breaking change (`feat!` / `fix!`)
- [ ] Refactor (`refactor`)
- [x] Documentation (`docs`)
- [ ] Chore / tooling (`chore`)

## Verification

Built the site locally with the same command CI uses (`uv run mkdocs build --config-file docs/reference/mkdocs.yml`) on a clean worktree of this branch:

- Build succeeds; only pre-existing warnings (griffe `**kwargs` annotations, autorefs duplicate anchors) plus a local-only SSL error fetching the Python objects inventory.
- Rendered `instruments/daq/index.html` contains the NI/LabJack/MCC driver classes; `instruments/i2c/index.html` contains the Aardvark driver.
- The supported-devices table renders in `instruments/index.html` via the README snippet include.
- The Exceptions link renders on all six instrument pages.

## Tests

- [ ] Unit tests added or updated
- [ ] Existing tests cover this change
- [x] No tests — explain why: docs-only change; verified via the mkdocs build above.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(driver): add support for Keysight E36300`)
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] Documentation updated if user-facing behavior changed
- [x] Code follows the style/conventions of the surrounding code

## Notes for reviewers

The mkdocstrings `paths:` approach means vendor-driver docs are read statically from source — if a vendor package's module layout moves, the reference build will warn rather than fail. `main`'s new `instruments.mdx` landing page (#244) already links to the reference pages this PR fills in, so the two changes compose.