### PR TITLE
feat(psu): add EA PSB/PSBE bidirectional driver (source and sink)

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,9 +90,9 @@ pip install "instro[nidaq,contrib]"
 <!-- --8<-- [start:supported-devices] -->
 | Category | Class | Vendors |
 |---|---|---|
-| Power Supply | `InstroPSU` | B&K Precision (9115, 914X), Keysight (E36100-series), Rigol (DP800-series), Siglent (SPD3303), TDK Lambda (Genesys), simulated |
+| Power Supply | `InstroPSU` | B&K Precision (9115, 914X), EA Elektro-Automatik (PSB/PSBE 9000 & 10000), Keysight (E36100-series), Rigol (DP800-series), Siglent (SPD3303), TDK Lambda (Genesys), simulated |
 | Multimeter | `InstroDMM` | Agilent 34401A, Keithley 2400, Keithley 2750 (unstable), simulated |
-| Electronic Load | `InstroELoad` | B&K Precision (85xxB-series) |
+| Electronic Load | `InstroELoad` | B&K Precision (85xxB-series), EA Elektro-Automatik (PSB/PSBE 9000 & 10000) |
 | Oscilloscope | `InstroScope` | Keysight (1200X-series), Tektronix (2-series), Siglent (SDS1000X-E) |
 | DAQ | `InstroDAQ` | Keysight 34980A, NI-DAQmx, LabJack T-series, MCC USB-series |
 | I2C | `I2CInterface` | Total Phase Aardvark |

--- a/docs/guides/instrumentation/eload.mdx
+++ b/docs/guides/instrumentation/eload.mdx
@@ -10,7 +10,7 @@ description: Using InstroELoad for SCPI-based programmable electronic loads
 ## Supported Vendors
 
 - **B&K Precision**: 85xx Series via SCPI/VISA (`BK85XXB`)
-
+- **EA Elektro-Automatik**: PSB/PSBE 9000 and 10000-series bidirectional supplies via SCPI/VISA (`EAPSB`). The same driver also serves `InstroPSU` for sourcing.
 If your vendor or model is not listed, see [Custom Driver Development](#custom-driver-development) below.
 
 ## Key Concepts

--- a/docs/guides/instrumentation/psu.mdx
+++ b/docs/guides/instrumentation/psu.mdx
@@ -10,6 +10,7 @@ description: Using InstroPSU for SCPI-based programmable power supplies
 ## Supported Vendors
 
 - **B&K Precision**: 9115-series and 914X-series via SCPI/VISA (`BK9115`, `BK914X`)
+- **EA Elektro-Automatik**: PSB/PSBE 9000 and 10000-series bidirectional supplies via SCPI/VISA (`EAPSB`). The one driver both sources and sinks, and also serves `InstroELoad` for load operation.
 - **Keysight**: E36100-series single-channel via SCPI/VISA (`KeysightE36100`)
 - **Rigol**: DP-series via SCPI/VISA (`RigolDP800`), including OVP/OCP controls and remote sense on supported DP800 channels
 - **Siglent**: SPD-series via SCPI/VISA (`SiglentSPD3303`)

--- a/instro/eload/drivers/__init__.py
+++ b/instro/eload/drivers/__init__.py
@@ -2,5 +2,6 @@
 
 from instro.eload import ELoadDriverBase
 from instro.eload.drivers.bk_85xxb import BK85XXB
+from instro.psu.drivers.ea_psb import EAPSB
 
-__all__ = ["ELoadDriverBase", "BK85XXB"]
+__all__ = ["ELoadDriverBase", "BK85XXB", "EAPSB"]

--- a/instro/psu/drivers/__init__.py
+++ b/instro/psu/drivers/__init__.py
@@ -3,6 +3,7 @@
 from instro.psu import PSUDriverBase
 from instro.psu.drivers.bk_914x import BK914X
 from instro.psu.drivers.bk_9115 import BK9115
+from instro.psu.drivers.ea_psb import EAPSB
 from instro.psu.drivers.keysight_e36100 import KeysightE36100
 from instro.psu.drivers.keysight_n5700 import KeysightN5700
 from instro.psu.drivers.rigol_dp800 import RigolDP800
@@ -14,6 +15,7 @@ __all__ = [
     "PSUDriverBase",
     "BK9115",
     "BK914X",
+    "EAPSB",
     "KeysightE36100",
     "KeysightN5700",
     "RigolDP800",

--- a/instro/psu/drivers/ea_psb.py
+++ b/instro/psu/drivers/ea_psb.py
@@ -1,0 +1,144 @@
+"""EA Elektro-Automatik PSB/PSBE bidirectional DC supply driver (source and sink over SCPI)."""
+
+import string
+
+from instro.eload import ELoadDriverBase, LoadMode, SlewRateDirection
+from instro.lib.exceptions import FeatureNotSupportedError
+from instro.lib.transports.visa import VisaConfig, VisaDriver
+from instro.psu import PSUDriverBase
+
+FRIENDLY_NAME = "EA PSB/PSBE"
+
+_SINK_CMD: dict[LoadMode, str] = {
+    LoadMode.CC: "SINK:CURR",
+    LoadMode.CP: "SINK:POW",
+    LoadMode.CR: "SINK:RES",
+}
+
+
+class EAPSB(PSUDriverBase, ELoadDriverBase):
+    """EA PSB/PSBE bidirectional line (PSB 9000/10000, PSBE 9000/10000); SCPI surface shared across the line per REV 24."""
+
+    def __init__(self, visa_resource: str | VisaConfig) -> None:
+        self._visa = VisaDriver(visa_resource)
+
+    def open(self) -> None:
+        self._visa.open()
+        self._write_checked("SYST:LOCK ON")
+        owner = self._visa.query("SYST:LOCK:OWN?").strip()
+        if owner != "REMOTE":
+            raise RuntimeError(f"{FRIENDLY_NAME} did not grant the remote lock (owner: {owner})")
+
+    def close(self) -> None:
+        self._write_checked("SYST:LOCK OFF")
+        self._visa.close()
+
+    def set_voltage(self, voltage: float, channel: int) -> None:
+        _check_channel(channel)
+        self._write_checked(f"VOLT {voltage:.3f}")
+
+    def get_voltage(self, channel: int) -> float:
+        _check_channel(channel)
+        return self._query_checked_float("MEAS:VOLT?")
+
+    def set_current_limit(self, current_limit: float, channel: int) -> None:
+        _check_channel(channel)
+        self._write_checked(f"CURR {current_limit:.3f}")
+
+    def get_current(self, channel: int) -> float:
+        _check_channel(channel)
+        return self._query_checked_float("MEAS:CURR?")
+
+    def output_enable(self, enable: bool, channel: int) -> None:
+        _check_channel(channel)
+        self._write_checked("OUTP ON" if enable else "OUTP OFF")
+
+    def get_output_status(self, channel: int) -> bool:
+        _check_channel(channel)
+        with self._visa.lock():
+            resp = self._visa.query("OUTP?")
+            self._check_errors()
+        return resp.strip().upper() == "ON"
+
+    def set_overvoltage_protection_level(self, voltage: float, channel: int) -> None:
+        _check_channel(channel)
+        self._write_checked(f"VOLT:PROT {voltage:.3f}")
+
+    def get_overvoltage_protection_level(self, channel: int) -> float:
+        _check_channel(channel)
+        return self._query_checked_float("VOLT:PROT?")
+
+    def set_overvoltage_protection_enabled(self, enabled: bool, channel: int) -> None:
+        raise FeatureNotSupportedError(f"set_overvoltage_protection_enabled is not supported by the {FRIENDLY_NAME}")
+
+    def get_overvoltage_protection_enabled(self, channel: int) -> bool:
+        raise FeatureNotSupportedError(f"get_overvoltage_protection_enabled is not supported by the {FRIENDLY_NAME}")
+
+    def set_overvoltage_protection_delay(self, delay: float, channel: int) -> None:
+        raise FeatureNotSupportedError(f"set_overvoltage_protection_delay is not supported by the {FRIENDLY_NAME}")
+
+    def get_overvoltage_protection_delay(self, channel: int) -> float:
+        raise FeatureNotSupportedError(f"get_overvoltage_protection_delay is not supported by the {FRIENDLY_NAME}")
+
+    def set_overcurrent_protection_level(self, current: float, channel: int) -> None:
+        _check_channel(channel)
+        self._write_checked(f"CURR:PROT {current:.3f}")
+
+    def get_overcurrent_protection_level(self, channel: int) -> float:
+        _check_channel(channel)
+        return self._query_checked_float("CURR:PROT?")
+
+    def set_overcurrent_protection_enabled(self, enabled: bool, channel: int) -> None:
+        raise FeatureNotSupportedError(f"set_overcurrent_protection_enabled is not supported by the {FRIENDLY_NAME}")
+
+    def get_overcurrent_protection_enabled(self, channel: int) -> bool:
+        raise FeatureNotSupportedError(f"get_overcurrent_protection_enabled is not supported by the {FRIENDLY_NAME}")
+
+    def set_remote_sense_enabled(self, enabled: bool, channel: int) -> None:
+        raise FeatureNotSupportedError(f"set_remote_sense_enabled is not supported by the {FRIENDLY_NAME}")
+
+    def get_remote_sense_enabled(self, channel: int) -> bool:
+        raise FeatureNotSupportedError(f"get_remote_sense_enabled is not supported by the {FRIENDLY_NAME}")
+
+    def set_mode(self, mode: LoadMode, channel: int) -> None:
+        _check_channel(channel)
+        self._write_checked("SYST:CONF:MODE UIR" if mode is LoadMode.CR else "SYST:CONF:MODE UIP")
+
+    def set_level(self, mode: LoadMode, value: float, channel: int, curr_limit: float | None) -> None:
+        _check_channel(channel)
+        if mode is LoadMode.CV:
+            self._write_checked(f"VOLT {value:.3f}")
+            if curr_limit is not None:
+                self._write_checked(f"SINK:CURR {curr_limit:.3f}")
+        else:
+            self._write_checked(f"{_SINK_CMD[mode]} {value:.3f}")
+
+    def set_range(self, mode: LoadMode, value: float, channel: int) -> None:
+        raise FeatureNotSupportedError(f"set_range is not supported by the {FRIENDLY_NAME}")
+
+    def set_slewrate(self, direction: SlewRateDirection, rate: float, channel: int) -> None:
+        raise FeatureNotSupportedError(f"set_slewrate is not supported by the {FRIENDLY_NAME}")
+
+    def short_output(self, enable: bool, channel: int) -> None:
+        raise FeatureNotSupportedError(f"short_output is not supported by the {FRIENDLY_NAME}")
+
+    def _write_checked(self, command: str) -> None:
+        with self._visa.lock():
+            self._visa.write(command)
+            self._check_errors()
+
+    def _query_checked_float(self, command: str) -> float:
+        with self._visa.lock():
+            value = self._visa.query(command)
+            self._check_errors()
+            return float(value.strip().rstrip(string.ascii_letters))
+
+    def _check_errors(self) -> None:
+        err = self._visa.query("SYST:ERR?")
+        if not err.startswith("0"):
+            raise RuntimeError(f"EA PSB reported error: {err}")
+
+
+def _check_channel(channel: int) -> None:
+    if channel != 1:
+        raise ValueError("EA PSB channel must be 1")

--- a/tests/psu/ea/test_ea_psb_hardware.py
+++ b/tests/psu/ea/test_ea_psb_hardware.py
@@ -1,0 +1,367 @@
+"""Optional EA PSB/PSBE hardware smoke tests (bench unit: PSB 10080-60)."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from instro.eload import LoadMode, SlewRateDirection
+from instro.lib.exceptions import FeatureNotSupportedError
+from instro.lib.transports import VisaConfig
+from instro.psu.drivers.ea_psb import EAPSB
+
+pytestmark = pytest.mark.hardware
+
+# HARDWARE TEST SETUP - EDIT THESE VALUES BEFORE RUNNING THIS FILE.
+# Set VISA_ADDRESS to the bench unit's VISA resource string.
+# The PSB 10080-60 speaks raw-socket SCPI on port 5025 (not VXI-11/HiSLIP); default VisaConfig terminators work.
+# Keep the programmed values comfortably inside the unit's ratings (PSB 10080-60: 80 V / 60 A).
+VISA_ADDRESS = "TCPIP::192.168.0.3::5025::SOCKET"
+CHANNEL = 1
+PROGRAMMED_VOLTAGE = 12.0
+PROGRAMMED_CURRENT_LIMIT = 2.0
+OVP_LEVEL = 40.0
+OCP_LEVEL = 30.0
+SINK_CURRENT = 1.0
+SINK_POWER = 50.0
+SINK_RESISTANCE = 10.0  # within the unit's 0.04-80 ohm sink-resistance band (SYST:NOM:RES:MIN?/MAX?)
+SINK_CV_VOLTAGE = 12.0
+VOLTAGE_READBACK_TOLERANCE = 0.25
+CURRENT_READBACK_TOLERANCE = 0.05
+
+
+@pytest.fixture(scope="module")
+def driver(request: pytest.FixtureRequest) -> EAPSB:
+    psb_driver = EAPSB(VisaConfig(visa_resource=VISA_ADDRESS))
+    try:
+        psb_driver.open()
+    except Exception as exc:
+        psb_driver.close()
+        pytest.skip(f"EA PSB not reachable at {VISA_ADDRESS}: {exc}")
+
+    def cleanup() -> None:
+        try:
+            psb_driver.output_enable(False, channel=CHANNEL)
+        finally:
+            psb_driver.close()
+
+    request.addfinalizer(cleanup)
+    return psb_driver
+
+
+@pytest.fixture(autouse=True)
+def reset_before_each_test(driver: EAPSB) -> None:
+    driver._visa.write("*RST")
+    # PSB 10080-60 does not implement *OPC?; a short settle is enough and *RST alone leaves SYST:ERR? clean.
+    time.sleep(0.2)
+    driver._check_errors()
+    driver.output_enable(False, channel=CHANNEL)
+
+
+def _queue_instrument_error(driver: EAPSB) -> None:
+    driver._visa.write("INSTRO:INVALID")
+
+
+def test_set_voltage(driver: EAPSB) -> None:
+    driver.set_current_limit(PROGRAMMED_CURRENT_LIMIT, channel=CHANNEL)
+    driver.set_voltage(PROGRAMMED_VOLTAGE, channel=CHANNEL)
+    try:
+        driver.output_enable(True, channel=CHANNEL)
+        time.sleep(1)
+
+        assert driver.get_voltage(channel=CHANNEL) == pytest.approx(
+            PROGRAMMED_VOLTAGE,
+            abs=VOLTAGE_READBACK_TOLERANCE,
+        )
+    finally:
+        driver.output_enable(False, channel=CHANNEL)
+
+
+def test_set_voltage_raises_after_instrument_error(driver: EAPSB) -> None:
+    _queue_instrument_error(driver)
+
+    with pytest.raises(RuntimeError, match="EA PSB reported error"):
+        driver.set_voltage(PROGRAMMED_VOLTAGE, channel=CHANNEL)
+
+
+def test_set_voltage_invalid_channel_raises_without_instrument_error(driver: EAPSB) -> None:
+    with pytest.raises(ValueError, match="EA PSB channel must be 1"):
+        driver.set_voltage(PROGRAMMED_VOLTAGE, channel=2)
+
+    driver._check_errors()
+
+
+def test_get_voltage(driver: EAPSB) -> None:
+    driver.set_current_limit(PROGRAMMED_CURRENT_LIMIT, channel=CHANNEL)
+    driver.set_voltage(PROGRAMMED_VOLTAGE, channel=CHANNEL)
+    try:
+        driver.output_enable(True, channel=CHANNEL)
+        time.sleep(1)
+
+        voltage = driver.get_voltage(channel=CHANNEL)
+
+        assert voltage == pytest.approx(PROGRAMMED_VOLTAGE, abs=VOLTAGE_READBACK_TOLERANCE)
+    finally:
+        driver.output_enable(False, channel=CHANNEL)
+
+
+def test_get_voltage_raises_after_instrument_error(driver: EAPSB) -> None:
+    _queue_instrument_error(driver)
+
+    with pytest.raises(RuntimeError, match="EA PSB reported error"):
+        driver.get_voltage(channel=CHANNEL)
+
+
+def test_set_current_limit(driver: EAPSB) -> None:
+    driver.set_current_limit(PROGRAMMED_CURRENT_LIMIT, channel=CHANNEL)
+    driver.set_voltage(PROGRAMMED_VOLTAGE, channel=CHANNEL)
+    try:
+        driver.output_enable(True, channel=CHANNEL)
+        time.sleep(1)
+
+        # No load attached: the supply should source (approximately) no current.
+        assert driver.get_current(channel=CHANNEL) == pytest.approx(0.0, abs=CURRENT_READBACK_TOLERANCE)
+    finally:
+        driver.output_enable(False, channel=CHANNEL)
+
+
+def test_set_current_limit_raises_after_instrument_error(driver: EAPSB) -> None:
+    _queue_instrument_error(driver)
+
+    with pytest.raises(RuntimeError, match="EA PSB reported error"):
+        driver.set_current_limit(PROGRAMMED_CURRENT_LIMIT, channel=CHANNEL)
+
+
+def test_get_current(driver: EAPSB) -> None:
+    driver.set_current_limit(PROGRAMMED_CURRENT_LIMIT, channel=CHANNEL)
+    driver.set_voltage(PROGRAMMED_VOLTAGE, channel=CHANNEL)
+    try:
+        driver.output_enable(True, channel=CHANNEL)
+        time.sleep(1)
+
+        current = driver.get_current(channel=CHANNEL)
+
+        assert current == pytest.approx(0.0, abs=CURRENT_READBACK_TOLERANCE)
+    finally:
+        driver.output_enable(False, channel=CHANNEL)
+
+
+def test_get_current_raises_after_instrument_error(driver: EAPSB) -> None:
+    _queue_instrument_error(driver)
+
+    with pytest.raises(RuntimeError, match="EA PSB reported error"):
+        driver.get_current(channel=CHANNEL)
+
+
+def test_output_enable(driver: EAPSB) -> None:
+    driver.set_current_limit(PROGRAMMED_CURRENT_LIMIT, channel=CHANNEL)
+    driver.set_voltage(PROGRAMMED_VOLTAGE, channel=CHANNEL)
+    try:
+        driver.output_enable(True, channel=CHANNEL)
+        time.sleep(1)
+        assert driver.get_output_status(channel=CHANNEL) is True
+
+        driver.output_enable(False, channel=CHANNEL)
+        time.sleep(0.1)
+        assert driver.get_output_status(channel=CHANNEL) is False
+    finally:
+        driver.output_enable(False, channel=CHANNEL)
+
+
+def test_output_enable_raises_after_instrument_error(driver: EAPSB) -> None:
+    _queue_instrument_error(driver)
+    try:
+        with pytest.raises(RuntimeError, match="EA PSB reported error"):
+            driver.output_enable(True, channel=CHANNEL)
+    finally:
+        driver.output_enable(False, channel=CHANNEL)
+
+
+def test_output_disable_readback(driver: EAPSB) -> None:
+    assert driver.get_output_status(channel=CHANNEL) is False
+
+    driver.set_current_limit(PROGRAMMED_CURRENT_LIMIT, channel=CHANNEL)
+    driver.set_voltage(PROGRAMMED_VOLTAGE, channel=CHANNEL)
+    try:
+        driver.output_enable(True, channel=CHANNEL)
+        time.sleep(1)
+
+        assert driver.get_output_status(channel=CHANNEL) is True
+    finally:
+        driver.output_enable(False, channel=CHANNEL)
+
+
+def test_get_output_status_raises_after_instrument_error(driver: EAPSB) -> None:
+    _queue_instrument_error(driver)
+
+    with pytest.raises(RuntimeError, match="EA PSB reported error"):
+        driver.get_output_status(channel=CHANNEL)
+
+
+def test_overvoltage_protection_level_round_trip(driver: EAPSB) -> None:
+    driver.set_overvoltage_protection_level(OVP_LEVEL, channel=CHANNEL)
+
+    assert driver.get_overvoltage_protection_level(channel=CHANNEL) == pytest.approx(OVP_LEVEL, abs=0.1)
+
+
+def test_set_overvoltage_protection_level_raises_after_instrument_error(driver: EAPSB) -> None:
+    _queue_instrument_error(driver)
+
+    with pytest.raises(RuntimeError, match="EA PSB reported error"):
+        driver.set_overvoltage_protection_level(OVP_LEVEL, channel=CHANNEL)
+
+
+def test_overcurrent_protection_level_round_trip(driver: EAPSB) -> None:
+    driver.set_overcurrent_protection_level(OCP_LEVEL, channel=CHANNEL)
+
+    assert driver.get_overcurrent_protection_level(channel=CHANNEL) == pytest.approx(OCP_LEVEL, abs=0.1)
+
+
+def test_set_overcurrent_protection_level_raises_after_instrument_error(driver: EAPSB) -> None:
+    _queue_instrument_error(driver)
+
+    with pytest.raises(RuntimeError, match="EA PSB reported error"):
+        driver.set_overcurrent_protection_level(OCP_LEVEL, channel=CHANNEL)
+
+
+def test_set_mode_cc_cp_cv_select_uip(driver: EAPSB) -> None:
+    for mode in (LoadMode.CC, LoadMode.CP, LoadMode.CV):
+        driver.set_mode(mode, channel=CHANNEL)
+        driver._check_errors()
+
+
+def test_set_mode_cr_selects_uir(driver: EAPSB) -> None:
+    driver.set_mode(LoadMode.CR, channel=CHANNEL)
+    driver._check_errors()
+
+
+def test_set_level_cc(driver: EAPSB) -> None:
+    driver.set_mode(LoadMode.CC, channel=CHANNEL)
+
+    driver.set_level(LoadMode.CC, SINK_CURRENT, channel=CHANNEL, curr_limit=None)
+
+    driver._check_errors()
+
+
+def test_set_level_cp(driver: EAPSB) -> None:
+    driver.set_mode(LoadMode.CP, channel=CHANNEL)
+
+    driver.set_level(LoadMode.CP, SINK_POWER, channel=CHANNEL, curr_limit=None)
+
+    driver._check_errors()
+
+
+def test_set_level_cr(driver: EAPSB) -> None:
+    driver.set_mode(LoadMode.CR, channel=CHANNEL)
+
+    driver.set_level(LoadMode.CR, SINK_RESISTANCE, channel=CHANNEL, curr_limit=None)
+
+    driver._check_errors()
+
+
+def test_set_level_cv_with_curr_limit(driver: EAPSB) -> None:
+    driver.set_mode(LoadMode.CV, channel=CHANNEL)
+
+    driver.set_level(LoadMode.CV, SINK_CV_VOLTAGE, channel=CHANNEL, curr_limit=PROGRAMMED_CURRENT_LIMIT)
+
+    driver._check_errors()
+
+
+def test_set_level_raises_after_instrument_error(driver: EAPSB) -> None:
+    _queue_instrument_error(driver)
+
+    with pytest.raises(RuntimeError, match="EA PSB reported error"):
+        driver.set_level(LoadMode.CC, SINK_CURRENT, channel=CHANNEL, curr_limit=None)
+
+
+def test_set_range_unsupported(driver: EAPSB) -> None:
+    with pytest.raises(FeatureNotSupportedError, match="set_range is not supported by the EA PSB/PSBE"):
+        driver.set_range(LoadMode.CC, SINK_CURRENT, channel=CHANNEL)
+
+    driver._check_errors()
+
+
+def test_set_slewrate_unsupported(driver: EAPSB) -> None:
+    with pytest.raises(FeatureNotSupportedError, match="set_slewrate is not supported by the EA PSB/PSBE"):
+        driver.set_slewrate(SlewRateDirection.RISE, 1.0, channel=CHANNEL)
+
+    driver._check_errors()
+
+
+def test_short_output_unsupported(driver: EAPSB) -> None:
+    with pytest.raises(FeatureNotSupportedError, match="short_output is not supported by the EA PSB/PSBE"):
+        driver.short_output(True, channel=CHANNEL)
+
+    driver._check_errors()
+
+
+def test_set_overvoltage_protection_enabled_unsupported(driver: EAPSB) -> None:
+    with pytest.raises(
+        FeatureNotSupportedError,
+        match="set_overvoltage_protection_enabled is not supported by the EA PSB/PSBE",
+    ):
+        driver.set_overvoltage_protection_enabled(True, channel=CHANNEL)
+
+
+def test_get_overvoltage_protection_enabled_unsupported(driver: EAPSB) -> None:
+    with pytest.raises(
+        FeatureNotSupportedError,
+        match="get_overvoltage_protection_enabled is not supported by the EA PSB/PSBE",
+    ):
+        driver.get_overvoltage_protection_enabled(channel=CHANNEL)
+
+
+def test_set_overvoltage_protection_delay_unsupported(driver: EAPSB) -> None:
+    with pytest.raises(
+        FeatureNotSupportedError,
+        match="set_overvoltage_protection_delay is not supported by the EA PSB/PSBE",
+    ):
+        driver.set_overvoltage_protection_delay(0.1, channel=CHANNEL)
+
+
+def test_get_overvoltage_protection_delay_unsupported(driver: EAPSB) -> None:
+    with pytest.raises(
+        FeatureNotSupportedError,
+        match="get_overvoltage_protection_delay is not supported by the EA PSB/PSBE",
+    ):
+        driver.get_overvoltage_protection_delay(channel=CHANNEL)
+
+
+def test_set_overcurrent_protection_enabled_unsupported(driver: EAPSB) -> None:
+    with pytest.raises(
+        FeatureNotSupportedError,
+        match="set_overcurrent_protection_enabled is not supported by the EA PSB/PSBE",
+    ):
+        driver.set_overcurrent_protection_enabled(True, channel=CHANNEL)
+
+
+def test_get_overcurrent_protection_enabled_unsupported(driver: EAPSB) -> None:
+    with pytest.raises(
+        FeatureNotSupportedError,
+        match="get_overcurrent_protection_enabled is not supported by the EA PSB/PSBE",
+    ):
+        driver.get_overcurrent_protection_enabled(channel=CHANNEL)
+
+
+def test_set_remote_sense_enabled_unsupported(driver: EAPSB) -> None:
+    with pytest.raises(
+        FeatureNotSupportedError,
+        match="set_remote_sense_enabled is not supported by the EA PSB/PSBE",
+    ):
+        driver.set_remote_sense_enabled(True, channel=CHANNEL)
+
+
+def test_get_remote_sense_enabled_unsupported(driver: EAPSB) -> None:
+    with pytest.raises(
+        FeatureNotSupportedError,
+        match="get_remote_sense_enabled is not supported by the EA PSB/PSBE",
+    ):
+        driver.get_remote_sense_enabled(channel=CHANNEL)
+
+
+def test_check_errors_raises_after_instrument_error(driver: EAPSB) -> None:
+    _queue_instrument_error(driver)
+
+    with pytest.raises(RuntimeError, match="EA PSB reported error"):
+        driver._check_errors()

--- a/tests/psu/ea/test_ea_psb_software.py
+++ b/tests/psu/ea/test_ea_psb_software.py
@@ -1,0 +1,344 @@
+"""Feature test: EA PSB/PSBE driven through both HALs, exercising the whole command set."""
+
+from collections.abc import Iterator
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from instro.eload import InstroELoad, LoadMode, SlewRateDirection
+from instro.lib.exceptions import FeatureNotSupportedError
+from instro.lib.transports import VisaConfig
+from instro.lib.types import Measurement
+from instro.psu import InstroPSU
+from instro.psu.drivers import EAPSB
+
+RESOURCE = "TCPIP::192.168.0.2::INSTR"
+
+# Canned query responses keyed by the exact SCPI query string.
+_QUERY_RESPONSES = {
+    "SYST:ERR?": '0,"No error"',
+    "SYST:LOCK:OWN?": "REMOTE",
+    "MEAS:VOLT?": "48.00V",
+    "MEAS:CURR?": "20.00A",
+    "OUTP?": "ON",
+    "VOLT:PROT?": "60.00",
+    "CURR:PROT?": "25.00",
+}
+
+
+@pytest.fixture
+def visa_cls() -> Iterator[MagicMock]:
+    with patch("instro.psu.drivers.ea_psb.VisaDriver", autospec=True) as cls:
+        yield cls
+
+
+@pytest.fixture
+def visa(visa_cls: MagicMock) -> MagicMock:
+    inst = visa_cls.return_value
+    inst.query.side_effect = lambda cmd: _QUERY_RESPONSES[cmd]
+    return inst
+
+
+def _writes(visa: MagicMock) -> list[str]:
+    return [c.args[0] for c in visa.write.call_args_list]
+
+
+def _latest(measurement: Measurement | None) -> float | str:
+    assert measurement is not None
+    return measurement.latest
+
+
+@pytest.fixture
+def drv(visa_cls: MagicMock) -> EAPSB:
+    return EAPSB(RESOURCE)
+
+
+def test_init_builds_visa_driver_from_resource(visa_cls: MagicMock) -> None:
+    EAPSB(RESOURCE)
+    visa_cls.assert_called_once_with(RESOURCE)
+
+
+def test_init_accepts_prebuilt_connection_config(visa_cls: MagicMock) -> None:
+    config = VisaConfig(visa_resource=RESOURCE)
+    EAPSB(config)
+    visa_cls.assert_called_once_with(config)
+
+
+def test_open_acquires_remote_lock_and_verifies_ownership(drv: EAPSB, visa: MagicMock) -> None:
+    drv.open()
+    visa.open.assert_called_once()
+    assert _writes(visa) == ["SYST:LOCK ON"]
+    assert call("SYST:LOCK:OWN?") in visa.query.call_args_list
+
+
+def test_open_raises_when_ownership_not_remote(drv: EAPSB, visa: MagicMock) -> None:
+    visa.query.side_effect = lambda cmd: {"SYST:ERR?": '0,"No error"', "SYST:LOCK:OWN?": "LOCAL"}[cmd]
+    with pytest.raises(RuntimeError, match="remote lock"):
+        drv.open()
+
+
+def test_close_releases_lock_then_closes(drv: EAPSB, visa: MagicMock) -> None:
+    drv.close()
+    assert _writes(visa) == ["SYST:LOCK OFF"]
+    visa.close.assert_called_once()
+
+
+def test_check_errors_raises_on_error_response(drv: EAPSB, visa: MagicMock) -> None:
+    visa.query.side_effect = None
+    visa.query.return_value = '-201,"Cannot be done in local mode"'
+    with pytest.raises(RuntimeError, match="EA PSB reported error"):
+        drv.open()
+
+
+def test_set_voltage_writes_checked(drv: EAPSB, visa: MagicMock) -> None:
+    drv.set_voltage(48.0, channel=1)
+    visa.write.assert_called_once_with("VOLT 48.000")
+    visa.query.assert_called_once_with("SYST:ERR?")
+
+
+def test_get_voltage_strips_unit_suffix(drv: EAPSB, visa: MagicMock) -> None:
+    visa.query.side_effect = ["48.00V", '0,"No error"']
+    assert drv.get_voltage(channel=1) == pytest.approx(48.0)
+    assert visa.query.call_args_list == [call("MEAS:VOLT?"), call("SYST:ERR?")]
+
+
+def test_set_current_limit_writes_checked(drv: EAPSB, visa: MagicMock) -> None:
+    drv.set_current_limit(20.0, channel=1)
+    visa.write.assert_called_once_with("CURR 20.000")
+    visa.query.assert_called_once_with("SYST:ERR?")
+
+
+def test_get_current_parses_negative_sink_current(drv: EAPSB, visa: MagicMock) -> None:
+    visa.query.side_effect = ["-5.00A", '0,"No error"']
+    assert drv.get_current(channel=1) == pytest.approx(-5.0)
+    assert visa.query.call_args_list == [call("MEAS:CURR?"), call("SYST:ERR?")]
+
+
+def test_output_enable_writes_checked(drv: EAPSB, visa: MagicMock) -> None:
+    drv.output_enable(True, channel=1)
+    visa.write.assert_called_once_with("OUTP ON")
+    drv.output_enable(False, channel=1)
+    assert visa.write.call_args_list[-1] == call("OUTP OFF")
+
+
+def test_get_output_status_parses(drv: EAPSB, visa: MagicMock) -> None:
+    visa.query.side_effect = ["ON", '0,"No error"']
+    assert drv.get_output_status(channel=1) is True
+    visa.query.side_effect = ["OFF", '0,"No error"']
+    assert drv.get_output_status(channel=1) is False
+
+
+def test_overvoltage_protection_level_round_trip(drv: EAPSB, visa: MagicMock) -> None:
+    drv.set_overvoltage_protection_level(60.0, channel=1)
+    visa.write.assert_called_once_with("VOLT:PROT 60.000")
+    visa.query.side_effect = ["60.00", '0,"No error"']
+    assert drv.get_overvoltage_protection_level(channel=1) == pytest.approx(60.0)
+    assert visa.query.call_args_list[-2:] == [call("VOLT:PROT?"), call("SYST:ERR?")]
+
+
+def test_overcurrent_protection_level_round_trip(drv: EAPSB, visa: MagicMock) -> None:
+    drv.set_overcurrent_protection_level(25.0, channel=1)
+    visa.write.assert_called_once_with("CURR:PROT 25.000")
+    visa.query.side_effect = ["25.00", '0,"No error"']
+    assert drv.get_overcurrent_protection_level(channel=1) == pytest.approx(25.0)
+    assert visa.query.call_args_list[-2:] == [call("CURR:PROT?"), call("SYST:ERR?")]
+
+
+@pytest.mark.parametrize(
+    ("method_name", "args"),
+    [
+        ("set_overvoltage_protection_enabled", (True,)),
+        ("get_overvoltage_protection_enabled", ()),
+        ("set_overvoltage_protection_delay", (0.1,)),
+        ("get_overvoltage_protection_delay", ()),
+        ("set_overcurrent_protection_enabled", (True,)),
+        ("get_overcurrent_protection_enabled", ()),
+        ("set_remote_sense_enabled", (True,)),
+        ("get_remote_sense_enabled", ()),
+    ],
+)
+def test_unsupported_psu_optionals_raise_without_scpi(
+    drv: EAPSB,
+    visa: MagicMock,
+    method_name: str,
+    args: tuple[object, ...],
+) -> None:
+    with pytest.raises(FeatureNotSupportedError, match=f"{method_name} is not supported"):
+        getattr(drv, method_name)(*args, channel=1)
+    visa.write.assert_not_called()
+    visa.query.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("method_name", "args"),
+    [
+        ("set_voltage", (48.0,)),
+        ("get_voltage", ()),
+        ("set_current_limit", (20.0,)),
+        ("get_current", ()),
+        ("output_enable", (True,)),
+        ("get_output_status", ()),
+        ("set_overvoltage_protection_level", (60.0,)),
+        ("get_overvoltage_protection_level", ()),
+        ("set_overcurrent_protection_level", (25.0,)),
+        ("get_overcurrent_protection_level", ()),
+    ],
+)
+def test_invalid_channel_raises_without_scpi(
+    drv: EAPSB,
+    visa: MagicMock,
+    method_name: str,
+    args: tuple[object, ...],
+) -> None:
+    with pytest.raises(ValueError, match="EA PSB channel must be 1"):
+        getattr(drv, method_name)(*args, channel=2)
+    visa.write.assert_not_called()
+    visa.query.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected"),
+    [
+        (LoadMode.CC, "SYST:CONF:MODE UIP"),
+        (LoadMode.CP, "SYST:CONF:MODE UIP"),
+        (LoadMode.CV, "SYST:CONF:MODE UIP"),
+        (LoadMode.CR, "SYST:CONF:MODE UIR"),
+    ],
+)
+def test_set_mode_selects_operation_mode(drv: EAPSB, visa: MagicMock, mode: LoadMode, expected: str) -> None:
+    drv.set_mode(mode, channel=1)
+    visa.write.assert_called_once_with(expected)
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected"),
+    [
+        (LoadMode.CC, "SINK:CURR 10.000"),
+        (LoadMode.CP, "SINK:POW 500.000"),
+        (LoadMode.CR, "SINK:RES 5.000"),
+    ],
+)
+def test_set_level_writes_sink_setpoint(drv: EAPSB, visa: MagicMock, mode: LoadMode, expected: str) -> None:
+    drv.set_level(mode, {LoadMode.CC: 10.0, LoadMode.CP: 500.0, LoadMode.CR: 5.0}[mode], channel=1, curr_limit=None)
+    visa.write.assert_called_once_with(expected)
+
+
+def test_set_level_cv_writes_shared_voltage_setpoint(drv: EAPSB, visa: MagicMock) -> None:
+    drv.set_level(LoadMode.CV, 24.0, channel=1, curr_limit=None)
+    visa.write.assert_called_once_with("VOLT 24.000")
+
+
+def test_set_level_cv_with_curr_limit_also_writes_sink_current(drv: EAPSB, visa: MagicMock) -> None:
+    drv.set_level(LoadMode.CV, 24.0, channel=1, curr_limit=15.0)
+    assert _writes(visa) == ["VOLT 24.000", "SINK:CURR 15.000"]
+
+
+@pytest.mark.parametrize(
+    ("method_name", "args"),
+    [
+        ("set_range", (LoadMode.CC, 10.0)),
+        ("set_slewrate", (SlewRateDirection.RISE, 1.0)),
+        ("short_output", (True,)),
+    ],
+)
+def test_unsupported_eload_methods_raise_without_scpi(
+    drv: EAPSB,
+    visa: MagicMock,
+    method_name: str,
+    args: tuple[object, ...],
+) -> None:
+    with pytest.raises(FeatureNotSupportedError, match=f"{method_name} is not supported"):
+        getattr(drv, method_name)(*args, channel=1)
+    visa.write.assert_not_called()
+    visa.query.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("method_name", "args"),
+    [
+        ("set_mode", (LoadMode.CC,)),
+        ("set_level", (LoadMode.CC, 10.0)),
+    ],
+)
+def test_eload_invalid_channel_raises_without_scpi(
+    drv: EAPSB,
+    visa: MagicMock,
+    method_name: str,
+    args: tuple[object, ...],
+) -> None:
+    kwargs: dict[str, object] = {"curr_limit": None} if method_name == "set_level" else {}
+    with pytest.raises(ValueError, match="EA PSB channel must be 1"):
+        getattr(drv, method_name)(*args, channel=2, **kwargs)
+    visa.write.assert_not_called()
+    visa.query.assert_not_called()
+
+
+def test_psb_full_interface_through_both_hals(visa_cls: MagicMock, visa: MagicMock) -> None:
+    # One driver, wrapped as both a source (InstroPSU) and a sink (InstroELoad).
+    driver = EAPSB(VisaConfig(visa_resource=RESOURCE))
+    visa_cls.assert_called_once_with(VisaConfig(visa_resource=RESOURCE))
+
+    psu = InstroPSU("psb", driver=driver, num_channels=1)
+    eload = InstroELoad("psb_sink", driver=driver)
+
+    psu.open()
+    visa.open.assert_called_once()
+    assert "SYST:LOCK ON" in _writes(visa)
+    assert call("SYST:LOCK:OWN?") in visa.query.call_args_list
+
+    # --- PSU (source) surface ---
+    psu.set_voltage(48, channel=1)
+    psu.set_current_limit(20, channel=1)
+    psu.output_enable(True, channel=1)
+    assert _latest(psu.get_output_status(channel=1)) == pytest.approx(1.0)  # "ON" -> True -> 1.0
+    assert _latest(psu.get_voltage(channel=1)) == pytest.approx(48.0)
+    assert _latest(psu.get_current(channel=1)) == pytest.approx(20.0)
+    psu.set_overvoltage_protection_level(60, channel=1)
+    assert _latest(psu.get_overvoltage_protection_level(channel=1)) == pytest.approx(60.0)
+    psu.set_overcurrent_protection_level(25, channel=1)
+    assert _latest(psu.get_overcurrent_protection_level(channel=1)) == pytest.approx(25.0)
+
+    for expected in ("VOLT 48.000", "CURR 20.000", "OUTP ON", "VOLT:PROT 60.000", "CURR:PROT 25.000"):
+        assert expected in _writes(visa)
+
+    # --- E-Load (sink) surface: every LoadMode ---
+    eload.set_mode(LoadMode.CC)
+    eload.set_level(10)
+    eload.set_mode(LoadMode.CP)
+    eload.set_level(500)
+    eload.set_mode(LoadMode.CR)
+    eload.set_level(5)
+    eload.set_mode(LoadMode.CV)
+    eload.set_level(24, curr_limit=15)
+
+    writes = _writes(visa)
+    for expected in (
+        "SYST:CONF:MODE UIP",  # CC/CP/CV
+        "SYST:CONF:MODE UIR",  # CR unlocks the resistance subsystem
+        "SINK:CURR 10.000",
+        "SINK:POW 500.000",
+        "SINK:RES 5.000",
+        "VOLT 24.000",  # CV uses the shared voltage setpoint
+        "SINK:CURR 15.000",  # CV curr_limit
+    ):
+        assert expected in writes
+
+    # --- Unsupported over SCPI: raise FeatureNotSupportedError and emit no new SCPI ---
+    before = len(visa.write.call_args_list)
+    unsupported = [
+        lambda: eload.set_range(1.0),
+        lambda: eload.set_slewrate(SlewRateDirection.RISE, 1.0),
+        lambda: eload.short_output(True),
+        lambda: psu.set_overvoltage_protection_enabled(True, channel=1),
+        lambda: psu.set_overvoltage_protection_delay(0.1, channel=1),
+        lambda: psu.set_overcurrent_protection_enabled(True, channel=1),
+        lambda: psu.set_remote_sense_enabled(True, channel=1),
+    ]
+    for invoke in unsupported:
+        with pytest.raises(FeatureNotSupportedError):
+            invoke()
+    assert len(visa.write.call_args_list) == before
+
+    psu.close()
+    assert "SYST:LOCK OFF" in _writes(visa)
+    visa.close.assert_called_once()


### PR DESCRIPTION
## Summary

Adds support for the Elektro Automatik PSB series of bidirectional power supplies. Only implements SCPI over VISA. Modbus to be added later. Closes INSTRO-133.

## Type of change

- [ ] Bug fix (`fix`)
- [X] New feature (`feat`)
- [ ] Breaking change (`feat!` / `fix!`)
- [ ] Refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] Chore / tooling (`chore`)

## Verification

Confirmed with added hardware test.

========================================================================== test session starts ===========================================================================
platform darwin -- Python 3.12.12, pytest-9.1.1, pluggy-1.6.0
rootdir: /Users/william/Projects/instro
configfile: pyproject.toml
collected 36 items                                                                                                                                                       

tests/psu/ea/test_ea_psb_hardware.py ....................................                                                                                          [100%]

========================================================================== 36 passed in 14.24s ===========================================================================

## Tests

- [X] Unit tests added or updated
- [ ] Existing tests cover this change
- [ ] No tests — explain why:

## Checklist

- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(driver): add support for Keysight E36300`)
- [X] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [X] Documentation updated if user-facing behavior changed
- [X] Code follows the style/conventions of the surrounding code

## Notes for reviewers

This is our first composed driver and will likely serve as the base for all future composed instruments. Make sure you like the way the files are organized and where I've placed everything in the docs.