### PR TITLE
fix(instrument): remove flaky channel names test

### DIFF
--- a/tests/lib/test_instrumentation.py
+++ b/tests/lib/test_instrumentation.py
@@ -115,21 +115,6 @@ def test_channel_names_raises_when_daemon_not_running():
         assert "No channel buffer exists" in str(e)
 
 
-def test_channel_names_returns_empty_initially():
-    instrument = _make_publishing_instrument()
-    try:
-        instrument.start()
-        # Wait for at least one publication cycle
-        time.sleep(0.05)
-        assert isinstance(instrument.channel_names, tuple)
-        # Should have at least loop_time and daemon_work_time
-        assert len(instrument.channel_names) >= 2
-        assert "ut.loop_time" in instrument.channel_names
-        assert "ut.daemon_work_time" in instrument.channel_names
-    finally:
-        instrument.stop()
-
-
 def test_channel_names_includes_published_channels():
     instrument = _make_publishing_instrument()
     try:


### PR DESCRIPTION
## Summary

Remove redundant timing-sensitive coverage to keep the instrument test suite reliable.

Fixes #266

## Type of change

- [x] Bug fix (`fix`)
- [ ] New feature (`feat`)
- [ ] Breaking change (`feat!` / `fix!`)
- [ ] Refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] Chore / tooling (`chore`)

## Verification

- `just check`
- `just test` — 1,145 passed, 1 xfailed

## Tests

- [ ] Unit tests added or updated
- [x] Existing tests cover this change
- [ ] No tests — explain why:

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(driver): add support for Keysight E36300`)
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] Documentation updated if user-facing behavior changed
- [x] Code follows the style/conventions of the surrounding code

## Notes for reviewers

None.
