### PR TITLE
feat(scaling): add inverse thermocouple scaling

### DIFF
--- a/docs/guides/instrumentation/daq.mdx
+++ b/docs/guides/instrumentation/daq.mdx
@@ -166,9 +166,9 @@ For example, a thermocouple that's fed into an amplifier and then the DAQ will r
 
  ```python
  from instro.daq.scaling import ScalerPipeline, ReverseLinearScaler
- from instro.daq.scaling.thermocouple import ThermocoupleSensor
+ from instro.daq.scaling.thermocouple import ThermocoupleScaler
 
-scaler_pipeline = ScalerPipeline(ReverseLinearScaler(gain=<amplifier gain>, offset=<voltage offset>, units="V"), ThermocoupleSensor(type = <TC_type>, cjc_temp = <cjc temp in Celsius>))
+scaler_pipeline = ScalerPipeline(ReverseLinearScaler(gain=<amplifier gain>, offset=<voltage offset>, units="V"), ThermocoupleScaler(type = <TC_type>, cjc_temp = <cjc temp in Celsius>))
  ```
 
  You can create your own scaler by subclassing `Scaler` and implementing `scale` and `units` methods.

--- a/docs/guides/instrumentation/daq.mdx
+++ b/docs/guides/instrumentation/daq.mdx
@@ -166,9 +166,9 @@ For example, a thermocouple that's fed into an amplifier and then the DAQ will r
 
  ```python
  from instro.daq.scaling import ScalerPipeline, ReverseLinearScaler
- from instro.daq.scaling.thermocouple import ThermocoupleScaler
+ from instro.daq.scaling.thermocouple import ThermocoupleSensor
 
-scaler_pipeline = ScalerPipeline(ReverseLinearScaler(gain=<amplifier gain>, offset=<voltage offset>, units="V"), ThermocoupleScaler(type = <TC_type>, cjc_temp = <cjc temp in Celsius>))
+scaler_pipeline = ScalerPipeline(ReverseLinearScaler(gain=<amplifier gain>, offset=<voltage offset>, units="V"), ThermocoupleSensor(type = <TC_type>, cjc_temp = <cjc temp in Celsius>))
  ```
 
  You can create your own scaler by subclassing `Scaler` and implementing `scale` and `units` methods.

--- a/instro/daq/scaling/thermocouple.py
+++ b/instro/daq/scaling/thermocouple.py
@@ -18,14 +18,14 @@ class TC_TYPE(enum.Enum):
     T = "T"
 
 
-class ThermocoupleScaler(Scaler):
+class ThermocoupleSensor(Scaler):
     """Thermocouple voltage → °C with cold-junction compensation.
 
-    >>> ThermocoupleScaler(TC_TYPE.K, cjc_temp=25.0)  # Type K, 25 °C reference junction
+    >>> ThermocoupleSensor(TC_TYPE.K, cjc_temp=25.0)  # Type K, 25 °C reference junction
     """
 
     def __init__(self, type: TC_TYPE, cjc_temp: float):
-        """Initialize the thermocouple scaler.
+        """Initialize the thermocouple sensor.
 
         Args:
             type: Thermocouple type (B/E/J/K/N/R/S/T).

--- a/instro/daq/scaling/thermocouple.py
+++ b/instro/daq/scaling/thermocouple.py
@@ -18,14 +18,14 @@ class TC_TYPE(enum.Enum):
     T = "T"
 
 
-class ThermocoupleSensor(Scaler):
+class ThermocoupleScaler(Scaler):
     """Thermocouple voltage → °C with cold-junction compensation.
 
-    >>> ThermocoupleSensor(TC_TYPE.K, cjc_temp=25.0)  # Type K, 25 °C reference junction
+    >>> ThermocoupleScaler(TC_TYPE.K, cjc_temp=25.0)  # Type K, 25 °C reference junction
     """
 
     def __init__(self, type: TC_TYPE, cjc_temp: float):
-        """Initialize the thermocouple sensor.
+        """Initialize the thermocouple scaler.
 
         Args:
             type: Thermocouple type (B/E/J/K/N/R/S/T).
@@ -38,6 +38,10 @@ class ThermocoupleSensor(Scaler):
     def scale(self, raw: float | int) -> float:
         """Voltage (volts or millivolts per the ``thermocouples`` library) → temperature (°C)."""
         return self._tc.volt_to_temp_with_cjc(voltage=raw, ref_temp=self._cjc)
+
+    def inverse_scale(self, temp: float) -> float:
+        """Temperature (°C) → voltage, inverse of :meth:`scale` with cold-junction compensation."""
+        return self._tc.temp_to_volt(temp) - self._tc.temp_to_volt(self._cjc)
 
     @property
     def units(self) -> str:

--- a/instro/daq/scaling/thermocouple.py
+++ b/instro/daq/scaling/thermocouple.py
@@ -39,10 +39,32 @@ class ThermocoupleSensor(Scaler):
         """Voltage (volts or millivolts per the ``thermocouples`` library) → temperature (°C)."""
         return self._tc.volt_to_temp_with_cjc(voltage=raw, ref_temp=self._cjc)
 
-    def inverse_scale(self, temp: float) -> float:
-        """Temperature (°C) → voltage, inverse of :meth:`scale` with cold-junction compensation."""
-        return self._tc.temp_to_volt(temp) - self._tc.temp_to_volt(self._cjc)
-
     @property
     def units(self) -> str:
         return "degC"
+
+
+class InverseThermocoupleSensor(Scaler):
+    """Temperature (°C) → voltage with cold-junction compensation — inverse of ``ThermocoupleSensor``.
+
+    >>> InverseThermocoupleSensor(TC_TYPE.K, cjc_temp=25.0)  # Type K, 25 °C reference junction
+    """
+
+    def __init__(self, type: TC_TYPE, cjc_temp: float):
+        """Initialize the inverse thermocouple sensor.
+
+        Args:
+            type: Thermocouple type (B/E/J/K/N/R/S/T).
+            cjc_temp: Cold-junction reference temperature in °C.
+        """
+        self._type = type
+        self._cjc = cjc_temp
+        self._tc = tc.get_thermocouple(self._type.value)
+
+    def scale(self, raw: float | int) -> float:
+        """Temperature (°C) → voltage with cold-junction compensation."""
+        return self._tc.temp_to_volt(raw) - self._tc.temp_to_volt(self._cjc)
+
+    @property
+    def units(self) -> str:
+        return "V"

--- a/tests/daq/test_scaling.py
+++ b/tests/daq/test_scaling.py
@@ -1,0 +1,12 @@
+"""Unit tests for DAQ scalers."""
+
+import pytest
+
+from instro.daq.scaling.thermocouple import TC_TYPE, ThermocoupleScaler
+
+
+@pytest.mark.parametrize("cjc_temp", [0.0, 23.0])
+@pytest.mark.parametrize("temp", [-100.0, 0.0, 100.0])
+def test_thermocouple_inverse_scale_roundtrip(cjc_temp: float, temp: float) -> None:
+    scaler = ThermocoupleScaler(TC_TYPE.K, cjc_temp=cjc_temp)
+    assert scaler.scale(scaler.inverse_scale(temp)) == pytest.approx(temp, abs=0.1)

--- a/tests/daq/test_scaling.py
+++ b/tests/daq/test_scaling.py
@@ -2,11 +2,11 @@
 
 import pytest
 
-from instro.daq.scaling.thermocouple import TC_TYPE, ThermocoupleScaler
+from instro.daq.scaling.thermocouple import TC_TYPE, ThermocoupleSensor
 
 
 @pytest.mark.parametrize("cjc_temp", [0.0, 23.0])
 @pytest.mark.parametrize("temp", [-100.0, 0.0, 100.0])
 def test_thermocouple_inverse_scale_roundtrip(cjc_temp: float, temp: float) -> None:
-    scaler = ThermocoupleScaler(TC_TYPE.K, cjc_temp=cjc_temp)
+    scaler = ThermocoupleSensor(TC_TYPE.K, cjc_temp=cjc_temp)
     assert scaler.scale(scaler.inverse_scale(temp)) == pytest.approx(temp, abs=0.1)

--- a/tests/daq/test_scaling.py
+++ b/tests/daq/test_scaling.py
@@ -2,11 +2,16 @@
 
 import pytest
 
-from instro.daq.scaling.thermocouple import TC_TYPE, ThermocoupleSensor
+from instro.daq.scaling.thermocouple import (
+    TC_TYPE,
+    InverseThermocoupleSensor,
+    ThermocoupleSensor,
+)
 
 
 @pytest.mark.parametrize("cjc_temp", [0.0, 23.0])
 @pytest.mark.parametrize("temp", [-100.0, 0.0, 100.0])
 def test_thermocouple_inverse_scale_roundtrip(cjc_temp: float, temp: float) -> None:
-    scaler = ThermocoupleSensor(TC_TYPE.K, cjc_temp=cjc_temp)
-    assert scaler.scale(scaler.inverse_scale(temp)) == pytest.approx(temp, abs=0.1)
+    forward = ThermocoupleSensor(TC_TYPE.K, cjc_temp=cjc_temp)
+    inverse = InverseThermocoupleSensor(TC_TYPE.K, cjc_temp=cjc_temp)
+    assert forward.scale(inverse.scale(temp)) == pytest.approx(temp, abs=0.1)


### PR DESCRIPTION
## Summary

This PR adds inverse scaling to the `ThermocoupleSensor` scaler.

## Type of change

- [ ] Bug fix (`fix`)
- [x] New feature (`feat`)
- [ ] Breaking change (`feat!` / `fix!`)
- [ ] Refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] Chore / tooling (`chore`)

## Verification

<img width="1290" height="130" alt="verification" src="https://github.com/user-attachments/assets/3e7cae97-70b8-4aaa-95e1-904be4c81c33" />

## Tests

- [x] Unit tests added or updated
- [ ] Existing tests cover this change
- [ ] No tests — explain why:

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(driver): add support for Keysight E36300`)
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] Documentation updated if user-facing behavior changed
- [x] Code follows the style/conventions of the surrounding code

## Notes for reviewers