### PR TITLE
fix(ci): sync uv.lock in release-please PRs

### DIFF
--- a/.github/workflows/release-please-publish.yml
+++ b/.github/workflows/release-please-publish.yml
@@ -15,6 +15,7 @@ jobs:
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
       paths_released: ${{ steps.release.outputs.paths_released }}
+      pr: ${{ steps.release.outputs.pr }}
     steps:
       - uses: googleapis/release-please-action@v4
         id: release
@@ -22,6 +23,34 @@ jobs:
           token: ${{ secrets.NOMBOT_CLASSIC_PERSONAL_ACCESS_TOKEN }}
           config-file: .github/release-please-config.json
           manifest-file: .github/release-please-manifest.json
+
+  update-lockfile:
+    needs: release-please
+    if: ${{ needs.release-please.outputs.pr != '' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ fromJSON(needs.release-please.outputs.pr).headBranchName }}
+          token: ${{ secrets.NOMBOT_CLASSIC_PERSONAL_ACCESS_TOKEN }}
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: "0.8.x"
+          enable-cache: false
+      - name: Sync uv.lock with released versions
+        run: uv lock
+      - name: Commit and push lockfile if changed
+        run: |
+          if git diff --quiet -- uv.lock; then
+            echo "uv.lock already up to date."
+            exit 0
+          fi
+          git config user.name "nominal-bot"
+          git config user.email "nominal-bot@users.noreply.github.com"
+          git add uv.lock
+          git commit -m "chore: sync uv.lock with release-please version bumps"
+          git push
 
   publish-python:
     needs: release-please

--- a/uv.lock
+++ b/uv.lock
@@ -474,7 +474,7 @@ wheels = [
 
 [[package]]
 name = "instro"
-version = "1.2.0"
+version = "1.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastavro", extra = ["snappy"] },


### PR DESCRIPTION
## Summary

Fixes INSTRO-463 (nominal-io/instro#267). release-please bumps package versions in the `pyproject.toml` files but never touches `uv.lock`, so every release leaves the workspace incoherent. CI's `uv lock --check` step then fails on `main` — right now `uv.lock` pins `instro` at `1.2.0` while `pyproject.toml` is `1.3.0`.

This PR:
- Adds an `update-lockfile` job to `release-please-publish.yml` that runs whenever release-please opens/updates a release PR. It checks out the release PR branch, runs `uv lock`, and commits the refreshed `uv.lock` back onto that branch so the lockfile ships with the version bumps.

  ```yaml
  update-lockfile:
    needs: release-please
    if: ${{ needs.release-please.outputs.pr != '' }}
    steps:
      - uses: actions/checkout@v4
        with:
          ref: ${{ fromJSON(needs.release-please.outputs.pr).headBranchName }}
          token: ${{ secrets.NOMBOT_CLASSIC_PERSONAL_ACCESS_TOKEN }}
      - install uv @ 0.8.x
      - run: uv lock
      - commit & push uv.lock if changed
  ```
  Uses the NOMBOT token (so the push registers on the PR and re-triggers CI), pins uv to `0.8.x` to match the existing `publish-python` / `build-check-test` jobs, and no-ops when the lock is already current. Both jobs run on the same push event, ordered via `needs`, so the lock is refreshed after each release-please branch update.
- Regenerates the currently-stale `uv.lock` (`instro` `1.2.0` → `1.3.0`) to make `main` coherent again.

## Type of change

- [x] Bug fix (`fix`)
- [ ] New feature (`feat`)
- [ ] Breaking change (`feat!` / `fix!`)
- [ ] Refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] Chore / tooling (`chore`)

## Verification

- Reproduced the incoherent state: `uv.lock` had `instro 1.2.0` vs `pyproject.toml 1.3.0`, and `uv lock --check` (the guard in `build-check-test.yml`) fails against it.
- Ran `uv lock` with uv `0.8.22` (matching CI's pin); it produced exactly one change, `Updated instro v1.2.0 -> v1.3.0`, and `uv lock --check` now exits 0.

## Tests

- [ ] Unit tests added or updated
- [x] Existing tests cover this change
- [ ] No tests — explain why:

CI's existing `uv lock --check` step is the regression guard for lockfile coherence; the workflow job itself is only exercisable end-to-end when release-please runs on `main`.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] Documentation updated if user-facing behavior changed
- [x] Code follows the style/conventions of the surrounding code

## Notes for reviewers

The `update-lockfile` job pushes with `NOMBOT_CLASSIC_PERSONAL_ACCESS_TOKEN` so the commit lands on the release PR and re-runs checks. release-please recreates its branch on each run, but since `update-lockfile` runs after `release-please` on every push to `main`, the lockfile is re-synced each time.

Link to Devin session: https://app.devin.ai/sessions/56b56ccc0f37409bb1c86727f12e05b5
Requested by: @cartercanedy