### PR TITLE
feat(transports): add composable ModbusDriver transport

### DIFF
--- a/docs/guides/docs.json
+++ b/docs/guides/docs.json
@@ -89,7 +89,8 @@
             "group": "Transports",
             "icon": "plug",
             "pages": [
-              "instrumentation/transports/visa"
+              "instrumentation/transports/visa",
+              "instrumentation/transports/modbus"
             ]
           },
           {

--- a/docs/guides/instrumentation/transports/modbus.mdx
+++ b/docs/guides/instrumentation/transports/modbus.mdx
@@ -1,0 +1,64 @@
+---
+title: ModbusDriver
+description: Modbus transport driver for building custom register-mapped instrument drivers
+---
+
+# ModbusDriver
+
+`ModbusDriver` is the Modbus transport that register-mapped instrument drivers sit on top of. It is a public part of the library so customers can build their own drivers for Modbus-attached instruments (temperature and process controllers, meters, PLCs) without wrapping [pymodbus](https://pymodbus.readthedocs.io/) themselves.
+
+It is intentionally narrow: it opens, closes, and locks a Modbus TCP or RTU connection and exposes raw function-code I/O plus typed register encode and decode. The caller owns the register map (which address holds what).
+
+<Note>
+Modbus is a register-and-coil protocol. A driver reads and writes numbered 16-bit registers and single-bit coils by address; there is no self-describing command set. `ModbusDriver` uses pymodbus under the hood and supports both Modbus TCP and Modbus RTU (serial).
+</Note>
+
+## When to reach for it
+
+`ModbusDriver` is the right starting point when any of the following are true:
+
+| If you want to... | `ModbusDriver` is the right fit because... |
+| --- | --- |
+| Talk to a **Modbus TCP or RTU** instrument | It wraps pymodbus and owns the client lifecycle, locking, and dead-socket reconnect |
+| Build a **vendor- or model-specific driver** whose register map is fixed in code | It exposes raw function-code ops and typed codec, so the driver composes it the same way a SCPI driver composes `VisaDriver` |
+| Use a **standalone client** for a register-mapped device | It is usable on its own, addressing registers directly by number |
+
+For a config-driven device where the register map lives in a JSON file rather than driver code, use [`ModbusDevice`](/instrumentation/protocols/modbus) instead. `ModbusDevice` composes `ModbusDriver` and adds semantic access by register alias, scaling, validation, and background polling.
+
+## Quickstart
+
+The most common use of `ModbusDriver` is as a transport inside an instrument driver. Here it is on its own, talking to a Modbus TCP device directly:
+
+```python
+from instro.lib.transports import ModbusDriver, TCPConnection
+
+modbus = ModbusDriver(TCPConnection(host="192.168.1.50", port=502, unit_id=1))
+modbus.open()
+try:
+    # Raw function-code access by address.
+    setpoint_regs = modbus.read_holding_registers(0x0100, count=2)
+
+    # Typed access decodes across registers, applying byte/word/long swaps.
+    process_value = modbus.read_typed("input", 0x0000, "float32")
+    modbus.write_typed("holding", 0x0100, 72.5, "float32")
+finally:
+    modbus.close()
+```
+
+Use `RTUConnection` for serial devices:
+
+```python
+from instro.lib.transports import ModbusDriver, RTUConnection
+
+modbus = ModbusDriver(RTUConnection(port="/dev/ttyUSB0", baudrate=19200, unit_id=1))
+```
+
+## Atomic multi-step sequences
+
+`ModbusDriver` serializes every op behind an internal reentrant lock, so a background poller and user code can share one connection safely. Hold the lock across several ops to keep them atomic (for example, select a page or bank register, then read from it):
+
+```python
+with modbus.lock():
+    modbus.write_holding_register(0x00FF, page)
+    values = modbus.read_holding_registers(0x0000, count=8)
+```

--- a/docs/guides/instrumentation/transports/visa.mdx
+++ b/docs/guides/instrumentation/transports/visa.mdx
@@ -23,7 +23,7 @@ It is intentionally narrow: it opens, closes, and locks a VISA resource and expo
 | Build a **vendor- or model-specific driver** that plugs into an `Instro*` instrument type (`InstroPSU`, `InstroDMM`, `InstroELoad`, …) for a device `instro` doesn't ship | It's the same transport every built-in SCPI driver uses, so your driver composes the same way |
 | Use a **standalone client** for a SCPI instrument that doesn't fit any existing instrument type | It's usable on its own, without an `Instro*` wrapper |
 
-If you're working with a non-VISA protocol (Modbus, raw TCP without VISA framing, a vendor REST API), use the appropriate protocol module (e.g. [ModbusDevice](/instrumentation/protocols/modbus)) or a plain client library instead.
+If you're working with a non-VISA protocol (Modbus, raw TCP without VISA framing, a vendor REST API), use the appropriate transport or protocol module instead. For Modbus-attached instruments, compose [`ModbusDriver`](/instrumentation/transports/modbus) the same way, or use the config-driven [`ModbusDevice`](/instrumentation/protocols/modbus).
 
 ## Quickstart
 

--- a/instro/lib/__init__.py
+++ b/instro/lib/__init__.py
@@ -3,6 +3,7 @@
 from instro.lib.exceptions import FeatureNotSupportedError, InstroError, InstrumentNotOpenError
 from instro.lib.instrument import Instrument
 from instro.lib.nominal import install_nominal_core_log_handler
+from instro.lib.transports.modbus import ModbusDriver
 from instro.lib.transports.visa import VisaConfig, VisaDriver
 from instro.lib.types import Command, DeviceInfo, LinearScale, Measurement, ScaleType
 
@@ -15,6 +16,7 @@ __all__ = [
     "InstrumentNotOpenError",
     "LinearScale",
     "Measurement",
+    "ModbusDriver",
     "ScaleType",
     "VisaConfig",
     "VisaDriver",

--- a/instro/lib/transports/__init__.py
+++ b/instro/lib/transports/__init__.py
@@ -1,5 +1,12 @@
-"""Transport drivers (VISA today; EtherNet/IP, OPC-UA, raw socket as they graduate from ``unstable``)."""
+"""Transport drivers (VISA and Modbus today; EtherNet/IP, OPC-UA, raw socket as they graduate from ``unstable``)."""
 
+from instro.lib.transports.modbus import (
+    DataType,
+    ModbusDriver,
+    RegisterType,
+    RTUConnection,
+    TCPConnection,
+)
 from instro.lib.transports.visa import (
     ControlFlow,
     Parity,
@@ -13,9 +20,14 @@ from instro.lib.transports.visa import (
 
 __all__ = [
     "ControlFlow",
+    "DataType",
+    "ModbusDriver",
     "Parity",
+    "RTUConnection",
+    "RegisterType",
     "SerialConfig",
     "StopBits",
+    "TCPConnection",
     "TerminatorConfig",
     "TimeoutConfig",
     "VisaConfig",

--- a/instro/lib/transports/modbus.py
+++ b/instro/lib/transports/modbus.py
@@ -1,0 +1,395 @@
+"""Modbus transport driver. Wraps pymodbus; callers own register maps, this owns I/O, framing, and locking."""
+
+from __future__ import annotations
+
+import functools
+import struct
+import threading
+from typing import TYPE_CHECKING, Literal
+
+from pydantic import BaseModel, Field
+from pymodbus.exceptions import ConnectionException as PymodbusConnectionException
+
+if TYPE_CHECKING:
+    from pymodbus.client import ModbusSerialClient, ModbusTcpClient
+
+
+class TCPConnection(BaseModel):
+    """Modbus TCP connection configuration."""
+
+    transport: Literal["tcp"] = "tcp"
+    host: str
+    port: int = Field(default=502, ge=1, le=65535)
+    unit_id: int = Field(default=1, ge=0, le=255)
+    timeout: float = Field(default=3.0, gt=0, description="Response timeout in seconds")
+
+
+class RTUConnection(BaseModel):
+    """Modbus RTU (serial) connection configuration."""
+
+    transport: Literal["rtu"] = "rtu"
+    port: str  # e.g., "/dev/ttyUSB0" (Linux), "/dev/cu.usbserial-1234" (macOS), "COM3" (Windows)
+    baudrate: int = 9600
+    parity: Literal["N", "E", "O"] = "N"
+    stopbits: Literal[1, 2] = 1
+    bytesize: Literal[5, 6, 7, 8] = 8
+    unit_id: int = Field(default=1, ge=0, le=255)
+    timeout: float = Field(default=3.0, gt=0, description="Response timeout in seconds")
+
+
+ConnectionType = TCPConnection | RTUConnection
+
+# Modbus protocol vocabulary. Single source of truth; ``instro.modbus.types`` re-exports these.
+RegisterType = Literal["holding", "input", "coil", "discrete"]
+DataType = Literal["uint16", "int16", "uint32", "int32", "uint64", "int64", "float32", "float64", "bool"]
+
+
+def _modbus_op(fn):
+    """Acquire the lock, run the operation, and clear dead sockets on failure.
+
+    The pymodbus sync client does not auto-reconnect between operations
+    (``reconnect_delay`` is async-only). It does call ``connect()`` before every
+    operation, creating a new socket when ``self._client.socket is None``. So on
+    a transport error we close the dead socket and re-raise — the next call gets
+    a fresh connection.
+    """
+
+    @functools.wraps(fn)
+    def wrapper(self, *args, **kwargs):
+        with self._lock:
+            if self._client is None:
+                raise RuntimeError("Modbus client not connected. Call open() first.")
+            try:
+                return fn(self, *args, **kwargs)
+            except (OSError, ConnectionError, PymodbusConnectionException):
+                self._client.close()
+                raise
+
+    return wrapper
+
+
+class ModbusDriver:
+    """Transport for Modbus TCP/RTU instruments. Composed by concrete drivers, not extended.
+
+    Thread-safe at the I/O level via an internal lock; use :meth:`lock` to keep a
+    multi-step Modbus sequence atomic. Raw function-code ops return/accept the
+    16-bit register words or coil bits on the wire; :meth:`read_typed` /
+    :meth:`write_typed` add typed encode/decode across registers.
+    """
+
+    def __init__(self, connection: TCPConnection | RTUConnection) -> None:
+        """Construct from a ``TCPConnection`` or ``RTUConnection``."""
+        self._connection = connection
+        self._client: ModbusTcpClient | ModbusSerialClient | None = None
+        self._lock = threading.RLock()
+
+    @property
+    def is_open(self) -> bool:
+        """Whether the underlying Modbus client is currently connected."""
+        return self._client is not None
+
+    @property
+    def unit_id(self) -> int:
+        """Modbus unit/slave ID from the connection config."""
+        return self._connection.unit_id
+
+    def open(self) -> None:
+        """Open the Modbus TCP/RTU connection."""
+        with self._lock:
+            if self._client is not None:
+                return
+
+            connection = self._connection
+            if isinstance(connection, TCPConnection):
+                from pymodbus.client import ModbusTcpClient
+
+                client: ModbusTcpClient | ModbusSerialClient = ModbusTcpClient(
+                    host=connection.host,
+                    port=connection.port,
+                    timeout=connection.timeout,
+                )
+            elif isinstance(connection, RTUConnection):
+                from pymodbus.client import ModbusSerialClient
+
+                client = ModbusSerialClient(
+                    port=connection.port,
+                    baudrate=connection.baudrate,
+                    parity=connection.parity,
+                    stopbits=connection.stopbits,
+                    bytesize=connection.bytesize,
+                    timeout=connection.timeout,
+                )
+            else:
+                raise ValueError(f"Unknown connection type: {type(connection)}")
+
+            if not client.connect():
+                target = (
+                    f"{connection.host}:{connection.port}" if isinstance(connection, TCPConnection) else connection.port
+                )
+                client.close()
+                raise ConnectionError(f"Failed to connect to Modbus device at {target}")
+
+            self._client = client
+
+    def close(self) -> None:
+        """Close the connection. Idempotent."""
+        with self._lock:
+            if self._client is not None:
+                self._client.close()
+                self._client = None
+
+    def lock(self) -> threading.RLock:
+        """Return the reentrant resource lock for atomic multi-step Modbus sequences.
+
+        Reentrant: the holding thread can call read/write ops inside the ``with``.
+        """
+        return self._lock
+
+    @_modbus_op
+    def read_holding_registers(self, address: int, count: int) -> list[int]:
+        """Read holding registers by address (FC03)."""
+        assert self._client is not None
+        result = self._client.read_holding_registers(address, count=count, device_id=self.unit_id)
+        if result.isError():
+            raise RuntimeError(self._format_modbus_error(f"reading holding registers at addr={address}", result))
+        return list(result.registers)
+
+    @_modbus_op
+    def read_input_registers(self, address: int, count: int) -> list[int]:
+        """Read input registers by address (FC04)."""
+        assert self._client is not None
+        result = self._client.read_input_registers(address, count=count, device_id=self.unit_id)
+        if result.isError():
+            raise RuntimeError(self._format_modbus_error(f"reading input registers at addr={address}", result))
+        return list(result.registers)
+
+    @_modbus_op
+    def write_holding_register(self, address: int, value: int) -> None:
+        """Write a single holding register by address (FC06)."""
+        assert self._client is not None
+        result = self._client.write_register(address, value, device_id=self.unit_id)
+        if result.isError():
+            raise RuntimeError(self._format_modbus_error(f"writing holding register at addr={address}", result))
+
+    @_modbus_op
+    def write_holding_registers(self, address: int, values: list[int]) -> None:
+        """Write multiple holding registers by address (FC16)."""
+        assert self._client is not None
+        result = self._client.write_registers(address, values, device_id=self.unit_id)
+        if result.isError():
+            raise RuntimeError(self._format_modbus_error(f"writing holding registers at addr={address}", result))
+
+    @_modbus_op
+    def read_coils(self, address: int, count: int) -> list[bool]:
+        """Read coils by address (FC01)."""
+        assert self._client is not None
+        result = self._client.read_coils(address, count=count, device_id=self.unit_id)
+        if result.isError():
+            raise RuntimeError(self._format_modbus_error(f"reading coils at addr={address}", result))
+        return list(result.bits[:count])
+
+    @_modbus_op
+    def write_coil(self, address: int, value: bool) -> None:
+        """Write a single coil by address (FC05)."""
+        assert self._client is not None
+        result = self._client.write_coil(address, value, device_id=self.unit_id)
+        if result.isError():
+            raise RuntimeError(self._format_modbus_error(f"writing coil at addr={address}", result))
+
+    @_modbus_op
+    def write_coils(self, address: int, values: list[bool]) -> None:
+        """Write multiple coils by address (FC15)."""
+        assert self._client is not None
+        result = self._client.write_coils(address, values, device_id=self.unit_id)
+        if result.isError():
+            raise RuntimeError(self._format_modbus_error(f"writing coils at addr={address}", result))
+
+    @_modbus_op
+    def read_discrete_inputs(self, address: int, count: int) -> list[bool]:
+        """Read discrete inputs by address (FC02)."""
+        assert self._client is not None
+        result = self._client.read_discrete_inputs(address, count=count, device_id=self.unit_id)
+        if result.isError():
+            raise RuntimeError(self._format_modbus_error(f"reading discrete inputs at addr={address}", result))
+        return list(result.bits[:count])
+
+    def read_typed(
+        self,
+        register_type: RegisterType,
+        address: int,
+        data_type: DataType,
+        *,
+        byte_swap: bool = False,
+        word_swap: bool = False,
+        long_swap: bool = False,
+    ) -> int | float:
+        """Read ``address`` as ``data_type``, dispatching by ``register_type`` and decoding across registers."""
+        match register_type:
+            case "holding":
+                raw_regs = self.read_holding_registers(address, self.register_count(data_type))
+            case "input":
+                raw_regs = self.read_input_registers(address, self.register_count(data_type))
+            case "coil":
+                return int(self.read_coils(address, 1)[0])
+            case "discrete":
+                return int(self.read_discrete_inputs(address, 1)[0])
+            case _:
+                raise ValueError(f"Unknown register type: {register_type}")
+        return self.decode_registers(raw_regs, data_type, byte_swap, word_swap, long_swap)
+
+    def write_typed(
+        self,
+        register_type: RegisterType,
+        address: int,
+        value: int | float | bool,
+        data_type: DataType,
+        *,
+        byte_swap: bool = False,
+        word_swap: bool = False,
+        long_swap: bool = False,
+    ) -> None:
+        """Encode ``value`` as ``data_type`` and write it to ``address``, dispatching by ``register_type``."""
+        match register_type:
+            case "holding":
+                encoded = self.encode_value(value, data_type, byte_swap, word_swap, long_swap)
+                if len(encoded) == 1:
+                    self.write_holding_register(address, encoded[0])
+                else:
+                    self.write_holding_registers(address, encoded)
+            case "coil":
+                self.write_coil(address, bool(value))
+            case "input" | "discrete":
+                raise ValueError(f"Cannot write to read-only register type: {register_type}")
+            case _:
+                raise ValueError(f"Unknown register type: {register_type}")
+
+    @staticmethod
+    def register_count(data_type: DataType) -> int:
+        """Number of 16-bit registers ``data_type`` spans (uint16→1, uint32→2, uint64→4)."""
+        match data_type:
+            case "uint16" | "int16" | "bool":
+                return 1
+            case "uint32" | "int32" | "float32":
+                return 2
+            case "uint64" | "int64" | "float64":
+                return 4
+            case _:
+                return 1
+
+    @staticmethod
+    def decode_registers(
+        registers: list[int],
+        data_type: DataType,
+        byte_swap: bool = False,
+        word_swap: bool = False,
+        long_swap: bool = False,
+    ) -> int | float:
+        """Decode raw 16-bit registers into a typed value, applying byte/word/long swaps as configured."""
+        raw_bytes = b"".join(reg.to_bytes(2, "big") for reg in registers)
+
+        if byte_swap:
+            raw_bytes = b"".join(raw_bytes[i : i + 2][::-1] for i in range(0, len(raw_bytes), 2))
+
+        if word_swap and len(raw_bytes) >= 4:
+            swapped = bytearray()
+            for i in range(0, len(raw_bytes), 4):
+                chunk = raw_bytes[i : i + 4]
+                if len(chunk) == 4:
+                    swapped.extend(chunk[2:4] + chunk[0:2])
+                else:
+                    swapped.extend(chunk)
+            raw_bytes = bytes(swapped)
+
+        if long_swap and len(raw_bytes) == 8:
+            raw_bytes = raw_bytes[4:8] + raw_bytes[0:4]
+
+        match data_type:
+            case "uint16":
+                return struct.unpack(">H", raw_bytes)[0]
+            case "int16":
+                return struct.unpack(">h", raw_bytes)[0]
+            case "uint32":
+                return struct.unpack(">I", raw_bytes)[0]
+            case "int32":
+                return struct.unpack(">i", raw_bytes)[0]
+            case "uint64":
+                return struct.unpack(">Q", raw_bytes)[0]
+            case "int64":
+                return struct.unpack(">q", raw_bytes)[0]
+            case "float32":
+                return float(struct.unpack(">f", raw_bytes)[0])
+            case "float64":
+                return float(struct.unpack(">d", raw_bytes)[0])
+            case "bool":
+                return int(registers[0] != 0)
+            case _:
+                raise ValueError(f"Unknown data type: {data_type}")
+
+    @staticmethod
+    def encode_value(
+        value: int | float | bool,
+        data_type: DataType,
+        byte_swap: bool = False,
+        word_swap: bool = False,
+        long_swap: bool = False,
+    ) -> list[int]:
+        """Encode a typed value into 16-bit registers, applying byte/word/long swaps as configured."""
+        match data_type:
+            case "uint16":
+                raw_bytes = struct.pack(">H", round(value))
+            case "int16":
+                raw_bytes = struct.pack(">h", round(value))
+            case "uint32":
+                raw_bytes = struct.pack(">I", round(value))
+            case "int32":
+                raw_bytes = struct.pack(">i", round(value))
+            case "uint64":
+                raw_bytes = struct.pack(">Q", round(value))
+            case "int64":
+                raw_bytes = struct.pack(">q", round(value))
+            case "float32":
+                raw_bytes = struct.pack(">f", float(value))
+            case "float64":
+                raw_bytes = struct.pack(">d", float(value))
+            case "bool":
+                return [1 if value else 0]
+            case _:
+                raise ValueError(f"Unknown data type: {data_type}")
+
+        if long_swap and len(raw_bytes) == 8:
+            raw_bytes = raw_bytes[4:8] + raw_bytes[0:4]
+
+        if word_swap and len(raw_bytes) >= 4:
+            swapped = bytearray()
+            for i in range(0, len(raw_bytes), 4):
+                chunk = raw_bytes[i : i + 4]
+                if len(chunk) == 4:
+                    swapped.extend(chunk[2:4] + chunk[0:2])
+                else:
+                    swapped.extend(chunk)
+            raw_bytes = bytes(swapped)
+
+        if byte_swap:
+            raw_bytes = b"".join(raw_bytes[i : i + 2][::-1] for i in range(0, len(raw_bytes), 2))
+
+        return [int.from_bytes(raw_bytes[i : i + 2], "big") for i in range(0, len(raw_bytes), 2)]
+
+    @staticmethod
+    def _format_modbus_error(operation: str, result: object) -> str:
+        """Format a Modbus error response, including the standard exception-code name (FC 0x01–0x0B)."""
+        exception_codes = {
+            1: "IllegalFunction",
+            2: "IllegalDataAddress",
+            3: "IllegalDataValue",
+            4: "SlaveDeviceFailure",
+            5: "Acknowledge",
+            6: "SlaveDeviceBusy",
+            8: "MemoryParityError",
+            10: "GatewayPathUnavailable",
+            11: "GatewayNoResponse",
+        }
+        code = getattr(result, "exception_code", 0)
+        name = exception_codes.get(code, "Unknown")
+        if code:
+            return f"Modbus error {operation}: {name} (0x{code:02X})"
+        return f"Modbus error {operation}: {result}"

--- a/instro/lib/transports/modbus.py
+++ b/instro/lib/transports/modbus.py
@@ -83,9 +83,16 @@ class ModbusDriver:
         self._client: ModbusTcpClient | ModbusSerialClient | None = None
         self._lock = threading.RLock()
 
+    def __del__(self) -> None:
+        """Best-effort close on garbage collection."""
+        try:
+            self.close()
+        except Exception:
+            pass
+
     @property
     def is_open(self) -> bool:
-        """Whether the underlying Modbus client is currently connected."""
+        """Whether the client has been opened and not closed. Stays ``True`` across a dropped socket, which the next op reconnects."""
         return self._client is not None
 
     @property

--- a/instro/lib/transports/modbus.py
+++ b/instro/lib/transports/modbus.py
@@ -229,17 +229,24 @@ class ModbusDriver:
         byte_swap: bool = False,
         word_swap: bool = False,
         long_swap: bool = False,
-    ) -> int | float:
-        """Read ``address`` as ``data_type``, dispatching by ``register_type`` and decoding across registers."""
+    ) -> int | float | bool:
+        """Read ``address`` as ``data_type``, dispatching by ``register_type`` and decoding across registers.
+
+        Coils and discrete inputs are single-bit, so ``data_type`` must be ``"bool"`` and the read returns a ``bool``.
+        """
         match register_type:
             case "holding":
                 raw_regs = self.read_holding_registers(address, self.register_count(data_type))
             case "input":
                 raw_regs = self.read_input_registers(address, self.register_count(data_type))
             case "coil":
-                return int(self.read_coils(address, 1)[0])
+                if data_type != "bool":
+                    raise ValueError(f"coil registers are single-bit; data_type must be 'bool', got '{data_type}'")
+                return bool(self.read_coils(address, 1)[0])
             case "discrete":
-                return int(self.read_discrete_inputs(address, 1)[0])
+                if data_type != "bool":
+                    raise ValueError(f"discrete registers are single-bit; data_type must be 'bool', got '{data_type}'")
+                return bool(self.read_discrete_inputs(address, 1)[0])
             case _:
                 raise ValueError(f"Unknown register type: {register_type}")
         return self.decode_registers(raw_regs, data_type, byte_swap, word_swap, long_swap)
@@ -255,7 +262,10 @@ class ModbusDriver:
         word_swap: bool = False,
         long_swap: bool = False,
     ) -> None:
-        """Encode ``value`` as ``data_type`` and write it to ``address``, dispatching by ``register_type``."""
+        """Encode ``value`` as ``data_type`` and write it to ``address``, dispatching by ``register_type``.
+
+        Coils are single-bit, so ``data_type`` must be ``"bool"`` and ``value`` must be a ``bool`` (no numeric coercion).
+        """
         match register_type:
             case "holding":
                 encoded = self.encode_value(value, data_type, byte_swap, word_swap, long_swap)
@@ -264,7 +274,11 @@ class ModbusDriver:
                 else:
                     self.write_holding_registers(address, encoded)
             case "coil":
-                self.write_coil(address, bool(value))
+                if data_type != "bool":
+                    raise ValueError(f"coil registers are single-bit; data_type must be 'bool', got '{data_type}'")
+                if not isinstance(value, bool):
+                    raise ValueError(f"coil writes require a bool value, got {type(value).__name__} {value!r}")
+                self.write_coil(address, value)
             case "input" | "discrete":
                 raise ValueError(f"Cannot write to read-only register type: {register_type}")
             case _:

--- a/instro/modbus/modbus.py
+++ b/instro/modbus/modbus.py
@@ -2,18 +2,13 @@
 
 from __future__ import annotations
 
-import functools
-import struct
-import threading
 import time
 from pathlib import Path
-from typing import TYPE_CHECKING
-
-from pymodbus.exceptions import ConnectionException as PymodbusConnectionException
 
 from instro.lib import Command, Instrument, Measurement
 from instro.lib.instrument import publish_command, publish_measurement
 from instro.lib.publishers import Publisher
+from instro.lib.transports.modbus import ModbusDriver
 
 from .types import (
     BOOL_DATA_TYPES,
@@ -25,37 +20,6 @@ from .types import (
     RTUConnection,
     TCPConnection,
 )
-
-if TYPE_CHECKING:
-    from pymodbus.client import ModbusSerialClient, ModbusTcpClient
-
-
-def _modbus_op(fn):
-    """Acquire the lock, run the operation, and clear dead sockets on failure.
-
-    The pymodbus *sync* client does NOT auto-reconnect between operations
-    (``reconnect_delay`` is async-only). It does call ``connect()`` before
-    every operation, which creates a new socket when ``self.socket is None``.
-    So on a transport error we just close the dead socket and re-raise — the
-    next call gets a fresh connection.
-    """
-
-    @functools.wraps(fn)
-    def wrapper(self, *args, **kwargs):
-        with self._lock:
-            if self._background_stop_event.is_set():
-                raise RuntimeError("Instrument is shutting down.")
-            if self._client is None:
-                raise RuntimeError("Modbus client not connected. Call open() first.")
-            assert self._client is not None
-            try:
-                return fn(self, *args, **kwargs)
-            except (OSError, ConnectionError, PymodbusConnectionException):
-                # Clear the dead socket so pymodbus's connect() creates a fresh one.
-                self._client.close()
-                raise
-
-    return wrapper
 
 
 class ModbusDevice(Instrument):
@@ -118,9 +82,7 @@ class ModbusDevice(Instrument):
         super().__init__(name=instrument_name, publishers=publishers, **kwargs)
 
         self._config = resolved_config
-        self._connection = resolved_connection
-        self._client: ModbusTcpClient | ModbusSerialClient | None = None
-        self._lock = threading.RLock()
+        self._modbus = ModbusDriver(resolved_connection)
 
         self._define_background_daemon()
 
@@ -150,59 +112,27 @@ class ModbusDevice(Instrument):
     @property
     def unit_id(self) -> int:
         """Modbus unit/slave ID from the active connection config."""
-        return self._connection.unit_id
+        return self._modbus.unit_id
+
+    def _require_ready_locked(self) -> None:
+        """Reject I/O during shutdown or before the transport is open. Call under ``self._modbus.lock()``."""
+        if self._background_stop_event.is_set():
+            raise RuntimeError("Instrument is shutting down.")
+        if not self._modbus.is_open:
+            raise RuntimeError("Modbus client not connected. Call open() first.")
 
     # ============ Connection Management ============
 
     def open(self) -> None:
         """Open the Modbus TCP/RTU connection."""
-        with self._lock:
-            self._background_stop_event.clear()
-            if self._client is not None:
-                return
-
-            connection = self._connection
-            if isinstance(connection, TCPConnection):
-                from pymodbus.client import ModbusTcpClient
-
-                self._client = ModbusTcpClient(
-                    host=connection.host,
-                    port=connection.port,
-                    timeout=connection.timeout,
-                )
-            elif isinstance(connection, RTUConnection):
-                from pymodbus.client import ModbusSerialClient
-
-                self._client = ModbusSerialClient(
-                    port=connection.port,
-                    baudrate=connection.baudrate,
-                    parity=connection.parity,
-                    stopbits=connection.stopbits,
-                    bytesize=connection.bytesize,
-                    timeout=connection.timeout,
-                )
-            else:
-                raise ValueError(f"Unknown connection type: {type(connection)}")
-
-            if not self._client.connect():
-                if isinstance(connection, TCPConnection):
-                    target = f"{connection.host}:{connection.port}"
-                elif isinstance(connection, RTUConnection):
-                    target = connection.port
-                else:
-                    target = str(connection)
-                self._client.close()
-                self._client = None
-                raise ConnectionError(f"Failed to connect to Modbus device at {target}")
+        self._background_stop_event.clear()
+        self._modbus.open()
 
     def close(self) -> None:
         """Close the connection and stop the daemon."""
         self._background_stop_event.set()
         super().close()
-        with self._lock:
-            if self._client is not None:
-                self._client.close()
-                self._client = None
+        self._modbus.close()
 
     # ============ Semantic Access (by alias) ============
 
@@ -210,7 +140,16 @@ class ModbusDevice(Instrument):
     def read(self, alias: str, **kwargs) -> Measurement:
         """Read the register named ``alias`` and return the scaled value."""
         reg = self._config.get_register(alias)
-        raw_value = self._read_register_raw(reg)
+        with self._modbus.lock():
+            self._require_ready_locked()
+            raw_value = self._modbus.read_typed(
+                reg.register_type,
+                reg.starting_address,
+                reg.data_type,
+                byte_swap=reg.byte_swap,
+                word_swap=reg.word_swap,
+                long_swap=reg.long_swap,
+            )
         scaled_value = self._apply_scaling(raw_value, reg)
         channel_data = self._build_register_channels(reg, raw_value, scaled_value)
         return self._package_register_measurement(channel_data, **kwargs)
@@ -229,17 +168,19 @@ class ModbusDevice(Instrument):
         else:
             total_count = (last.starting_address + last.register_count) - start_address
 
-        match first.register_type:
-            case "holding":
-                raw_regs = self._read_holding_registers(start_address, total_count)
-            case "input":
-                raw_regs = self._read_input_registers(start_address, total_count)
-            case "coil":
-                raw_bits = self._read_coils(start_address, total_count)
-            case "discrete":
-                raw_bits = self._read_discrete_inputs(start_address, total_count)
-            case _:
-                raise ValueError(f"Unknown register type: {first.register_type}")
+        with self._modbus.lock():
+            self._require_ready_locked()
+            match first.register_type:
+                case "holding":
+                    raw_regs = self._modbus.read_holding_registers(start_address, total_count)
+                case "input":
+                    raw_regs = self._modbus.read_input_registers(start_address, total_count)
+                case "coil":
+                    raw_bits = self._modbus.read_coils(start_address, total_count)
+                case "discrete":
+                    raw_bits = self._modbus.read_discrete_inputs(start_address, total_count)
+                case _:
+                    raise ValueError(f"Unknown register type: {first.register_type}")
 
         channel_data: dict[str, list[float | int]] = {}
 
@@ -250,7 +191,7 @@ class ModbusDevice(Instrument):
                 scaled_value = raw_value
             else:
                 reg_slice = raw_regs[offset : offset + reg.register_count]
-                raw_value = self._decode_registers(
+                raw_value = self._modbus.decode_registers(
                     reg_slice, reg.data_type, reg.byte_swap, reg.word_swap, reg.long_swap
                 )
                 scaled_value = self._apply_scaling(raw_value, reg)
@@ -317,7 +258,17 @@ class ModbusDevice(Instrument):
 
         raw_value = self._validate_raw_value_range(raw_value, reg, alias)
 
-        self._write_register_raw(reg, raw_value)
+        with self._modbus.lock():
+            self._require_ready_locked()
+            self._modbus.write_typed(
+                reg.register_type,
+                reg.starting_address,
+                raw_value,
+                reg.data_type,
+                byte_swap=reg.byte_swap,
+                word_swap=reg.word_swap,
+                long_swap=reg.long_swap,
+            )
         timestamp = time.time_ns()
 
         # Apply write delay
@@ -425,216 +376,6 @@ class ModbusDevice(Instrument):
                 )
 
         return raw_value
-
-    @staticmethod
-    def _format_modbus_error(operation: str, result: object) -> str:
-        """Format a Modbus error response, including the standard exception-code name (FC 0x01–0x0B)."""
-        exception_codes = {
-            1: "IllegalFunction",
-            2: "IllegalDataAddress",
-            3: "IllegalDataValue",
-            4: "SlaveDeviceFailure",
-            5: "Acknowledge",
-            6: "SlaveDeviceBusy",
-            8: "MemoryParityError",
-            10: "GatewayPathUnavailable",
-            11: "GatewayNoResponse",
-        }
-        code = getattr(result, "exception_code", 0)
-        name = exception_codes.get(code, "Unknown")
-        if code:
-            return f"Modbus error {operation}: {name} (0x{code:02X})"
-        return f"Modbus error {operation}: {result}"
-
-    @_modbus_op
-    def _read_holding_registers(self, address: int, count: int) -> list[int]:
-        """Read holding registers by address (FC03)."""
-        assert self._client is not None
-        result = self._client.read_holding_registers(address, count=count, device_id=self.unit_id)
-        if result.isError():
-            raise RuntimeError(self._format_modbus_error(f"reading holding registers at addr={address}", result))
-        return list(result.registers)
-
-    @_modbus_op
-    def _read_input_registers(self, address: int, count: int) -> list[int]:
-        """Read input registers by address (FC04)."""
-        assert self._client is not None
-        result = self._client.read_input_registers(address, count=count, device_id=self.unit_id)
-        if result.isError():
-            raise RuntimeError(self._format_modbus_error(f"reading input registers at addr={address}", result))
-        return list(result.registers)
-
-    @_modbus_op
-    def _write_holding_register(self, address: int, value: int) -> None:
-        """Write a single holding register by address (FC06)."""
-        assert self._client is not None
-        result = self._client.write_register(address, value, device_id=self.unit_id)
-        if result.isError():
-            raise RuntimeError(self._format_modbus_error(f"writing holding register at addr={address}", result))
-
-    @_modbus_op
-    def _write_holding_registers(self, address: int, values: list[int]) -> None:
-        """Write multiple holding registers by address (FC16)."""
-        assert self._client is not None
-        result = self._client.write_registers(address, values, device_id=self.unit_id)
-        if result.isError():
-            raise RuntimeError(self._format_modbus_error(f"writing holding registers at addr={address}", result))
-
-    @_modbus_op
-    def _read_coils(self, address: int, count: int) -> list[bool]:
-        """Read coils by address (FC01)."""
-        assert self._client is not None
-        result = self._client.read_coils(address, count=count, device_id=self.unit_id)
-        if result.isError():
-            raise RuntimeError(self._format_modbus_error(f"reading coils at addr={address}", result))
-        return list(result.bits[:count])
-
-    @_modbus_op
-    def _write_coil(self, address: int, value: bool) -> None:
-        """Write a single coil by address (FC05)."""
-        assert self._client is not None
-        result = self._client.write_coil(address, value, device_id=self.unit_id)
-        if result.isError():
-            raise RuntimeError(self._format_modbus_error(f"writing coil at addr={address}", result))
-
-    @_modbus_op
-    def _write_coils(self, address: int, values: list[bool]) -> None:
-        """Write multiple coils by address (FC15)."""
-        assert self._client is not None
-        result = self._client.write_coils(address, values, device_id=self.unit_id)
-        if result.isError():
-            raise RuntimeError(self._format_modbus_error(f"writing coils at addr={address}", result))
-
-    @_modbus_op
-    def _read_discrete_inputs(self, address: int, count: int) -> list[bool]:
-        """Read discrete inputs by address (FC02)."""
-        assert self._client is not None
-        result = self._client.read_discrete_inputs(address, count=count, device_id=self.unit_id)
-        if result.isError():
-            raise RuntimeError(self._format_modbus_error(f"reading discrete inputs at addr={address}", result))
-        return list(result.bits[:count])
-
-    def _read_register_raw(self, reg: RegisterDef) -> int | float:
-        """Dispatch by ``register_type`` (holding/input/coil/discrete) and decode by ``data_type``."""
-        match reg.register_type:
-            case "holding":
-                raw_regs = self._read_holding_registers(reg.starting_address, reg.register_count)
-            case "input":
-                raw_regs = self._read_input_registers(reg.starting_address, reg.register_count)
-            case "coil":
-                bits = self._read_coils(reg.starting_address, 1)
-                return int(bits[0])
-            case "discrete":
-                bits = self._read_discrete_inputs(reg.starting_address, 1)
-                return int(bits[0])
-            case _:
-                raise ValueError(f"Unknown register type: {reg.register_type}")
-
-        return self._decode_registers(raw_regs, reg.data_type, reg.byte_swap, reg.word_swap, reg.long_swap)
-
-    def _write_register_raw(self, reg: RegisterDef, value: int | float | bool) -> None:
-        """Encode ``value`` per ``data_type`` and dispatch to the matching write function code."""
-        match reg.register_type:
-            case "holding":
-                encoded = self._encode_value(value, reg.data_type, reg.byte_swap, reg.word_swap, reg.long_swap)
-                if len(encoded) == 1:
-                    self._write_holding_register(reg.starting_address, encoded[0])
-                else:
-                    self._write_holding_registers(reg.starting_address, encoded)
-            case "coil":
-                self._write_coil(reg.starting_address, bool(value))
-            case "input" | "discrete":
-                raise ValueError(f"Cannot write to read-only register type: {reg.register_type}")
-            case _:
-                raise ValueError(f"Unknown register type: {reg.register_type}")
-
-    def _decode_registers(
-        self, registers: list[int], data_type: str, byte_swap: bool, word_swap: bool, long_swap: bool
-    ) -> int | float:
-        """Decode raw 16-bit registers into a typed value, applying byte/word/long swaps as configured."""
-        raw_bytes = b"".join(reg.to_bytes(2, "big") for reg in registers)
-
-        if byte_swap:
-            raw_bytes = b"".join(raw_bytes[i : i + 2][::-1] for i in range(0, len(raw_bytes), 2))
-
-        if word_swap and len(raw_bytes) >= 4:
-            swapped = bytearray()
-            for i in range(0, len(raw_bytes), 4):
-                chunk = raw_bytes[i : i + 4]
-                if len(chunk) == 4:
-                    swapped.extend(chunk[2:4] + chunk[0:2])
-                else:
-                    swapped.extend(chunk)
-            raw_bytes = bytes(swapped)
-
-        if long_swap and len(raw_bytes) == 8:
-            raw_bytes = raw_bytes[4:8] + raw_bytes[0:4]
-
-        match data_type:
-            case "uint16":
-                return struct.unpack(">H", raw_bytes)[0]
-            case "int16":
-                return struct.unpack(">h", raw_bytes)[0]
-            case "uint32":
-                return struct.unpack(">I", raw_bytes)[0]
-            case "int32":
-                return struct.unpack(">i", raw_bytes)[0]
-            case "uint64":
-                return struct.unpack(">Q", raw_bytes)[0]
-            case "int64":
-                return struct.unpack(">q", raw_bytes)[0]
-            case "float32":
-                return float(struct.unpack(">f", raw_bytes)[0])
-            case "float64":
-                return float(struct.unpack(">d", raw_bytes)[0])
-            case "bool":
-                return int(registers[0] != 0)
-            case _:
-                raise ValueError(f"Unknown data type: {data_type}")
-
-    def _encode_value(
-        self, value: int | float | bool, data_type: str, byte_swap: bool, word_swap: bool, long_swap: bool
-    ) -> list[int]:
-        """Encode a typed value into 16-bit registers, applying byte/word/long swaps as configured."""
-        match data_type:
-            case "uint16":
-                raw_bytes = struct.pack(">H", round(value))
-            case "int16":
-                raw_bytes = struct.pack(">h", round(value))
-            case "uint32":
-                raw_bytes = struct.pack(">I", round(value))
-            case "int32":
-                raw_bytes = struct.pack(">i", round(value))
-            case "uint64":
-                raw_bytes = struct.pack(">Q", round(value))
-            case "int64":
-                raw_bytes = struct.pack(">q", round(value))
-            case "float32":
-                raw_bytes = struct.pack(">f", float(value))
-            case "float64":
-                raw_bytes = struct.pack(">d", float(value))
-            case "bool":
-                return [1 if value else 0]
-            case _:
-                raise ValueError(f"Unknown data type: {data_type}")
-
-        if long_swap and len(raw_bytes) == 8:
-            raw_bytes = raw_bytes[4:8] + raw_bytes[0:4]
-
-        if word_swap and len(raw_bytes) >= 4:
-            swapped = bytearray()
-            for i in range(0, len(raw_bytes), 4):
-                chunk = raw_bytes[i : i + 4]
-                if len(chunk) == 4:
-                    swapped.extend(chunk[2:4] + chunk[0:2])
-                else:
-                    swapped.extend(chunk)
-            raw_bytes = bytes(swapped)
-
-        if byte_swap:
-            raw_bytes = b"".join(raw_bytes[i : i + 2][::-1] for i in range(0, len(raw_bytes), 2))
-
-        return [int.from_bytes(raw_bytes[i : i + 2], "big") for i in range(0, len(raw_bytes), 2)]
 
     def _apply_scaling(self, raw_value: int | float, reg: RegisterDef) -> int | float:
         """Apply ``reg.scale`` to ``raw_value`` if scaling is configured; otherwise pass through."""

--- a/instro/modbus/modbus.py
+++ b/instro/modbus/modbus.py
@@ -187,7 +187,7 @@ class ModbusDevice(Instrument):
         for reg in regs:
             offset = reg.starting_address - start_address
             if is_bit_type:
-                raw_value: int | float = int(raw_bits[offset])
+                raw_value: int | float | bool = bool(raw_bits[offset])
                 scaled_value = raw_value
             else:
                 reg_slice = raw_regs[offset : offset + reg.register_count]
@@ -258,12 +258,16 @@ class ModbusDevice(Instrument):
 
         raw_value = self._validate_raw_value_range(raw_value, reg, alias)
 
+        # Coils are single-bit: the transport requires a real bool. _validate_write_value has
+        # already constrained the value to bool or 0/1, so coercing here is safe.
+        wire_value = bool(raw_value) if reg.register_type == "coil" else raw_value
+
         with self._modbus.lock():
             self._require_ready_locked()
             self._modbus.write_typed(
                 reg.register_type,
                 reg.starting_address,
-                raw_value,
+                wire_value,
                 reg.data_type,
                 byte_swap=reg.byte_swap,
                 word_swap=reg.word_swap,

--- a/instro/modbus/types.py
+++ b/instro/modbus/types.py
@@ -1,13 +1,20 @@
-"""Modbus configuration types (Pydantic). ``DeviceInfo``/``LinearScale``/``ScaleType`` come from ``instro.lib.types``."""
+"""Modbus configuration types (Pydantic). Connection configs and protocol vocabulary come from ``instro.lib.transports.modbus``; ``DeviceInfo``/``LinearScale``/``ScaleType`` from ``instro.lib.types``."""
 
 from __future__ import annotations
 
 from functools import cached_property
 from pathlib import Path
-from typing import Literal
 
 from pydantic import BaseModel, Field, model_validator
 
+from instro.lib.transports.modbus import (
+    ConnectionType,
+    DataType,
+    ModbusDriver,
+    RegisterType,
+    RTUConnection,
+    TCPConnection,
+)
 from instro.lib.types import (
     DeviceInfo,
     LinearScale,
@@ -23,6 +30,8 @@ __all__ = [
     "TimingConfig",
     "TCPConnection",
     "RTUConnection",
+    "RegisterType",
+    "DataType",
     "RegisterDef",
     "BitDef",
 ]
@@ -63,19 +72,6 @@ FLOAT_DATA_TYPES = ("float32", "float64")
 BOOL_DATA_TYPES = ("bool",)
 ALL_DATA_TYPES = INTEGER_DATA_TYPES + FLOAT_DATA_TYPES + BOOL_DATA_TYPES
 
-# Type alias for use in Literal annotations
-DataType = Literal[
-    "uint16",
-    "int16",
-    "uint32",
-    "int32",
-    "uint64",
-    "int64",
-    "float32",
-    "float64",
-    "bool",
-]
-
 
 # ============ Timing Config ============
 
@@ -85,35 +81,6 @@ class TimingConfig(BaseModel):
 
     poll_interval: float = Field(ge=0.01, le=10.0, description="Polling interval in seconds")
     write_delay_ms: int = Field(default=0, ge=0, description="Delay in milliseconds applied after every write")
-
-
-# ============ Connection Configs ============
-
-
-class TCPConnection(BaseModel):
-    """Modbus TCP connection configuration."""
-
-    transport: Literal["tcp"] = "tcp"
-    host: str
-    port: int = Field(default=502, ge=1, le=65535)
-    unit_id: int = Field(default=1, ge=0, le=255)
-    timeout: float = Field(default=3.0, gt=0, description="Response timeout in seconds")
-
-
-class RTUConnection(BaseModel):
-    """Modbus RTU (serial) connection configuration."""
-
-    transport: Literal["rtu"] = "rtu"
-    port: str  # e.g., "/dev/ttyUSB0" (Linux), "/dev/cu.usbserial-1234" (macOS), "COM3" (Windows)
-    baudrate: int = 9600
-    parity: Literal["N", "E", "O"] = "N"
-    stopbits: Literal[1, 2] = 1
-    bytesize: Literal[5, 6, 7, 8] = 8
-    unit_id: int = Field(default=1, ge=0, le=255)
-    timeout: float = Field(default=3.0, gt=0, description="Response timeout in seconds")
-
-
-ConnectionType = TCPConnection | RTUConnection
 
 
 # ============ Register Definition ============
@@ -134,7 +101,7 @@ class RegisterDef(BaseModel):
     name: str = Field(description="Unique name/alias for this register")
     description: str | None = None
     starting_address: int = Field(ge=0, le=65535)
-    register_type: Literal["holding", "input", "coil", "discrete"] = "holding"
+    register_type: RegisterType = "holding"
     data_type: DataType = "uint16"
     byte_swap: bool = False
     word_swap: bool = False
@@ -315,17 +282,7 @@ class RegisterDef(BaseModel):
     @property
     def register_count(self) -> int:
         """Number of 16-bit registers this data type spans (uint16→1, uint32→2, uint64→4)."""
-        match self.data_type:
-            case "uint16" | "int16":
-                return 1
-            case "uint32" | "int32" | "float32":
-                return 2
-            case "uint64" | "int64" | "float64":
-                return 4
-            case "bool":
-                return 1
-            case _:
-                return 1
+        return ModbusDriver.register_count(self.data_type)
 
 
 # ============ Top-Level Config ============

--- a/instro/modbus/types.py
+++ b/instro/modbus/types.py
@@ -277,6 +277,16 @@ class RegisterDef(BaseModel):
                     seen.add(i)
                 raise ValueError(f"Duplicate bit_index values in bitmap: {sorted(set(dupes))}")
 
+        # Coils and discrete inputs are single-bit: data_type must be bool. Coerce the default
+        # (data_type otherwise defaults to uint16) when omitted; reject an explicit non-bool.
+        # Runs last so the more specific bitmap/scale/swap errors above win when they also apply.
+        if self.register_type in ("coil", "discrete") and self.data_type != "bool":
+            if "data_type" in self.model_fields_set:
+                raise ValueError(
+                    f"{self.register_type} registers are single-bit; data_type must be 'bool', got '{self.data_type}'"
+                )
+            self.data_type = "bool"
+
         return self
 
     @property

--- a/tests/lib/test_modbus_driver.py
+++ b/tests/lib/test_modbus_driver.py
@@ -6,6 +6,7 @@ import asyncio
 import struct
 import threading
 import time
+from unittest.mock import patch
 
 import pytest
 from pymodbus.datastore import (
@@ -13,6 +14,7 @@ from pymodbus.datastore import (
     ModbusSequentialDataBlock,
     ModbusServerContext,
 )
+from pymodbus.exceptions import ConnectionException
 from pymodbus.server import StartAsyncTcpServer
 
 from instro.lib.transports import ModbusDriver, RTUConnection, TCPConnection
@@ -166,6 +168,23 @@ class TestLifecycle:
     def test_del_on_unopened_is_safe(self):
         ModbusDriver(TCPConnection(host="127.0.0.1", port=TEST_PORT)).__del__()  # no raise
 
+    def test_reconnects_after_transport_error(self, modbus_server):
+        drv = ModbusDriver(TCPConnection(host="127.0.0.1", port=TEST_PORT))
+        drv.open()
+        try:
+            assert drv.read_holding_registers(100, 1) == [TEST_DATA["holding_uint16"]]
+
+            # Force one transport error at the pymodbus client layer; _modbus_op should
+            # drop the dead socket and re-raise.
+            with patch.object(drv._client, "read_holding_registers", side_effect=ConnectionException("boom")):
+                with pytest.raises(ConnectionException):
+                    drv.read_holding_registers(100, 1)
+
+            # The next real op reconnects (pymodbus connect() rebuilds the socket) and succeeds.
+            assert drv.read_holding_registers(100, 1) == [TEST_DATA["holding_uint16"]]
+        finally:
+            drv.close()
+
 
 # ============ Raw Function-Code Ops ============
 
@@ -306,6 +325,20 @@ class TestCodec:
         decoded = ModbusDriver.decode_registers(encoded, "uint32", byte_swap=byte_swap, word_swap=word_swap)
         assert decoded == 0xDEADBEEF
 
+    @pytest.mark.parametrize("long_swap", [False, True])
+    @pytest.mark.parametrize("word_swap", [False, True])
+    @pytest.mark.parametrize("byte_swap", [False, True])
+    def test_swap_roundtrip_64bit(self, long_swap, word_swap, byte_swap):
+        # long_swap only applies to 64-bit types; exercise it across every swap combination.
+        value = 0x1337BEEFCAFEBABE
+        encoded = ModbusDriver.encode_value(
+            value, "uint64", byte_swap=byte_swap, word_swap=word_swap, long_swap=long_swap
+        )
+        decoded = ModbusDriver.decode_registers(
+            encoded, "uint64", byte_swap=byte_swap, word_swap=word_swap, long_swap=long_swap
+        )
+        assert decoded == value
+
     def test_encode_unknown_type_raises(self):
         with pytest.raises(ValueError, match="Unknown data type"):
             ModbusDriver.encode_value(1, "uint128")
@@ -339,3 +372,30 @@ class TestConnectionConfigs:
     def test_rtu_defaults(self):
         conn = RTUConnection(port="/dev/ttyUSB0")
         assert (conn.transport, conn.baudrate, conn.parity) == ("rtu", 9600, "N")
+
+
+class TestRTUOpen:
+    """RTU/serial open path, mocked (no serial hardware in CI)."""
+
+    def test_open_builds_serial_client_from_connection(self):
+        conn = RTUConnection(port="/dev/ttyUSB0", baudrate=19200, parity="E", stopbits=2, bytesize=7, unit_id=3)
+        with patch("pymodbus.client.ModbusSerialClient") as mock_cls:
+            mock_cls.return_value.connect.return_value = True
+            drv = ModbusDriver(conn)
+            drv.open()
+            assert drv.is_open
+            assert drv.unit_id == 3
+            mock_cls.assert_called_once_with(
+                port="/dev/ttyUSB0", baudrate=19200, parity="E", stopbits=2, bytesize=7, timeout=conn.timeout
+            )
+            drv.close()
+            mock_cls.return_value.close.assert_called()
+
+    def test_connect_failure_raises_with_serial_port(self):
+        with patch("pymodbus.client.ModbusSerialClient") as mock_cls:
+            mock_cls.return_value.connect.return_value = False
+            drv = ModbusDriver(RTUConnection(port="/dev/ttyUSB0"))
+            with pytest.raises(ConnectionError, match="/dev/ttyUSB0"):
+                drv.open()
+            assert not drv.is_open
+            mock_cls.return_value.close.assert_called_once()

--- a/tests/lib/test_modbus_driver.py
+++ b/tests/lib/test_modbus_driver.py
@@ -1,0 +1,332 @@
+"""Tests for the standalone ModbusDriver transport against a simulated Modbus TCP server."""
+
+from __future__ import annotations
+
+import asyncio
+import struct
+import threading
+import time
+
+import pytest
+from pymodbus.datastore import (
+    ModbusDeviceContext,
+    ModbusSequentialDataBlock,
+    ModbusServerContext,
+)
+from pymodbus.server import StartAsyncTcpServer
+
+from instro.lib.transports import ModbusDriver, RTUConnection, TCPConnection
+
+TEST_PORT = 5031
+
+TEST_DATA = {
+    "input_uint16": 12345,
+    "input_int16": -4567,
+    "input_uint32": 123456789,
+    "input_float32": 123.456,
+    "input_float64": 12345.6789012345,
+    "holding_uint16": 54321,
+    "holding_word_swap": 0xDEADBEEF,
+    "coil_1": False,
+    "coil_2": True,
+    "discrete_1": True,
+    "discrete_2": False,
+}
+
+
+def _pack(fmt: str, value) -> list[int]:
+    data = struct.pack(fmt, value)
+    return [int.from_bytes(data[i * 2 : (i + 1) * 2], "big") for i in range(len(data) // 2)]
+
+
+def _create_datastore() -> ModbusServerContext:
+    ir = [0] * 200
+    ir[0] = TEST_DATA["input_uint16"]
+    ir[1] = struct.unpack(">H", struct.pack(">h", TEST_DATA["input_int16"]))[0]
+    ir[10:12] = _pack(">I", TEST_DATA["input_uint32"])
+    ir[30:32] = _pack(">f", TEST_DATA["input_float32"])
+    ir[40:44] = _pack(">d", TEST_DATA["input_float64"])
+
+    hr = [0] * 200
+    hr[100] = TEST_DATA["holding_uint16"]
+    ws_regs = _pack(">I", TEST_DATA["holding_word_swap"])
+    hr[130], hr[131] = ws_regs[1], ws_regs[0]  # stored word-swapped
+
+    co = [False] * 10
+    co[0] = TEST_DATA["coil_1"]
+    co[1] = TEST_DATA["coil_2"]
+
+    di = [False] * 10
+    di[0] = TEST_DATA["discrete_1"]
+    di[1] = TEST_DATA["discrete_2"]
+
+    # ModbusDeviceContext has a +1 offset quirk, so prepend a dummy so Modbus
+    # address N maps to array index N+1.
+    store = ModbusDeviceContext(
+        di=ModbusSequentialDataBlock(0, [False] + di),
+        co=ModbusSequentialDataBlock(0, [False] + co),
+        hr=ModbusSequentialDataBlock(0, [0] + hr),
+        ir=ModbusSequentialDataBlock(0, [0] + ir),
+    )
+    return ModbusServerContext(devices={1: store}, single=False)
+
+
+@pytest.fixture(scope="module")
+def modbus_server():
+    """Start a sim Modbus TCP server in a background thread for the test module."""
+    loop = asyncio.new_event_loop()
+    context = _create_datastore()
+    shutdown: asyncio.Event | None = None
+
+    async def _run():
+        nonlocal shutdown
+        shutdown = asyncio.Event()
+        server_task = asyncio.create_task(StartAsyncTcpServer(context=context, address=("127.0.0.1", TEST_PORT)))
+        await shutdown.wait()
+        server_task.cancel()
+        try:
+            await server_task
+        except asyncio.CancelledError:
+            pass
+
+    def _thread_target():
+        asyncio.set_event_loop(loop)
+        try:
+            loop.run_until_complete(_run())
+        finally:
+            loop.close()
+
+    thread = threading.Thread(target=_thread_target, daemon=True)
+    thread.start()
+    time.sleep(0.3)  # wait for server to bind
+    yield
+    assert shutdown is not None
+    loop.call_soon_threadsafe(shutdown.set)
+    thread.join(timeout=2.0)
+
+
+@pytest.fixture
+def driver(modbus_server):
+    """Create a connected ModbusDriver instance."""
+    drv = ModbusDriver(TCPConnection(host="127.0.0.1", port=TEST_PORT))
+    drv.open()
+    yield drv
+    drv.close()
+
+
+# ============ Lifecycle ============
+
+
+class TestLifecycle:
+    def test_unit_id_from_connection(self):
+        assert ModbusDriver(TCPConnection(host="h", port=1, unit_id=7)).unit_id == 7
+
+    def test_not_open_before_open(self):
+        assert not ModbusDriver(TCPConnection(host="h", port=1)).is_open
+
+    def test_open_close_toggles_is_open(self, modbus_server):
+        drv = ModbusDriver(TCPConnection(host="127.0.0.1", port=TEST_PORT))
+        assert not drv.is_open
+        drv.open()
+        assert drv.is_open
+        drv.close()
+        assert not drv.is_open
+
+    def test_open_is_idempotent(self, modbus_server):
+        drv = ModbusDriver(TCPConnection(host="127.0.0.1", port=TEST_PORT))
+        drv.open()
+        drv.open()  # no raise, no reconnect churn
+        assert drv.is_open
+        drv.close()
+
+    def test_close_is_idempotent(self, modbus_server):
+        drv = ModbusDriver(TCPConnection(host="127.0.0.1", port=TEST_PORT))
+        drv.open()
+        drv.close()
+        drv.close()  # no raise
+        assert not drv.is_open
+
+    def test_connect_failure_raises(self):
+        drv = ModbusDriver(TCPConnection(host="127.0.0.1", port=1, timeout=0.2))
+        with pytest.raises(ConnectionError, match="Failed to connect"):
+            drv.open()
+        assert not drv.is_open
+
+    def test_op_before_open_raises(self):
+        drv = ModbusDriver(TCPConnection(host="127.0.0.1", port=TEST_PORT))
+        with pytest.raises(RuntimeError, match="not connected"):
+            drv.read_holding_registers(100, 1)
+
+
+# ============ Raw Function-Code Ops ============
+
+
+class TestRawOps:
+    def test_read_holding_registers(self, driver):
+        assert driver.read_holding_registers(100, 1) == [TEST_DATA["holding_uint16"]]
+
+    def test_read_input_registers(self, driver):
+        assert driver.read_input_registers(0, 1) == [TEST_DATA["input_uint16"]]
+
+    def test_read_coils(self, driver):
+        assert driver.read_coils(0, 2) == [TEST_DATA["coil_1"], TEST_DATA["coil_2"]]
+
+    def test_read_discrete_inputs(self, driver):
+        assert driver.read_discrete_inputs(0, 2) == [TEST_DATA["discrete_1"], TEST_DATA["discrete_2"]]
+
+    def test_write_holding_register_readback(self, driver):
+        driver.write_holding_register(150, 4242)
+        assert driver.read_holding_registers(150, 1) == [4242]
+
+    def test_write_holding_registers_readback(self, driver):
+        driver.write_holding_registers(160, [11, 22, 33])
+        assert driver.read_holding_registers(160, 3) == [11, 22, 33]
+
+    def test_write_coil_readback(self, driver):
+        driver.write_coil(5, True)
+        assert driver.read_coils(5, 1) == [True]
+
+    def test_write_coils_readback(self, driver):
+        driver.write_coils(6, [True, False, True])
+        assert driver.read_coils(6, 3) == [True, False, True]
+
+    def test_read_beyond_datastore_raises_modbus_error(self, driver):
+        # Valid Modbus address, but past the sim datastore -> device returns IllegalDataAddress.
+        with pytest.raises(RuntimeError, match="Modbus error"):
+            driver.read_holding_registers(500, 1)
+
+
+# ============ Typed Access ============
+
+
+class TestTypedAccess:
+    def test_read_typed_input_uint16(self, driver):
+        assert driver.read_typed("input", 0, "uint16") == TEST_DATA["input_uint16"]
+
+    def test_read_typed_input_int16(self, driver):
+        assert driver.read_typed("input", 1, "int16") == TEST_DATA["input_int16"]
+
+    def test_read_typed_input_uint32(self, driver):
+        assert driver.read_typed("input", 10, "uint32") == TEST_DATA["input_uint32"]
+
+    def test_read_typed_input_float32(self, driver):
+        assert driver.read_typed("input", 30, "float32") == pytest.approx(TEST_DATA["input_float32"], rel=1e-5)
+
+    def test_read_typed_input_float64(self, driver):
+        assert driver.read_typed("input", 40, "float64") == pytest.approx(TEST_DATA["input_float64"], rel=1e-10)
+
+    def test_read_typed_holding_word_swap(self, driver):
+        assert driver.read_typed("holding", 130, "uint32", word_swap=True) == TEST_DATA["holding_word_swap"]
+
+    def test_read_typed_coil(self, driver):
+        assert driver.read_typed("coil", 1, "bool") == 1
+
+    def test_read_typed_discrete(self, driver):
+        assert driver.read_typed("discrete", 1, "bool") == 0
+
+    def test_read_typed_unknown_register_type_raises(self, driver):
+        with pytest.raises(ValueError, match="Unknown register type"):
+            driver.read_typed("bogus", 0, "uint16")
+
+    def test_write_typed_holding_single_register_readback(self, driver):
+        driver.write_typed("holding", 170, 4321, "uint16")
+        assert driver.read_typed("holding", 170, "uint16") == 4321
+
+    def test_write_typed_holding_multi_register_readback(self, driver):
+        driver.write_typed("holding", 172, -123456789, "int32")
+        assert driver.read_typed("holding", 172, "int32") == -123456789
+
+    def test_write_typed_holding_float_roundtrip(self, driver):
+        driver.write_typed("holding", 176, 3.14159, "float32")
+        assert driver.read_typed("holding", 176, "float32") == pytest.approx(3.14159, rel=1e-5)
+
+    def test_write_typed_coil_readback(self, driver):
+        driver.write_typed("coil", 8, True, "bool")
+        assert driver.read_typed("coil", 8, "bool") == 1
+
+    def test_write_typed_read_only_raises(self, driver):
+        with pytest.raises(ValueError, match="read-only"):
+            driver.write_typed("input", 0, 1, "uint16")
+
+
+# ============ Pure Codec ============
+
+
+class TestCodec:
+    def test_data_type_literal_matches_category_constants(self):
+        # The transport's DataType Literal and instro.modbus.types.ALL_DATA_TYPES
+        # (derived from INTEGER_RANGES) can't share a definition; pin them together.
+        from typing import get_args
+
+        from instro.lib.transports.modbus import DataType
+        from instro.modbus.types import ALL_DATA_TYPES
+
+        assert set(get_args(DataType)) == set(ALL_DATA_TYPES)
+
+    @pytest.mark.parametrize(
+        "data_type,expected",
+        [("uint16", 1), ("int16", 1), ("bool", 1), ("uint32", 2), ("float32", 2), ("uint64", 4), ("float64", 4)],
+    )
+    def test_register_count(self, data_type, expected):
+        assert ModbusDriver.register_count(data_type) == expected
+
+    @pytest.mark.parametrize(
+        "data_type,value",
+        [
+            ("uint16", 54321),
+            ("int16", -4567),
+            ("uint32", 123456789),
+            ("int32", -123456789),
+            ("uint64", 12345678901234),
+            ("int64", -12345678901234),
+        ],
+    )
+    def test_int_roundtrip(self, data_type, value):
+        encoded = ModbusDriver.encode_value(value, data_type)
+        assert ModbusDriver.decode_registers(encoded, data_type) == value
+
+    @pytest.mark.parametrize("data_type,rel", [("float32", 1e-6), ("float64", 1e-12)])
+    def test_float_roundtrip(self, data_type, rel):
+        encoded = ModbusDriver.encode_value(3.14159265, data_type)
+        assert ModbusDriver.decode_registers(encoded, data_type) == pytest.approx(3.14159265, rel=rel)
+
+    @pytest.mark.parametrize("word_swap", [False, True])
+    @pytest.mark.parametrize("byte_swap", [False, True])
+    def test_swap_roundtrip(self, word_swap, byte_swap):
+        encoded = ModbusDriver.encode_value(0xDEADBEEF, "uint32", byte_swap=byte_swap, word_swap=word_swap)
+        decoded = ModbusDriver.decode_registers(encoded, "uint32", byte_swap=byte_swap, word_swap=word_swap)
+        assert decoded == 0xDEADBEEF
+
+    def test_encode_unknown_type_raises(self):
+        with pytest.raises(ValueError, match="Unknown data type"):
+            ModbusDriver.encode_value(1, "uint128")
+
+    def test_decode_unknown_type_raises(self):
+        with pytest.raises(ValueError, match="Unknown data type"):
+            ModbusDriver.decode_registers([0], "uint128")
+
+
+# ============ Lock ============
+
+
+class TestLock:
+    def test_lock_is_reentrant_and_serializes_ops(self, driver):
+        # Holding the lock lets the same thread issue ops inside the with-block (RLock).
+        with driver.lock():
+            assert driver.read_holding_registers(100, 1) == [TEST_DATA["holding_uint16"]]
+
+    def test_lock_returns_same_object(self, driver):
+        assert driver.lock() is driver.lock()
+
+
+# ============ Connection Configs ============
+
+
+class TestConnectionConfigs:
+    def test_tcp_defaults(self):
+        conn = TCPConnection(host="192.168.1.10")
+        assert (conn.transport, conn.port, conn.unit_id) == ("tcp", 502, 1)
+
+    def test_rtu_defaults(self):
+        conn = RTUConnection(port="/dev/ttyUSB0")
+        assert (conn.transport, conn.baudrate, conn.parity) == ("rtu", 9600, "N")

--- a/tests/lib/test_modbus_driver.py
+++ b/tests/lib/test_modbus_driver.py
@@ -246,11 +246,21 @@ class TestTypedAccess:
     def test_read_typed_holding_word_swap(self, driver):
         assert driver.read_typed("holding", 130, "uint32", word_swap=True) == TEST_DATA["holding_word_swap"]
 
-    def test_read_typed_coil(self, driver):
-        assert driver.read_typed("coil", 1, "bool") == 1
+    def test_read_typed_coil_returns_bool(self, driver):
+        result = driver.read_typed("coil", 1, "bool")
+        assert result is True
 
-    def test_read_typed_discrete(self, driver):
-        assert driver.read_typed("discrete", 1, "bool") == 0
+    def test_read_typed_discrete_returns_bool(self, driver):
+        result = driver.read_typed("discrete", 1, "bool")
+        assert result is False
+
+    def test_read_typed_coil_rejects_non_bool_dtype(self, driver):
+        with pytest.raises(ValueError, match="single-bit; data_type must be 'bool'"):
+            driver.read_typed("coil", 1, "uint16")
+
+    def test_read_typed_discrete_rejects_non_bool_dtype(self, driver):
+        with pytest.raises(ValueError, match="single-bit; data_type must be 'bool'"):
+            driver.read_typed("discrete", 1, "uint16")
 
     def test_read_typed_unknown_register_type_raises(self, driver):
         with pytest.raises(ValueError, match="Unknown register type"):
@@ -270,7 +280,16 @@ class TestTypedAccess:
 
     def test_write_typed_coil_readback(self, driver):
         driver.write_typed("coil", 8, True, "bool")
-        assert driver.read_typed("coil", 8, "bool") == 1
+        assert driver.read_typed("coil", 8, "bool") is True
+
+    def test_write_typed_coil_rejects_non_bool_dtype(self, driver):
+        with pytest.raises(ValueError, match="single-bit; data_type must be 'bool'"):
+            driver.write_typed("coil", 8, True, "uint16")
+
+    def test_write_typed_coil_rejects_non_bool_value(self, driver):
+        # Strict: no numeric coercion. Even 1/0 must be passed as real booleans.
+        with pytest.raises(ValueError, match="coil writes require a bool value"):
+            driver.write_typed("coil", 8, 1, "bool")
 
     def test_write_typed_read_only_raises(self, driver):
         with pytest.raises(ValueError, match="read-only"):

--- a/tests/lib/test_modbus_driver.py
+++ b/tests/lib/test_modbus_driver.py
@@ -157,6 +157,15 @@ class TestLifecycle:
         with pytest.raises(RuntimeError, match="not connected"):
             drv.read_holding_registers(100, 1)
 
+    def test_del_closes_open_driver(self, modbus_server):
+        drv = ModbusDriver(TCPConnection(host="127.0.0.1", port=TEST_PORT))
+        drv.open()
+        drv.__del__()  # best-effort close on GC
+        assert not drv.is_open
+
+    def test_del_on_unopened_is_safe(self):
+        ModbusDriver(TCPConnection(host="127.0.0.1", port=TEST_PORT)).__del__()  # no raise
+
 
 # ============ Raw Function-Code Ops ============
 

--- a/tests/modbus/test_modbus_autostart.py
+++ b/tests/modbus/test_modbus_autostart.py
@@ -97,7 +97,7 @@ class TestAutostart:
         )
         dev = ModbusDevice(config=config, autostart=True)
         try:
-            assert dev._client is not None  # open() ran
+            assert dev._modbus.is_open  # open() ran
         finally:
             dev.close()
 
@@ -111,6 +111,6 @@ class TestAutostart:
         )
         dev = ModbusDevice(config=config)
         try:
-            assert dev._client is None
+            assert not dev._modbus.is_open
         finally:
             dev.close()

--- a/tests/modbus/test_modbus_readwrite.py
+++ b/tests/modbus/test_modbus_readwrite.py
@@ -176,15 +176,15 @@ class TestReadInputRegisters:
 class TestReadBoolRegisters:
     def test_read_coil(self, device):
         m = device.read("coil_2")
-        assert m.latest == 1  # True -> 1
+        assert m.latest is True  # coils/discrete publish as bool, not 1/0
 
     def test_read_discrete(self, device):
         m = device.read("discrete_1")
-        assert m.latest == 1
+        assert m.latest is True
 
     def test_read_discrete_false(self, device):
         m = device.read("discrete_2")
-        assert m.latest == 0
+        assert m.latest is False
 
 
 class TestReadHoldingRegisters:

--- a/tests/modbus/test_modbus_validation.py
+++ b/tests/modbus/test_modbus_validation.py
@@ -94,6 +94,26 @@ class TestScaleRestrictions:
         assert reg.scale is not None
 
 
+class TestCoilDiscreteDataType:
+    """Coils and discrete inputs are single-bit: data_type is pinned to bool."""
+
+    @pytest.mark.parametrize("register_type", ["coil", "discrete"])
+    def test_omitted_data_type_coerced_to_bool(self, register_type):
+        # data_type otherwise defaults to uint16; single-bit types normalize it to bool.
+        reg = RegisterDef(name="ok", starting_address=0, register_type=register_type)
+        assert reg.data_type == "bool"
+
+    @pytest.mark.parametrize("register_type", ["coil", "discrete"])
+    def test_explicit_non_bool_data_type_rejected(self, register_type):
+        with pytest.raises(ValidationError, match="single-bit; data_type must be 'bool'"):
+            RegisterDef(name="bad", starting_address=0, register_type=register_type, data_type="uint16")
+
+    @pytest.mark.parametrize("register_type", ["coil", "discrete"])
+    def test_explicit_bool_data_type_allowed(self, register_type):
+        reg = RegisterDef(name="ok", starting_address=0, register_type=register_type, data_type="bool")
+        assert reg.data_type == "bool"
+
+
 # ============ Register Overlap Detection ============
 
 


### PR DESCRIPTION
## Summary

Makes Modbus a first-class, composable transport in `instro/lib/transports/`, paralleling `VisaDriver`. A new `ModbusDriver` owns the Modbus wire layer so register-mapped instrument drivers can compose it the same way SCPI drivers compose `VisaDriver`. The existing `ModbusDevice` HAL is refactored to compose it rather than reimplement it.

Closes INSTRO-492. Prerequisite for the process-controller category (INSTRO-487 — Watlow, Red Lion, etc.).

## Type of change

- [ ] Bug fix (`fix`)
- [X] New feature (`feat`)
- [ ] Breaking change (`feat!` / `fix!`)
- [ ] Refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] Chore / tooling (`chore`)

## Verification

Adds tests.

## Tests

- [X] Unit tests added or updated
- [ ] Existing tests cover this change
- [ ] No tests — explain why:

## Checklist

- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(driver): add support for Keysight E36300`)
- [X] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [X] Documentation updated if user-facing behavior changed
- [X] Code follows the style/conventions of the surrounding code

## Notes for reviewers
