### PR TITLE
feat(dmm): add simulated DMM driver and sim server

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ pip install "instro[nidaq,contrib]"
 | Category | Class | Vendors |
 |---|---|---|
 | Power Supply | `InstroPSU` | B&K Precision (9115, 914X), Keysight (E36100-series), Rigol (DP800-series), Siglent (SPD3303), TDK Lambda (Genesys), simulated |
-| Multimeter | `InstroDMM` | Agilent 34401A, Keithley 2400, Keithley 2750 (unstable) |
+| Multimeter | `InstroDMM` | Agilent 34401A, Keithley 2400, Keithley 2750 (unstable), simulated |
 | Electronic Load | `InstroELoad` | B&K Precision (85xxB-series) |
 | Oscilloscope | `InstroScope` | Keysight (1200X-series), Tektronix (2-series), Siglent (SDS1000X-E) |
 | DAQ | `InstroDAQ` | Keysight 34980A, NI-DAQmx, LabJack T-series, MCC USB-series |

--- a/docs/guides/docs.json
+++ b/docs/guides/docs.json
@@ -55,7 +55,14 @@
                 ]
               },
               "instrumentation/eload",
-              "instrumentation/dmm",
+              {
+                "group": "Multimeter (DMM)",
+                "expanded": true,
+                "pages": [
+                  "instrumentation/dmm",
+                  "instrumentation/dmm-simulator"
+                ]
+              },
               "instrumentation/daq",
               "instrumentation/oscilloscope"
             ]

--- a/docs/guides/instrumentation/dmm-simulator.mdx
+++ b/docs/guides/instrumentation/dmm-simulator.mdx
@@ -1,0 +1,103 @@
+---
+title: DMM simulator
+description: Run and program the bundled SCPI digital-multimeter simulator
+---
+
+# DMM simulator
+
+The DMM simulator is a local SCPI server for development, tests, and demos. It listens on a TCP socket and exposes a digital-multimeter command set: function switching plus the five primary measurements (DC/AC voltage, DC/AC current, and two-wire resistance). Each function measures a configurable stimulus value returned with Gaussian noise, so repeated reads look like a real bench instrument.
+
+Unlike the [PSU simulator](/instrumentation/psu-simulator), the DMM simulator is headless: there is no terminal UI. Set stimulus values with CLI flags at startup, or through the Python API when embedding the simulator in tests.
+
+## Quickstart
+
+Start the simulator in one terminal:
+
+```bash
+python -m instro.dmm.scpi_sim_server
+```
+
+It binds to `127.0.0.1:5026` by default. If you are working from a source checkout, run the same command through `uv`:
+
+```bash
+uv run python -m instro.dmm.scpi_sim_server
+```
+
+Connect from another terminal or script with the `SimulatedDMM` driver. This small Python client opens an `InstroDMM`, switches functions, and reads measurements:
+
+```python
+from instro.dmm import InstroDMM, MeasurementFunction
+from instro.dmm.drivers import SimulatedDMM
+
+
+with InstroDMM(
+    name="bench_dmm",
+    driver=SimulatedDMM("TCPIP0::127.0.0.1::5026::SOCKET"),
+) as dmm:
+    dmm.set_measurement_function(MeasurementFunction.DC_VOLTAGE)
+    voltage = dmm.read()
+    print(f"V: {voltage.latest:.4f} V")
+
+    dmm.set_measurement_function(MeasurementFunction.TWO_WIRE_RESISTANCE)
+    resistance = dmm.read()
+    print(f"R: {resistance.latest:.1f} ohm")
+```
+
+Use CLI flags to change the bind address, port, or the stimulus each function measures:
+
+```bash
+python -m instro.dmm.scpi_sim_server --port 5026 --dc-voltage 3.3 --resistance 4700
+```
+
+## Stimulus model
+
+The stimulus is the simulator's stand-in for the physical quantity on the probes (the DMM analog of the PSU simulator's load model). Each measurement function has one stimulus value, and every measurement returns that value with Gaussian noise (±0.5% at 3 standard deviations).
+
+| Function | CLI flag | Default |
+| --- | --- | --- |
+| DC voltage | `--dc-voltage` | `1.25` V |
+| AC voltage | `--ac-voltage` | `0.5` V |
+| DC current | `--dc-current` | `0.1` A |
+| AC current | `--ac-current` | `0.05` A |
+| Resistance | `--resistance` | `1000` Ω |
+
+When embedding the simulator in Python (for example in tests), construct the server in-process and set stimulus values at runtime:
+
+```python
+from instro.dmm.scpi_sim_server import (
+    FUNCTION_RESISTANCE,
+    SimulatedDMM,
+    SimulatedDMMServer,
+)
+
+sim = SimulatedDMM()
+server = SimulatedDMMServer(sim, port=0)  # port 0 = pick a free port
+server.start()
+print(f"TCPIP0::127.0.0.1::{server.port}::SOCKET")
+
+sim.set_stimulus(FUNCTION_RESISTANCE, 4700.0)  # change what the "probes" see
+
+# ... drive it with SimulatedDMM / InstroDMM ...
+
+server.shutdown()
+```
+
+Stimulus values persist across `*RST`: reset returns the instrument state (active function, error queue) to defaults, but the simulated physical world stays put.
+
+## Programming guide
+
+Brackets mark optional SCPI path components. For example, `[SENSe:]FUNCtion` accepts `FUNC`, `FUNCTION`, and `SENS:FUNC`. Keywords match in short or long form, in any case.
+
+| Command | Functionality |
+| --- | --- |
+| `*IDN?` | Returns `NOMINAL,SIMULATED_DMM,000001,1.0`. |
+| `*RST` | Resets the active function to DC voltage and clears the error queue. Stimulus values are preserved. |
+| `*CLS` | Clears the error queue. |
+| `SYSTem:ERRor?` | Pops the oldest queued error, or `0,"No error"`. |
+| `[SENSe:]FUNCtion "<function>"` | Sets the active function: `VOLT:DC`, `VOLT:AC`, `CURR:DC`, `CURR:AC`, or `RES`. Bare `VOLT`/`CURR` select DC. Quotes optional. |
+| `[SENSe:]FUNCtion?` | Returns the active function, quoted (e.g. `"VOLT:DC"`). |
+| `CONFigure:VOLTage[:DC]` | Sets the active function to DC voltage. Same pattern for `:AC`, `CURRent[:DC]`, `CURRent:AC`, and `RESistance`. |
+| `MEASure:VOLTage[:DC]?` | Switches to the function and returns a noisy measurement of its stimulus. Same pattern for the other four functions. |
+| `READ?` | Returns a noisy measurement using the active function. |
+
+Unknown headers queue `-113,"Undefined header"`; an unknown function name queues `-224,"Illegal parameter value"`. The `SimulatedDMM` driver checks `SYST:ERR?` after every transaction and raises on any queued error.

--- a/docs/guides/instrumentation/dmm.mdx
+++ b/docs/guides/instrumentation/dmm.mdx
@@ -11,6 +11,7 @@ description: Using InstroDMM for SCPI-based digital multimeters
 
 - **Agilent / HP / Keysight**: 34401A and compatible DMMs via SCPI/VISA (`Agilent34401A`)
 - **Keithley**: 2400 SourceMeter, measurement-only mode (`Keithley2400`)
+- **Simulated**: no hardware required; pairs with the bundled [DMM simulator](/instrumentation/dmm-simulator) (`SimulatedDMM`)
 
 If your vendor or model is not listed, see [Custom Driver Development](#custom-driver-development) below.
 

--- a/docs/guides/instrumentation/overview.mdx
+++ b/docs/guides/instrumentation/overview.mdx
@@ -232,6 +232,7 @@ These are the vendor/model-specific drivers available out of the box.
 - `InstroDMM`
   - Keithley 2400
   - Agilent/HP/Keysight 34401A
+  - Simulated (no hardware required)
 - `InstroScope`
   - Keysight 1200X
   - Tektronix 2-Series

--- a/docs/reference/src/instruments/dmm.md
+++ b/docs/reference/src/instruments/dmm.md
@@ -25,3 +25,9 @@
 ::: instro.dmm.drivers.agilent_a34401a
     options:
       heading_level: 4
+
+### Simulated
+
+::: instro.dmm.drivers.simulated
+    options:
+      heading_level: 4

--- a/instro/dmm/drivers/__init__.py
+++ b/instro/dmm/drivers/__init__.py
@@ -3,5 +3,6 @@
 from instro.dmm import DMMDriverBase
 from instro.dmm.drivers.agilent_a34401a import Agilent34401A
 from instro.dmm.drivers.keithley_2400 import Keithley2400
+from instro.dmm.drivers.simulated import SimulatedDMM
 
-__all__ = ["DMMDriverBase", "Agilent34401A", "Keithley2400"]
+__all__ = ["DMMDriverBase", "Agilent34401A", "Keithley2400", "SimulatedDMM"]

--- a/instro/dmm/drivers/simulated.py
+++ b/instro/dmm/drivers/simulated.py
@@ -1,0 +1,63 @@
+"""Simulated DMM driver."""
+
+from instro.dmm import DMMDriverBase
+from instro.dmm.types import MeasurementFunction
+from instro.lib.transports.visa import VisaConfig, VisaDriver
+
+_FUNCTION_NAMES = {
+    MeasurementFunction.DC_VOLTAGE: "VOLT:DC",
+    MeasurementFunction.AC_VOLTAGE: "VOLT:AC",
+    MeasurementFunction.DC_CURRENT: "CURR:DC",
+    MeasurementFunction.AC_CURRENT: "CURR:AC",
+    MeasurementFunction.TWO_WIRE_RESISTANCE: "RES",
+}
+
+
+class SimulatedDMM(DMMDriverBase):
+    """Client for the in-process simulated DMM SCPI server."""
+
+    def __init__(self, visa_resource: str | VisaConfig) -> None:
+        self._visa = VisaDriver(visa_resource)
+
+    def open(self) -> None:
+        self._visa.open()
+
+    def close(self) -> None:
+        self._visa.close()
+
+    def set_measurement_function(self, function: MeasurementFunction) -> None:
+        name = _FUNCTION_NAMES.get(function)
+        if name is None:
+            raise NotImplementedError(f"SimulatedDMM does not support {function.name}.")
+        self._write_checked(f'FUNC "{name}"')
+
+    def measure_dc_voltage(self) -> float:
+        return self._query_checked_float("MEAS:VOLT:DC?")
+
+    def measure_ac_voltage(self) -> float:
+        return self._query_checked_float("MEAS:VOLT:AC?")
+
+    def measure_dc_current(self) -> float:
+        return self._query_checked_float("MEAS:CURR:DC?")
+
+    def measure_ac_current(self) -> float:
+        return self._query_checked_float("MEAS:CURR:AC?")
+
+    def measure_resistance(self) -> float:
+        return self._query_checked_float("MEAS:RES?")
+
+    def _write_checked(self, command: str) -> None:
+        with self._visa.lock():
+            self._visa.write(command)
+            self._check_errors()
+
+    def _query_checked_float(self, command: str) -> float:
+        with self._visa.lock():
+            value = self._visa.query(command)
+            self._check_errors()
+            return float(value)
+
+    def _check_errors(self) -> None:
+        err = self._visa.query("SYST:ERR?")
+        if err.split(",", 1)[0].strip().lstrip("+") != "0":
+            raise RuntimeError(f"Simulated DMM reported error: {err}")

--- a/instro/dmm/scpi_sim_server.py
+++ b/instro/dmm/scpi_sim_server.py
@@ -1,0 +1,439 @@
+"""In-process SCPI digital-multimeter emulator (headless)."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import math
+import random
+import re
+import socket
+import threading
+import time
+from collections import deque
+from dataclasses import dataclass
+from enum import IntEnum
+from typing import Any, Callable, cast
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_PORT = 5026
+
+FUNCTION_DC_VOLTAGE = "VOLT:DC"
+FUNCTION_AC_VOLTAGE = "VOLT:AC"
+FUNCTION_DC_CURRENT = "CURR:DC"
+FUNCTION_AC_CURRENT = "CURR:AC"
+FUNCTION_RESISTANCE = "RES"
+FUNCTIONS = (
+    FUNCTION_DC_VOLTAGE,
+    FUNCTION_AC_VOLTAGE,
+    FUNCTION_DC_CURRENT,
+    FUNCTION_AC_CURRENT,
+    FUNCTION_RESISTANCE,
+)
+DEFAULT_FUNCTION = FUNCTION_DC_VOLTAGE
+DEFAULT_STIMULUS = {
+    FUNCTION_DC_VOLTAGE: 1.25,
+    FUNCTION_AC_VOLTAGE: 0.5,
+    FUNCTION_DC_CURRENT: 0.1,
+    FUNCTION_AC_CURRENT: 0.05,
+    FUNCTION_RESISTANCE: 1000.0,
+}
+NOISE_PERCENT = 0.005
+
+
+def add_noise(value: float, percent: float) -> float:
+    if not math.isfinite(value):
+        return value
+    std_dev = abs(value) * percent / 3
+    return random.gauss(value, std_dev)
+
+
+class SCPIError(IntEnum):
+    """SCPI and simulator error table."""
+
+    _message: str
+
+    NO_ERROR = (0, "No error")
+    # Command errors (-100 to -178)
+    COMMAND_ERROR = (-100, "Command error")
+    INVALID_CHARACTER = (-101, "Invalid character")
+    SYNTAX_ERROR = (-102, "Syntax error")
+    INVALID_SEPARATOR = (-103, "Invalid separator")
+    DATA_TYPE_ERROR = (-104, "Data type error")
+    PARAMETER_NOT_ALLOWED = (-108, "Parameter not allowed")
+    MISSING_PARAMETER = (-109, "Missing parameter")
+    UNDEFINED_HEADER = (-113, "Undefined header")
+    HEADER_SUFFIX_OUT_OF_RANGE = (-114, "Header suffix out of range")
+    INVALID_CHARACTER_DATA = (-141, "Invalid character data")
+    # Execution errors (-200 to -241)
+    EXECUTION_ERROR = (-200, "Execution error")
+    DATA_OUT_OF_RANGE = (-222, "Data out of range")
+    ILLEGAL_PARAMETER_VALUE = (-224, "Illegal parameter value")
+    QUEUE_OVERFLOW = (-350, "Queue overflow")
+    # Query errors (-400 to -440)
+    QUERY_ERROR = (-400, "Query error")
+
+    def __new__(cls, code: int, message: str) -> Any:
+        obj = int.__new__(cls, code)
+        obj._value_ = code
+        obj._message = message
+        return obj
+
+    @classmethod
+    def from_code(cls, code: int) -> "SCPIError":
+        return cast(SCPIError, cls._value2member_map_[code])
+
+    @property
+    def message(self) -> str:
+        return self._message
+
+
+def _normalize_header(header: str) -> tuple[str, int]:
+    channel = 1
+    parts: list[str] = []
+    for raw in header.removeprefix(":").split(":"):
+        upper = raw.upper()
+        base = upper.rstrip("0123456789")
+        suffix = upper[len(base) :]
+        if suffix:
+            channel = int(suffix)
+        parts.append(base)
+    return ":".join(parts), channel
+
+
+class SimulatedDMM:
+    """Simulated digital multimeter: one active function, per-function stimulus returned with noise."""
+
+    id = "NOMINAL,SIMULATED_DMM,000001,1.0"
+
+    def __init__(self, stimulus: dict[str, float] | None = None) -> None:
+        self.stimulus: dict[str, float] = dict(DEFAULT_STIMULUS)
+        if stimulus is not None:
+            self.stimulus.update(stimulus)
+        self.function = DEFAULT_FUNCTION
+        self._error_queue: deque[int] = deque()
+
+    def set_stimulus(self, function: str, value: float) -> None:
+        """Set the value the given function measures (before noise)."""
+        if function not in FUNCTIONS:
+            raise ValueError(f"unknown function {function!r}; expected one of {FUNCTIONS}")
+        self.stimulus[function] = value
+
+    def _push_error(self, err: SCPIError) -> None:
+        self._error_queue.append(err.value)
+
+    # ---- Top-level dispatch ----
+
+    def process_scpi_command(self, cmd: str) -> Any:
+        stripped = cmd.strip()
+        if not stripped:
+            return None
+        return self._dispatch(stripped)
+
+    def _dispatch(self, cmd: str) -> Any:
+        header_raw, _, rest = cmd.partition(" ")
+        rest = rest.strip()
+
+        is_query = header_raw.endswith("?")
+        if is_query:
+            header_raw = header_raw[:-1]
+
+        canonical, _ = _normalize_header(header_raw)
+
+        key = canonical + ("?" if is_query else "")
+        handler = _COMMAND_TABLE.get(key)
+        if handler is None:
+            logger.error("Unknown command: %s", cmd)
+            self._push_error(SCPIError.UNDEFINED_HEADER)
+            return None
+
+        positional = [a.strip() for a in rest.split(",") if a.strip()] if rest else []
+        if is_query and positional:
+            self._push_error(SCPIError.PARAMETER_NOT_ALLOWED)
+            return None
+
+        logger.info("Cmd %s args=%s", key, positional)
+        try:
+            return handler(self, positional)
+        except ValueError:
+            logger.warning("Invalid parameter in command: %s", cmd)
+            self._push_error(SCPIError.INVALID_CHARACTER_DATA)
+            return None
+
+    # ---- *IDN? / *RST / *CLS / SYST:ERR? ----
+
+    def _get_id(self, args: list[str]) -> str:
+        time.sleep(0.015)
+        return self.id
+
+    def _get_error(self, args: list[str]) -> str:
+        code = self._error_queue.popleft() if self._error_queue else SCPIError.NO_ERROR.value
+        err = SCPIError.from_code(code)
+        return f'{code:d},"{err.message}"'
+
+    def _reset(self, args: list[str]) -> None:
+        # Stimulus is the simulated physical world; *RST resets instrument state only.
+        self.function = DEFAULT_FUNCTION
+        self._error_queue.clear()
+
+    def _clear_status(self, args: list[str]) -> None:
+        self._error_queue.clear()
+
+    # ---- Function switching ----
+
+    def _set_function(self, args: list[str]) -> None:
+        if not self._require_args(args):
+            return
+        function = args[0].strip("\"'").upper()
+        if function == "VOLT":
+            function = FUNCTION_DC_VOLTAGE
+        elif function == "CURR":
+            function = FUNCTION_DC_CURRENT
+        if function not in FUNCTIONS:
+            self._push_error(SCPIError.ILLEGAL_PARAMETER_VALUE)
+            return
+        self.function = function
+
+    def _query_function(self, args: list[str]) -> str:
+        return f'"{self.function}"'
+
+    def _read(self, args: list[str]) -> float:
+        return add_noise(self.stimulus[self.function], NOISE_PERCENT)
+
+    # ---- Helpers ----
+
+    def _require_args(self, args: list[str]) -> bool:
+        if not args:
+            self._push_error(SCPIError.MISSING_PARAMETER)
+            return False
+        return True
+
+
+@dataclass(frozen=True)
+class _SCPICommand:
+    command: str
+    write: Callable[..., Any] | None = None
+    query: Callable[..., Any] | None = None
+
+    def headers(self) -> tuple[str, ...]:
+        prefix, required, suffix = self._split_segments()
+        headers = [required + suffix[:count] for count in range(len(suffix) + 1)]
+        if prefix:
+            headers += [prefix + header for header in headers]
+        return tuple(":".join(path) for header in headers for path in _paths_for(header))
+
+    def register(self, table: dict[str, Callable[..., Any]]) -> None:
+        for header in self.headers():
+            if self.write is not None:
+                table[header] = self.write
+            if self.query is not None:
+                table[f"{header}?"] = self.query
+
+    def _split_segments(self) -> tuple[list[str], list[str], list[str]]:
+        segments = self._segments()
+        required_indexes = [index for index, (_, optional) in enumerate(segments) if not optional]
+        if not required_indexes:
+            raise ValueError(f"unsupported SCPI optional layout: {self.command}")
+        start = required_indexes[0]
+        stop = required_indexes[-1] + 1
+        if any(optional for _, optional in segments[start:stop]):
+            raise ValueError(f"unsupported SCPI optional layout: {self.command}")
+        return (
+            [part for part, _ in segments[:start]],
+            [part for part, _ in segments[start:stop]],
+            [part for part, _ in segments[stop:]],
+        )
+
+    def _segments(self) -> list[tuple[str, bool]]:
+        segments: list[tuple[str, bool]] = []
+        for optional, required in re.findall(r"\[([^\]]+)\]|([^\[\]]+)", self.command):
+            text = optional or required
+            segments.extend((part, bool(optional)) for part in text.strip(":").split(":") if part)
+        return segments
+
+
+def _keyword_forms(text: str) -> tuple[str, ...]:
+    long = text.upper()
+    short = "".join(char for char in text if not char.isalpha() or char.isupper()).upper()
+    if short == long:
+        return (short,)
+    return (short, long)
+
+
+def _paths_for(parts: list[str]) -> list[tuple[str, ...]]:
+    paths: list[tuple[str, ...]] = [()]
+    for part in parts:
+        paths = [path + (form,) for path in paths for form in _keyword_forms(part)]
+    return paths
+
+
+_SCPI_COMMANDS = (
+    _SCPICommand("*IDN", query=SimulatedDMM._get_id),
+    _SCPICommand("*RST", SimulatedDMM._reset),
+    _SCPICommand("*CLS", SimulatedDMM._clear_status),
+    _SCPICommand("SYSTem:ERRor", query=SimulatedDMM._get_error),
+    _SCPICommand("[SENSe:]FUNCtion", SimulatedDMM._set_function, query=SimulatedDMM._query_function),
+    _SCPICommand("READ", query=SimulatedDMM._read),
+)
+
+
+_COMMAND_TABLE: dict[str, Callable[..., Any]] = {}
+for command in _SCPI_COMMANDS:
+    command.register(_COMMAND_TABLE)
+
+
+def _make_configure(function: str) -> Callable[[SimulatedDMM, list[str]], None]:
+    def handler(dmm: SimulatedDMM, args: list[str]) -> None:
+        dmm.function = function
+
+    return handler
+
+
+def _make_measure(function: str) -> Callable[[SimulatedDMM, list[str]], float]:
+    def handler(dmm: SimulatedDMM, args: list[str]) -> float:
+        dmm.function = function
+        return add_noise(dmm.stimulus[function], NOISE_PERCENT)
+
+    return handler
+
+
+_FUNCTION_HEADERS = {
+    FUNCTION_DC_VOLTAGE: "VOLTage[:DC]",
+    FUNCTION_AC_VOLTAGE: "VOLTage:AC",
+    FUNCTION_DC_CURRENT: "CURRent[:DC]",
+    FUNCTION_AC_CURRENT: "CURRent:AC",
+    FUNCTION_RESISTANCE: "RESistance",
+}
+for function, header in _FUNCTION_HEADERS.items():
+    _SCPICommand(f"CONFigure:{header}", _make_configure(function)).register(_COMMAND_TABLE)
+    _SCPICommand(f"MEASure:{header}", query=_make_measure(function)).register(_COMMAND_TABLE)
+
+
+# ---- Background TCP server ----
+
+
+class SimulatedDMMServer:
+    """TCP socket server that hands incoming SCPI lines to the simulator."""
+
+    def __init__(self, dmm: SimulatedDMM, host: str = "127.0.0.1", port: int = DEFAULT_PORT) -> None:
+        self.dmm = dmm
+        self._host = host
+        self._port = port
+        self.lock = threading.Lock()
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        self._socket: socket.socket | None = None
+
+    @property
+    def port(self) -> int:
+        """The bound TCP port (resolved from the OS when started with port 0)."""
+        return self._port
+
+    def start(self) -> None:
+        self._socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._socket.bind((self._host, self._port))
+        self._port = self._socket.getsockname()[1]
+        self._socket.listen(1)
+        self._socket.settimeout(0.5)
+        self._thread = threading.Thread(target=self._run, daemon=True, name="dmm-sim-server")
+        self._thread.start()
+
+    def shutdown(self) -> None:
+        self._stop.set()
+        if self._socket is not None:
+            try:
+                self._socket.close()
+            except OSError:
+                pass
+        if self._thread is not None:
+            self._thread.join(timeout=2.0)
+
+    def _run(self) -> None:
+        assert self._socket is not None
+        while not self._stop.is_set():
+            try:
+                conn, _ = self._socket.accept()
+            except socket.timeout:
+                continue
+            except OSError:
+                return
+            try:
+                self._handle_client(conn)
+            except Exception:
+                logger.exception("client handler error")
+            finally:
+                try:
+                    conn.close()
+                except OSError:
+                    pass
+
+    def _handle_client(self, conn: socket.socket) -> None:
+        conn.settimeout(0.5)
+        buffer = b""
+        while not self._stop.is_set():
+            try:
+                data = conn.recv(1024)
+            except socket.timeout:
+                continue
+            except OSError:
+                return
+            if not data:
+                return
+            buffer += data
+            while b"\n" in buffer:
+                line, buffer = buffer.split(b"\n", 1)
+                cmd_text = line.decode(errors="replace").strip()
+                if not cmd_text:
+                    continue
+                with self.lock:
+                    response = self.dmm.process_scpi_command(cmd_text)
+                if response is not None:
+                    try:
+                        conn.sendall((str(response) + "\n").encode())
+                    except OSError:
+                        return
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Run the simulated DMM as a headless SCPI TCP server.",
+    )
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT, help="TCP port to listen on")
+    parser.add_argument("--host", default="127.0.0.1", help="TCP host to bind to")
+    parser.add_argument("--dc-voltage", type=float, help="DC voltage stimulus (V)")
+    parser.add_argument("--ac-voltage", type=float, help="AC voltage stimulus (V)")
+    parser.add_argument("--dc-current", type=float, help="DC current stimulus (A)")
+    parser.add_argument("--ac-current", type=float, help="AC current stimulus (A)")
+    parser.add_argument("--resistance", type=float, help="Resistance stimulus (ohms)")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+
+    stimulus = {
+        function: value
+        for function, value in (
+            (FUNCTION_DC_VOLTAGE, args.dc_voltage),
+            (FUNCTION_AC_VOLTAGE, args.ac_voltage),
+            (FUNCTION_DC_CURRENT, args.dc_current),
+            (FUNCTION_AC_CURRENT, args.ac_current),
+            (FUNCTION_RESISTANCE, args.resistance),
+        )
+        if value is not None
+    }
+    dmm = SimulatedDMM(stimulus=stimulus)
+    server = SimulatedDMMServer(dmm, host=args.host, port=args.port)
+    server.start()
+    print(f"Simulated DMM listening on TCPIP0::{args.host}::{server.port}::SOCKET (Ctrl-C to stop)")
+    try:
+        while True:
+            time.sleep(1.0)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.shutdown()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/dmm/simulated/test_simulated_dmm_hardware.py
+++ b/tests/dmm/simulated/test_simulated_dmm_hardware.py
@@ -1,0 +1,154 @@
+"""Full-transport tests for the simulated DMM driver."""
+
+from __future__ import annotations
+
+import pytest
+
+from instro.dmm import InstroDMM, MeasurementFunction
+from instro.dmm.drivers.simulated import SimulatedDMM
+from instro.dmm.scpi_sim_server import (
+    DEFAULT_STIMULUS,
+    FUNCTION_AC_CURRENT,
+    FUNCTION_AC_VOLTAGE,
+    FUNCTION_DC_CURRENT,
+    FUNCTION_DC_VOLTAGE,
+    FUNCTION_RESISTANCE,
+    SimulatedDMMServer,
+)
+from instro.dmm.scpi_sim_server import SimulatedDMM as SimulatedDMMSimulator
+from instro.lib.transports import VisaConfig
+
+# SIMULATED HARDWARE TEST TEMPLATE:
+#
+# Copy this file into tests/dmm/<vendor>/test_<driver>_hardware.py, uncomment
+# pytestmark, set VISA_ADDRESS to the bench instrument address, and instantiate
+# the real driver in driver(). Keep reset_before_each_test() for SCPI/VISA
+# instruments that accept *RST; replace it for hardware with a different reset
+# path. Delete sim_target, _SimulatedTarget, and simulator imports because real
+# hardware tests do not need to launch the local SCPI simulator.
+# pytestmark = pytest.mark.hardware
+
+VISA_ADDRESS = "TCPIP0::127.0.0.1::5026::SOCKET"
+
+
+@pytest.fixture(scope="module")
+def driver(request: pytest.FixtureRequest, sim_target: "_SimulatedTarget") -> SimulatedDMM:
+    dmm_driver = SimulatedDMM(
+        VisaConfig(
+            visa_resource=sim_target.visa_address,
+        )
+    )
+    try:
+        dmm_driver.open()
+    except Exception:
+        dmm_driver.close()
+        raise
+
+    request.addfinalizer(dmm_driver.close)
+    return dmm_driver
+
+
+@pytest.fixture(autouse=True)
+def reset_before_each_test(driver: SimulatedDMM) -> None:
+    driver._visa.write("*RST")
+
+
+@pytest.mark.parametrize(
+    "function",
+    [
+        MeasurementFunction.DC_VOLTAGE,
+        MeasurementFunction.AC_VOLTAGE,
+        MeasurementFunction.DC_CURRENT,
+        MeasurementFunction.AC_CURRENT,
+        MeasurementFunction.TWO_WIRE_RESISTANCE,
+    ],
+)
+def test_set_measurement_function(driver: SimulatedDMM, function: MeasurementFunction) -> None:
+    driver.set_measurement_function(function)
+
+
+def test_set_measurement_function_four_wire_unsupported(driver: SimulatedDMM) -> None:
+    with pytest.raises(NotImplementedError):
+        driver.set_measurement_function(MeasurementFunction.FOUR_WIRE_RESISTANCE)
+
+
+@pytest.mark.parametrize(
+    ("method", "function"),
+    [
+        ("measure_dc_voltage", FUNCTION_DC_VOLTAGE),
+        ("measure_ac_voltage", FUNCTION_AC_VOLTAGE),
+        ("measure_dc_current", FUNCTION_DC_CURRENT),
+        ("measure_ac_current", FUNCTION_AC_CURRENT),
+        ("measure_resistance", FUNCTION_RESISTANCE),
+    ],
+)
+def test_measure_returns_stimulus(driver: SimulatedDMM, method: str, function: str) -> None:
+    value = getattr(driver, method)()
+
+    assert value == pytest.approx(DEFAULT_STIMULUS[function], rel=0.05)
+
+
+def test_measure_tracks_stimulus_change(
+    driver: SimulatedDMM,
+    sim_target: "_SimulatedTarget",
+) -> None:
+    original = sim_target.simulator.stimulus[FUNCTION_RESISTANCE]
+    try:
+        sim_target.simulator.set_stimulus(FUNCTION_RESISTANCE, 4700.0)
+        assert driver.measure_resistance() == pytest.approx(4700.0, rel=0.05)
+    finally:
+        sim_target.simulator.set_stimulus(FUNCTION_RESISTANCE, original)
+
+
+def test_device_error_raises(driver: SimulatedDMM) -> None:
+    driver._visa.write(":BOGUS:HEADER")
+
+    with pytest.raises(RuntimeError, match="Simulated DMM reported error"):
+        driver.measure_dc_voltage()
+
+    # The failed transaction popped the queued error; the next one succeeds.
+    assert driver.measure_dc_voltage() == pytest.approx(DEFAULT_STIMULUS[FUNCTION_DC_VOLTAGE], rel=0.05)
+
+
+def test_instro_dmm_reads_through_full_stack() -> None:
+    # Dedicated server: the sim server handles one client at a time, and the
+    # module-scoped driver fixture keeps its connection to sim_target open.
+    target = _SimulatedTarget.start()
+    try:
+        with InstroDMM(name="sim_dmm", driver=SimulatedDMM(target.visa_address)) as dmm:
+            for function, key in [
+                (MeasurementFunction.DC_VOLTAGE, FUNCTION_DC_VOLTAGE),
+                (MeasurementFunction.AC_CURRENT, FUNCTION_AC_CURRENT),
+                (MeasurementFunction.TWO_WIRE_RESISTANCE, FUNCTION_RESISTANCE),
+            ]:
+                dmm.set_measurement_function(function)
+                reading = dmm.read()
+                assert reading.latest == pytest.approx(DEFAULT_STIMULUS[key], rel=0.05)
+    finally:
+        target.shutdown()
+
+
+@pytest.fixture(scope="module")
+def sim_target(request: pytest.FixtureRequest) -> "_SimulatedTarget":
+    target = _SimulatedTarget.start()
+    request.addfinalizer(target.shutdown)
+    return target
+
+
+class _SimulatedTarget:
+    def __init__(self, simulator: SimulatedDMMSimulator, server: SimulatedDMMServer, visa_address: str) -> None:
+        self.simulator = simulator
+        self.server = server
+        self.visa_address = visa_address
+
+    @classmethod
+    def start(cls) -> "_SimulatedTarget":
+        simulator = SimulatedDMMSimulator()
+        # Bind an ephemeral port to avoid EADDRINUSE collisions on shared CI runners.
+        server = SimulatedDMMServer(simulator, host="127.0.0.1", port=0)
+        server.start()
+        visa_address = f"TCPIP0::127.0.0.1::{server.port}::SOCKET"
+        return cls(simulator, server, visa_address)
+
+    def shutdown(self) -> None:
+        self.server.shutdown()

--- a/tests/dmm/simulated/test_simulated_dmm_software.py
+++ b/tests/dmm/simulated/test_simulated_dmm_software.py
@@ -1,0 +1,106 @@
+"""Software tests for the simulated DMM driver."""
+
+from collections.abc import Iterator
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from instro.dmm.drivers.simulated import SimulatedDMM
+from instro.dmm.types import MeasurementFunction
+from instro.lib.transports import VisaConfig
+
+
+@pytest.fixture
+def sim_visa_cls() -> Iterator[MagicMock]:
+    with patch("instro.dmm.drivers.simulated.VisaDriver", autospec=True) as cls:
+        yield cls
+
+
+@pytest.fixture
+def sim_visa(sim_visa_cls: MagicMock) -> MagicMock:
+    visa = sim_visa_cls.return_value
+    visa.query.return_value = '0,"No error"'
+    return visa
+
+
+@pytest.fixture
+def sim(sim_visa_cls: MagicMock) -> SimulatedDMM:
+    return SimulatedDMM("TCPIP0::127.0.0.1::5026::SOCKET")
+
+
+def test_simulated_init_builds_visa_driver_from_resource(sim_visa_cls: MagicMock) -> None:
+    SimulatedDMM("TCPIP0::127.0.0.1::5026::SOCKET")
+
+    sim_visa_cls.assert_called_once_with("TCPIP0::127.0.0.1::5026::SOCKET")
+
+
+def test_simulated_init_accepts_prebuilt_connection_config(sim_visa_cls: MagicMock) -> None:
+    config = VisaConfig(visa_resource="TCPIP0::127.0.0.1::5026::SOCKET")
+    SimulatedDMM(config)
+
+    sim_visa_cls.assert_called_once_with(config)
+
+
+def test_simulated_open_close_delegate_to_visa(sim: SimulatedDMM, sim_visa: MagicMock) -> None:
+    sim.open()
+    sim.close()
+
+    sim_visa.open.assert_called_once()
+    sim_visa.close.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ("function", "name"),
+    [
+        (MeasurementFunction.DC_VOLTAGE, "VOLT:DC"),
+        (MeasurementFunction.AC_VOLTAGE, "VOLT:AC"),
+        (MeasurementFunction.DC_CURRENT, "CURR:DC"),
+        (MeasurementFunction.AC_CURRENT, "CURR:AC"),
+        (MeasurementFunction.TWO_WIRE_RESISTANCE, "RES"),
+    ],
+)
+def test_simulated_set_measurement_function_writes_func(
+    sim: SimulatedDMM, sim_visa: MagicMock, function: MeasurementFunction, name: str
+) -> None:
+    sim.set_measurement_function(function)
+
+    sim_visa.write.assert_called_once_with(f'FUNC "{name}"')
+    sim_visa.query.assert_called_once_with("SYST:ERR?")
+
+
+def test_simulated_set_measurement_function_four_wire_unsupported(sim: SimulatedDMM) -> None:
+    with pytest.raises(NotImplementedError, match="FOUR_WIRE_RESISTANCE"):
+        sim.set_measurement_function(MeasurementFunction.FOUR_WIRE_RESISTANCE)
+
+
+@pytest.mark.parametrize(
+    ("method", "command"),
+    [
+        ("measure_dc_voltage", "MEAS:VOLT:DC?"),
+        ("measure_ac_voltage", "MEAS:VOLT:AC?"),
+        ("measure_dc_current", "MEAS:CURR:DC?"),
+        ("measure_ac_current", "MEAS:CURR:AC?"),
+        ("measure_resistance", "MEAS:RES?"),
+    ],
+)
+def test_simulated_measure_queries_command(sim: SimulatedDMM, sim_visa: MagicMock, method: str, command: str) -> None:
+    sim_visa.query.side_effect = ["1.234", '0,"No error"']
+
+    assert getattr(sim, method)() == pytest.approx(1.234)
+    assert sim_visa.query.call_args_list == [call(command), call("SYST:ERR?")]
+
+
+def test_simulated_measure_raises_on_device_error(sim: SimulatedDMM, sim_visa: MagicMock) -> None:
+    sim_visa.query.side_effect = ["1.234", '-113,"Undefined header"']
+
+    with pytest.raises(RuntimeError, match="Simulated DMM reported error"):
+        sim.measure_dc_voltage()
+
+
+def test_simulated_optional_methods_raise_not_implemented(sim: SimulatedDMM) -> None:
+    with pytest.raises(NotImplementedError):
+        sim.set_digits(6)
+    with pytest.raises(NotImplementedError):
+        sim.set_dc_voltage_range(10.0)
+    with pytest.raises(NotImplementedError):
+        sim.measure_four_wire_resistance()

--- a/tests/dmm/test_dmm_scpi_sim_server.py
+++ b/tests/dmm/test_dmm_scpi_sim_server.py
@@ -1,0 +1,213 @@
+"""End-to-end tests for the simulated DMM SCPI server."""
+
+from __future__ import annotations
+
+import socket
+
+import pytest
+
+from instro.dmm.scpi_sim_server import (
+    DEFAULT_STIMULUS,
+    FUNCTION_AC_CURRENT,
+    FUNCTION_AC_VOLTAGE,
+    FUNCTION_DC_CURRENT,
+    FUNCTION_DC_VOLTAGE,
+    FUNCTION_RESISTANCE,
+    SCPIError,
+    SimulatedDMM,
+    SimulatedDMMServer,
+)
+
+
+@pytest.fixture
+def dmm() -> SimulatedDMM:
+    return SimulatedDMM()
+
+
+def _error_code(dmm: SimulatedDMM) -> int:
+    return int(dmm.process_scpi_command("SYST:ERR?").split(",")[0])
+
+
+# --- Identity and error queue ---
+
+
+@pytest.mark.parametrize("command", ["*IDN?", "*idn?"])
+def test_idn_returns_nominal_id(dmm: SimulatedDMM, command: str) -> None:
+    assert dmm.process_scpi_command(command).startswith("NOMINAL,SIMULATED_DMM")
+
+
+@pytest.mark.parametrize("command", ["SYST:ERR?", "system:error?"])
+def test_syst_err_no_error_when_empty(dmm: SimulatedDMM, command: str) -> None:
+    assert dmm.process_scpi_command(command) == '0,"No error"'
+
+
+def test_unknown_command_records_undefined_header(dmm: SimulatedDMM) -> None:
+    dmm.process_scpi_command(":BOGUS:THING")
+    assert _error_code(dmm) == SCPIError.UNDEFINED_HEADER.value
+
+
+def test_error_queue_clears_after_read(dmm: SimulatedDMM) -> None:
+    dmm.process_scpi_command(":BOGUS")
+    dmm.process_scpi_command(":BOGUS")
+
+    assert _error_code(dmm) == SCPIError.UNDEFINED_HEADER.value
+    assert _error_code(dmm) == SCPIError.UNDEFINED_HEADER.value
+    assert _error_code(dmm) == SCPIError.NO_ERROR.value
+
+
+def test_cls_clears_error_queue(dmm: SimulatedDMM) -> None:
+    dmm.process_scpi_command(":BOGUS")
+    dmm.process_scpi_command("*CLS")
+    assert _error_code(dmm) == SCPIError.NO_ERROR.value
+
+
+# --- Function switching ---
+
+
+@pytest.mark.parametrize(
+    "command",
+    ['FUNC "VOLT:AC"', 'FUNCTION "VOLT:AC"', 'SENS:FUNC "VOLT:AC"', "func 'volt:ac'", "FUNC VOLT:AC"],
+)
+def test_func_sets_function(dmm: SimulatedDMM, command: str) -> None:
+    dmm.process_scpi_command(command)
+    assert dmm.function == FUNCTION_AC_VOLTAGE
+    assert _error_code(dmm) == SCPIError.NO_ERROR.value
+
+
+def test_func_query_returns_quoted_function(dmm: SimulatedDMM) -> None:
+    assert dmm.process_scpi_command("FUNC?") == '"VOLT:DC"'
+    dmm.process_scpi_command('FUNC "RES"')
+    assert dmm.process_scpi_command("FUNC?") == '"RES"'
+
+
+def test_func_bare_volt_and_curr_default_to_dc(dmm: SimulatedDMM) -> None:
+    dmm.process_scpi_command('FUNC "CURR"')
+    assert dmm.function == FUNCTION_DC_CURRENT
+    dmm.process_scpi_command('FUNC "VOLT"')
+    assert dmm.function == FUNCTION_DC_VOLTAGE
+
+
+def test_func_unknown_records_illegal_value(dmm: SimulatedDMM) -> None:
+    dmm.process_scpi_command('FUNC "TEMP"')
+    assert _error_code(dmm) == SCPIError.ILLEGAL_PARAMETER_VALUE.value
+    assert dmm.function == FUNCTION_DC_VOLTAGE
+
+
+def test_func_missing_parameter(dmm: SimulatedDMM) -> None:
+    dmm.process_scpi_command("FUNC")
+    assert _error_code(dmm) == SCPIError.MISSING_PARAMETER.value
+
+
+@pytest.mark.parametrize(
+    ("command", "function"),
+    [
+        ("CONF:VOLT", FUNCTION_DC_VOLTAGE),
+        ("CONF:VOLT:DC", FUNCTION_DC_VOLTAGE),
+        ("configure:voltage:ac", FUNCTION_AC_VOLTAGE),
+        ("CONF:CURR", FUNCTION_DC_CURRENT),
+        ("CONF:CURR:AC", FUNCTION_AC_CURRENT),
+        ("CONF:RES", FUNCTION_RESISTANCE),
+    ],
+)
+def test_configure_sets_function(dmm: SimulatedDMM, command: str, function: str) -> None:
+    dmm.process_scpi_command(command)
+    assert dmm.function == function
+    assert _error_code(dmm) == SCPIError.NO_ERROR.value
+
+
+# --- Measurement ---
+
+
+@pytest.mark.parametrize(
+    ("command", "function"),
+    [
+        ("MEAS:VOLT?", FUNCTION_DC_VOLTAGE),
+        ("MEAS:VOLT:DC?", FUNCTION_DC_VOLTAGE),
+        ("measure:voltage:ac?", FUNCTION_AC_VOLTAGE),
+        ("MEAS:CURR:DC?", FUNCTION_DC_CURRENT),
+        ("MEAS:CURR:AC?", FUNCTION_AC_CURRENT),
+        ("MEAS:RES?", FUNCTION_RESISTANCE),
+    ],
+)
+def test_measure_returns_noisy_stimulus_and_switches_function(dmm: SimulatedDMM, command: str, function: str) -> None:
+    value = dmm.process_scpi_command(command)
+    assert value == pytest.approx(DEFAULT_STIMULUS[function], rel=0.05)
+    assert dmm.function == function
+    assert _error_code(dmm) == SCPIError.NO_ERROR.value
+
+
+def test_read_uses_active_function(dmm: SimulatedDMM) -> None:
+    dmm.set_stimulus(FUNCTION_RESISTANCE, 4700.0)
+    dmm.process_scpi_command("CONF:RES")
+    assert dmm.process_scpi_command("READ?") == pytest.approx(4700.0, rel=0.05)
+
+
+def test_measure_reflects_set_stimulus(dmm: SimulatedDMM) -> None:
+    dmm.set_stimulus(FUNCTION_DC_VOLTAGE, 3.3)
+    assert dmm.process_scpi_command("MEAS:VOLT:DC?") == pytest.approx(3.3, rel=0.05)
+
+
+def test_measure_returns_varying_values(dmm: SimulatedDMM) -> None:
+    values = {dmm.process_scpi_command("MEAS:VOLT:DC?") for _ in range(10)}
+    assert len(values) > 1
+
+
+def test_set_stimulus_rejects_unknown_function(dmm: SimulatedDMM) -> None:
+    with pytest.raises(ValueError, match="unknown function"):
+        dmm.set_stimulus("TEMP", 25.0)
+
+
+def test_measure_query_with_args_records_parameter_not_allowed(dmm: SimulatedDMM) -> None:
+    assert dmm.process_scpi_command("MEAS:VOLT:DC? 10,0.001") is None
+    assert _error_code(dmm) == SCPIError.PARAMETER_NOT_ALLOWED.value
+
+
+# --- *RST ---
+
+
+def test_rst_resets_function_and_errors_but_keeps_stimulus(dmm: SimulatedDMM) -> None:
+    dmm.set_stimulus(FUNCTION_RESISTANCE, 4700.0)
+    dmm.process_scpi_command("CONF:RES")
+    dmm.process_scpi_command(":BOGUS")
+
+    dmm.process_scpi_command("*RST")
+
+    assert dmm.function == FUNCTION_DC_VOLTAGE
+    assert dmm.stimulus[FUNCTION_RESISTANCE] == pytest.approx(4700.0)
+    assert _error_code(dmm) == SCPIError.NO_ERROR.value
+
+
+# --- Constructor stimulus ---
+
+
+def test_constructor_stimulus_overrides_defaults() -> None:
+    dmm = SimulatedDMM(stimulus={FUNCTION_DC_VOLTAGE: 9.0})
+    assert dmm.stimulus[FUNCTION_DC_VOLTAGE] == pytest.approx(9.0)
+    assert dmm.stimulus[FUNCTION_RESISTANCE] == pytest.approx(DEFAULT_STIMULUS[FUNCTION_RESISTANCE])
+
+
+# --- TCP server ---
+
+
+def test_server_round_trip_over_tcp() -> None:
+    dmm = SimulatedDMM()
+    server = SimulatedDMMServer(dmm, port=0)
+    server.start()
+    try:
+        with socket.create_connection(("127.0.0.1", server.port), timeout=2.0) as conn:
+            conn.settimeout(2.0)
+            f = conn.makefile("rw", newline="\n")
+            f.write("*IDN?\n")
+            f.flush()
+            assert f.readline().strip().startswith("NOMINAL,SIMULATED_DMM")
+
+            f.write('FUNC "RES"\nFUNC?\n')
+            f.flush()
+            assert f.readline().strip() == '"RES"'
+
+            f.write("MEAS:VOLT:DC?\n")
+            f.flush()
+            value = float(f.readline().strip())
+            assert value == pytest.approx(DEFAULT_STIMULUS[FUNCTION_DC_VOLTAGE], rel=0.05)
+    finally:
+        server.shutdown()


### PR DESCRIPTION
Closes #220

## Summary

Adds the DMM as the second simulated instrument, mirroring the PSU pattern per the v1 scope in #220:

- `instro/dmm/scpi_sim_server.py`: headless SCPI DMM emulator (stdlib-only). Handles `*IDN?`/`*RST`/`*CLS`/`SYST:ERR?`, function switching via `[SENSe:]FUNCtion` and `CONFigure:*`, the 5 primary `DMMDriverBase` measurements via `MEASure:*?` plus `READ?`, and a settable per-function stimulus value returned with Gaussian noise (the DMM analog of the PSU sim's load model; settable via CLI flags, constructor, or `set_stimulus()`). Default port 5026 so both simulators can run side by side.
- `instro/dmm/drivers/simulated.py`: thin `SimulatedDMM` driver mirroring the PSU pattern — composes `VisaDriver`, per-driver `_write_checked`/`_check_errors`, raises `NotImplementedError` for four-wire resistance. Registered in `drivers/__init__.py`.
- The `_SCPICommand` grammar expansion, `_normalize_header`, TCP line server, and the generic slice of the error table are deliberately duplicated from `instro/psu/scpi_sim_server.py` per the issue and AGENTS.md (revisit extraction only if a third simulator appears).
- No TUI in v1; `python -m instro.dmm.scpi_sim_server` headless is the deliverable. No new install extra (the server is stdlib-only).

Docs: new `dmm-simulator.mdx` guide page (nav grouped as "Multimeter (DMM)" mirroring the PSU group), plus README device table, `dmm.mdx` vendor list, and `overview.mdx` driver list.

## Type of change

- [ ] Bug fix (`fix`)
- [x] New feature (`feat`)
- [ ] Breaking change (`feat!` / `fix!`)
- [ ] Refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] Chore / tooling (`chore`)

## Verification

- `just check` clean; full unit suite passes (1118 passed).
- `mint broken-links` and `mint validate` pass for the docs changes.
- End-to-end against a real process: launched `uv run python -m instro.dmm.scpi_sim_server --dc-voltage 3.3 --resistance 4700`, then drove it with `SimulatedDMM` through `InstroDMM` over a real pyvisa TCP socket:

```
DC_VOLTAGE                  3.30003 V   (expect ~3.3)   OK   <- CLI flag honored
AC_VOLTAGE                  0.49843 V   (expect ~0.5)   OK   <- server default
DC_CURRENT                  0.10002 A   (expect ~0.1)   OK
AC_CURRENT                  0.05004 A   (expect ~0.05)  OK
TWO_WIRE_RESISTANCE      4706.03443 ohm (expect ~4700)  OK   <- CLI flag honored
FOUR_WIRE_RESISTANCE raises NotImplementedError as expected
```

## Tests

- [x] Unit tests added or updated
- [ ] Existing tests cover this change
- [ ] No tests — explain why:

39 new tests: dispatch-level server tests in `tests/dmm/test_dmm_scpi_sim_server.py` (keyword short/long/case forms, error-queue semantics, `*RST` preserves stimulus, noise varies across reads, raw-socket TCP round trip) and mocked-transport driver tests in `tests/dmm/simulated/test_simulated_dmm_software.py` asserting wire-level commands, both following the `tests/psu/` patterns.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(driver): add support for Keysight E36300`)
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] Documentation updated if user-facing behavior changed
- [x] Code follows the style/conventions of the surrounding code

## Notes for reviewers

- The test module is `test_dmm_scpi_sim_server.py` (not `test_scpi_sim_server.py`) because pytest can't collect two modules with the same basename without `__init__.py` files.
- `MEAS:*?` queries reject range/resolution arguments (`-108,"Parameter not allowed"`); the `SimulatedDMM` driver never sends them. Follow-ups on demand: TUI parity, range/resolution argument support, four-wire resistance.
- Stimulus survives `*RST` by design: reset restores instrument state, not the simulated physical world.