### PR TITLE
feat(ci): trigger claude review on @claude review comments

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -11,11 +11,15 @@ on:
     # skip every PR opened directly in a ready-for-review state.
     types: [opened, ready_for_review]
     branches: ["main"]
+  # On-demand review when someone comments `@claude review` on a PR. The job
+  # guard below restricts this path to trusted associations and PR comments.
+  issue_comment:
+    types: [created]
 
 # Serialize reviews per PR; don't cancel in-flight runs (they may have
 # half-posted tracking comments).
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}
   cancel-in-progress: false
 
 jobs:
@@ -25,8 +29,13 @@ jobs:
     # anyone opening a flood of hostile PRs) live on fork head repos and never trigger
     # this job -> no API spend and no secret exposure to untrusted code.
     if: |
-      github.event.pull_request.draft == false &&
-      github.event.pull_request.head.repo.full_name == github.repository
+      (github.event_name == 'pull_request' &&
+        github.event.pull_request.draft == false &&
+        github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request != null &&
+        startsWith(github.event.comment.body, '@claude review') &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -38,6 +47,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
+          # issue_comment events check out the default branch by default, not the PR head,
+          # so pin the PR head ref explicitly for that path. The pull_request path already
+          # resolves to the PR head.
+          ref: ${{ github.event_name == 'issue_comment' && format('refs/pull/{0}/head', github.event.issue.number) || '' }}
           # Full history so the granted git tools (git diff/log/show) can diff against the PR
           # base ref; a depth-1 shallow checkout only contains the head commit. `gh pr diff`
           # works either way (it uses the API), but local git range commands need this.
@@ -70,7 +83,7 @@ jobs:
 
           prompt: |
             REPO: ${{ github.repository }}
-            PR NUMBER: ${{ github.event.pull_request.number }}
+            PR NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
 
             Review this pull request by running /code-review --comment. These checks layer on top of
             the plugin's defaults; also follow the repo's AGENTS.md and CONTRIBUTING.md conventions.


### PR DESCRIPTION
## Summary

Adds an on-demand trigger to the Claude Code Review workflow so a reviewer can kick off a review by commenting `@claude review` on a PR. Previously the workflow only fired on the `opened` / `ready_for_review` `pull_request` events, so there was no way to re-run a review without toggling a PR back to draft and ready again.

Key changes to `.github/workflows/claude-review.yml`:

- Add an `issue_comment: [created]` trigger alongside the existing `pull_request` trigger.
- Split the job `if:` guard by `github.event_name`:
  - `pull_request` path keeps the existing draft + fork-head guard (load-bearing isolation for this public repo).
  - `issue_comment` path only runs when the comment is on a PR (`github.event.issue.pull_request != null`), the body `startsWith('@claude review')`, and the commenter's `author_association` is in `[OWNER, MEMBER, COLLABORATOR]`. This association gate is the trust control for the comment path, since `issue_comment` runs in the base repo with base-repo secrets and has no fork-head guard to lean on.
- `issue_comment` events check out the [REDACTED SECRET] branch by [REDACTED SECRET], so pin `ref: refs/pull/<n>/head` for that path; the `pull_request` path already resolves to the PR head.
- Generalize `concurrency.group` and the prompt's `PR NUMBER` to fall back to `github.event.issue.number` for the comment path.

All `github.event.*` interpolations are confined to `if:`, `with:`, and `concurrency` contexts (never `run:` blocks), so there's no script-injection surface.

## Type of change

- [x] Chore / tooling (`chore`)

(Conventional Commit type is `feat(ci)` for changelog purposes; it's a CI/tooling change.)

## Verification

- `actionlint` 1.7.12 passes clean on the edited workflow.
- The App-install requirement (Claude GitHub App on `nominal-io/instro`) is orthogonal to this change and still must be satisfied for a run to succeed; this PR only changes when the workflow is triggered.

## Tests

- [x] No tests — explain why: CI workflow change; validated with `actionlint`. End-to-end behavior is only observable by commenting `@claude review` on a PR after merge.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] Code follows the style/conventions of the surrounding code

## Notes for reviewers

- The `@claude review` filter uses `startsWith` (stricter than galaxy's `contains(..., '@claude')`) per the request — switch to `contains` if you'd rather allow the mention mid-sentence.
</body>
</invoke>


Link to Devin session: https://app.devin.ai/sessions/445f7d8ad5a9436b9e444395f54f1c1c
Requested by: @cartercanedy