### PR TITLE
refactor(instrodaq): explicit input output methods

### DIFF
--- a/docs/guides/instrumentation/daq.mdx
+++ b/docs/guides/instrumentation/daq.mdx
@@ -247,6 +247,23 @@ daq.configure_digital_port(
 ```
 Refer to your DAQ device's documentation for available physical channel names and supported features.
 
+### Typed Channel Configuration
+
+Alongside the generic `configure_analog_channel` / `configure_digital_line`, `InstroDAQ` exposes measurement-specific configuration methods. Each builds a typed channel (`AnalogVoltageChannel`, `AnalogCurrentChannel`, `AnalogThermocoupleChannel`, or a `DigitalLineChannel`) and delegates to a dedicated driver method:
+
+| Method | Channel type | Driver method |
+|--------|--------------|---------------|
+| `configure_voltage_input(physical_channel, *, alias, range_min, range_max, scaler, terminal_config)` | `AnalogVoltageChannel` | `configure_ai_voltage_channel` |
+| `configure_voltage_output(physical_channel, *, alias, range_min, range_max, scaler)` | `AnalogVoltageChannel` | `configure_ao_voltage_channel` |
+| `configure_current_input(physical_channel, *, alias, range_min, range_max, scaler)` | `AnalogCurrentChannel` | `configure_ai_current_channel` |
+| `configure_current_output(physical_channel, *, alias, range_min, range_max, scaler)` | `AnalogCurrentChannel` | `configure_ao_current_channel` |
+| `configure_thermocouple_input(physical_channel, tc_type, *, alias, range_min, range_max, cjc_source, cjc_temp, cjc_channel, unit)` | `AnalogThermocoupleChannel` | `configure_ai_thermocouple_channel` |
+| `configure_digital_input(physical_channel, *, logic, logic_level, alias)` | `DigitalLineChannel` | `configure_di_channel` |
+| `configure_digital_output(physical_channel, *, logic, logic_level, alias)` | `DigitalLineChannel` | `configure_do_channel` |
+
+<Note>
+**Not yet implemented for the packaged drivers.** None of the bundled DAQ drivers (NI-DAQmx, LabJack T-Series, MCC, Keysight 34980A) implement these typed methods yet. Please use `configure_analog_channel` / `configure_digital_line`.
+</Note>
 
 ### Hardware-Timed Sample Rate
 
@@ -646,6 +663,13 @@ The base `Instrument` background daemon additionally publishes per-iteration dia
 | `open()` | Establish connection to the DAQ device |
 | `close()` | Disconnect from device and close publishers |
 | `configure_analog_channel(direction, physical_channel, alias, range_min, range_max)` | Configure an analog I/O channel |
+| `configure_voltage_input(physical_channel, ...)` | Configure a typed analog voltage input channel |
+| `configure_voltage_output(physical_channel, ...)` | Configure a typed analog voltage output channel |
+| `configure_current_input(physical_channel, ...)` | Configure a typed analog current input channel |
+| `configure_current_output(physical_channel, ...)` | Configure a typed analog current output channel |
+| `configure_thermocouple_input(physical_channel, tc_type, ...)` | Configure a thermocouple input channel |
+| `configure_digital_input(physical_channel, ...)` | Configure a typed digital input line |
+| `configure_digital_output(physical_channel, ...)` | Configure a typed digital output line |
 | `configure_digital_line(direction, physical_channel, logic, logic_level=None, alias=None)` | Configure a single digital I/O line |
 | `configure_digital_port(direction, physical_channel, logic, port_width, logic_level=None, alias=None)` | Configure a digital I/O port (multi-line) |
 | `configure_ai_sample_rate(sample_rate, samples_per_channel=None)` | Set hardware timing for analog input |
@@ -717,6 +741,13 @@ Each of the methods below must (a) program the device and (b) record the resulti
 - **`configure_do_line_channel(physical_channel, logic, ...)`**: Parse, program, and register a digital output line. Record on `self._do_channels[channel.alias]`.
 - **`configure_di_port_channel(physical_channel, logic, port_width, ...)`**: Parse, program, and register a digital input port. Record on `self._di_channels[channel.alias]`. Default raises `NotImplementedError` for line-only devices.
 - **`configure_do_port_channel(physical_channel, logic, port_width, ...)`**: Parse, program, and register a digital output port. Record on `self._do_channels[channel.alias]`. Default raises `NotImplementedError` for line-only devices.
+
+The methods below back `InstroDAQ`'s [typed channel configuration](#typed-channel-configuration). They are not yet implemented for packaged drivers.
+
+- **`configure_ai_voltage_channel(channel)` / `configure_ao_voltage_channel(channel)`**: Configure a typed voltage input/output channel from an `AnalogVoltageChannel`; record on `self._ai_channels` / `self._ao_channels`.
+- **`configure_ai_current_channel(channel)` / `configure_ao_current_channel(channel)`**: Configure a typed current input/output channel from an `AnalogCurrentChannel`; record on `self._ai_channels` / `self._ao_channels`.
+- **`configure_ai_thermocouple_channel(channel)`**: Configure a thermocouple input channel from an `AnalogThermocoupleChannel` (thermocouple type plus cold-junction config); record on `self._ai_channels`.
+- **`configure_di_channel(channel)` / `configure_do_channel(channel)`**: Register a typed digital input/output line from a `DigitalLineChannel`; record on `self._di_channels` / `self._do_channels`.
 
 ### Timing Configuration
 

--- a/docs/guides/instrumentation/daq.mdx
+++ b/docs/guides/instrumentation/daq.mdx
@@ -257,7 +257,7 @@ Alongside the generic `configure_analog_channel` / `configure_digital_line`, `In
 | `configure_voltage_output(physical_channel, *, alias, range_min, range_max, scaler)` | `AnalogVoltageChannel` | `configure_ao_voltage_channel` |
 | `configure_current_input(physical_channel, *, alias, range_min, range_max, scaler)` | `AnalogCurrentChannel` | `configure_ai_current_channel` |
 | `configure_current_output(physical_channel, *, alias, range_min, range_max, scaler)` | `AnalogCurrentChannel` | `configure_ao_current_channel` |
-| `configure_thermocouple_input(physical_channel, tc_type, *, alias, range_min, range_max, cjc_source, cjc_temp, cjc_channel, unit)` | `AnalogThermocoupleChannel` | `configure_ai_thermocouple_channel` |
+| `configure_thermocouple_input(physical_channel, tc_type, *, alias, range_min, range_max, scaler, cjc_source, cjc_temp, cjc_channel, unit)` | `AnalogThermocoupleChannel` | `configure_ai_thermocouple_channel` |
 | `configure_digital_input(physical_channel, *, logic, logic_level, alias)` | `DigitalLineChannel` | `configure_di_channel` |
 | `configure_digital_output(physical_channel, *, logic, logic_level, alias)` | `DigitalLineChannel` | `configure_do_channel` |
 

--- a/instro/daq/daq.py
+++ b/instro/daq/daq.py
@@ -3,8 +3,9 @@
 import abc
 import logging
 import time
+from enum import Enum
 from types import MappingProxyType
-from typing import Any, Mapping
+from typing import Any, Mapping, TypeVar
 
 from instro.daq.scaling.scaling import Scaler
 from instro.daq.scaling.thermocouple import TC_TYPE, TC_UNIT
@@ -30,6 +31,17 @@ from instro.lib.publishers import Publisher
 from instro.lib.types import Command
 
 logger = logging.getLogger(__name__)
+
+_E = TypeVar("_E", bound=Enum)
+
+
+def _coerce_enum(value: str | _E, enum_cls: type[_E], param: str) -> _E:
+    """Convert ``value`` (name or member) to an ``enum_cls`` member, raising a uniform ValueError on a bad value."""
+    try:
+        return enum_cls(value)
+    except ValueError:
+        valid = ", ".join(str(member.value) for member in enum_cls)
+        raise ValueError(f"{param} '{value}' is not valid; choose one of {valid}.") from None
 
 
 class HWTimestamper:
@@ -531,7 +543,7 @@ class InstroDAQ(Instrument):
         range_min: float = -10.0,
         range_max: float = 10.0,
         scaler: Scaler | None = None,
-        terminal_config: TerminalConfig | None = None,
+        terminal_config: str | TerminalConfig | None = None,
     ):
         """Configure an analog voltage input channel.
 
@@ -544,6 +556,8 @@ class InstroDAQ(Instrument):
             terminal_config: Terminal wiring (RSE / NRSE / DIFF) for the channel.
         """
         self._require_open()
+        if terminal_config is not None:
+            terminal_config = _coerce_enum(terminal_config, TerminalConfig, "terminal_config")
         alias = alias if alias else physical_channel
         self._reject_duplicate_channel(alias)
         channel = AnalogVoltageChannel(
@@ -661,16 +675,16 @@ class InstroDAQ(Instrument):
     def configure_thermocouple_input(
         self,
         physical_channel: str,
-        tc_type: TC_TYPE,
+        tc_type: str | TC_TYPE,
         *,
         alias: str | None = None,
         range_min: float = 0.0,
         range_max: float = 100.0,
         scaler: Scaler | None = None,
-        cjc_source: CJCSource = CJCSource.INTERNAL,
+        cjc_source: str | CJCSource = CJCSource.INTERNAL,
         cjc_temp: float | None = None,
         cjc_channel: str | None = None,
-        unit: TC_UNIT = TC_UNIT.CELSIUS,
+        unit: str | TC_UNIT = TC_UNIT.CELSIUS,
     ):
         """Configure a thermocouple input channel.
 
@@ -680,13 +694,16 @@ class InstroDAQ(Instrument):
             range_min: Lower temperature range (in ``unit``).
             range_max: Upper temperature range (in ``unit``).
             scaler: Optional ``Scaler`` applied to AI samples after read.
-            tc_type: Type of thermocouple used
+            tc_type: Thermocouple type — one of B, E, J, K, N, R, S, T.
             cjc_source: Cold-junction compensation source (internal / constant / channel).
             cjc_temp: Cold-junction temperature when ``cjc_source`` is ``CONSTANT``.
             cjc_channel: Channel supplying cold-junction temperature when ``cjc_source`` is ``CHANNEL``.
             unit: Temperature unit for returned readings.
         """
         self._require_open()
+        tc_type = _coerce_enum(tc_type, TC_TYPE, "tc_type")
+        cjc_source = _coerce_enum(cjc_source, CJCSource, "cjc_source")
+        unit = _coerce_enum(unit, TC_UNIT, "unit")
         alias = alias if alias else physical_channel
         self._reject_duplicate_channel(alias)
         channel = AnalogThermocoupleChannel(
@@ -711,7 +728,7 @@ class InstroDAQ(Instrument):
         self,
         physical_channel: str,
         *,
-        logic: Logic = Logic.HIGH,
+        logic: str | Logic = Logic.HIGH,
         logic_level: float | None = None,
         alias: str | None = None,
     ):
@@ -724,6 +741,7 @@ class InstroDAQ(Instrument):
             alias: Friendly name; defaults to ``physical_channel``.
         """
         self._require_open()
+        logic = _coerce_enum(logic, Logic, "logic")
         alias = alias if alias else physical_channel
         self._reject_duplicate_channel(alias)
         channel = DigitalLineChannel(
@@ -740,7 +758,7 @@ class InstroDAQ(Instrument):
         self,
         physical_channel: str,
         *,
-        logic: Logic = Logic.HIGH,
+        logic: str | Logic = Logic.HIGH,
         logic_level: float | None = None,
         alias: str | None = None,
     ):
@@ -753,6 +771,7 @@ class InstroDAQ(Instrument):
             alias: Friendly name; defaults to ``physical_channel``.
         """
         self._require_open()
+        logic = _coerce_enum(logic, Logic, "logic")
         alias = alias if alias else physical_channel
         self._reject_duplicate_channel(alias)
         channel = DigitalLineChannel(

--- a/instro/daq/daq.py
+++ b/instro/daq/daq.py
@@ -906,7 +906,6 @@ class InstroDAQ(Instrument):
     def stop(self, **kwargs):
         """Stop hardware acquisition and the background daemon; tolerant teardown when not open."""
         super().stop()
-        self._running = False
         # Skip the device stop when not open: some drivers' stop() issues a transport
         # command (e.g. Keysight's ABORt) that raises if the session isn't open. close()
         # routes through here, so this gate keeps close-before-open from raising.
@@ -914,6 +913,7 @@ class InstroDAQ(Instrument):
             return
         channel_type = kwargs.pop("channel_type", None)
         self._driver.stop(channel_type=channel_type, **kwargs)
+        self._running = False
 
     def read_analog(
         self,

--- a/instro/daq/daq.py
+++ b/instro/daq/daq.py
@@ -437,6 +437,7 @@ class InstroDAQ(Instrument):
 
         self._driver = driver
         self._is_open = False
+        self._running = False
 
         self._background_config.interval = (
             0  # DAQ reads block so set this to zero because they implicitly time the loop
@@ -518,6 +519,11 @@ class InstroDAQ(Instrument):
                     f"({_channel_kind(existing)} on {existing.physical_channel}); remove it before reconfiguring."
                 )
 
+    def _verify_not_running(self, alias: str) -> None:
+        """Raise if a channel is configured while acquisition is running; the user must ``stop()`` first."""
+        if self._running:
+            raise RuntimeError(f"cannot configure channel '{alias}' while '{self.name}' is running; call stop() first.")
+
     def open(self):
         """Open the underlying driver."""
         logger.info("Opening DAQ '%s'", self.name)
@@ -559,7 +565,9 @@ class InstroDAQ(Instrument):
         if terminal_config is not None:
             terminal_config = _coerce_enum(terminal_config, TerminalConfig, "terminal_config")
         alias = alias if alias else physical_channel
+        # Channel validation
         self._reject_duplicate_channel(alias)
+        self._verify_not_running(alias)
         channel = AnalogVoltageChannel(
             physical_channel=physical_channel,
             alias=alias,
@@ -592,7 +600,9 @@ class InstroDAQ(Instrument):
         """
         self._require_open()
         alias = alias if alias else physical_channel
+        # Channel validation
         self._reject_duplicate_channel(alias)
+        self._verify_not_running(alias)
         channel = AnalogVoltageChannel(
             physical_channel=physical_channel,
             alias=alias,
@@ -626,7 +636,9 @@ class InstroDAQ(Instrument):
         """
         self._require_open()
         alias = alias if alias else physical_channel
+        # Channel validation
         self._reject_duplicate_channel(alias)
+        self._verify_not_running(alias)
         channel = AnalogCurrentChannel(
             physical_channel=physical_channel,
             alias=alias,
@@ -658,7 +670,9 @@ class InstroDAQ(Instrument):
         """
         self._require_open()
         alias = alias if alias else physical_channel
+        # Channel validation
         self._reject_duplicate_channel(alias)
+        self._verify_not_running(alias)
         channel = AnalogCurrentChannel(
             physical_channel=physical_channel,
             alias=alias,
@@ -705,7 +719,9 @@ class InstroDAQ(Instrument):
         cjc_source = _coerce_enum(cjc_source, CJCSource, "cjc_source")
         unit = _coerce_enum(unit, TC_UNIT, "unit")
         alias = alias if alias else physical_channel
+        # Channel validation
         self._reject_duplicate_channel(alias)
+        self._verify_not_running(alias)
         channel = AnalogThermocoupleChannel(
             physical_channel=physical_channel,
             alias=alias,
@@ -743,7 +759,9 @@ class InstroDAQ(Instrument):
         self._require_open()
         logic = _coerce_enum(logic, Logic, "logic")
         alias = alias if alias else physical_channel
+        # Channel validation
         self._reject_duplicate_channel(alias)
+        self._verify_not_running(alias)
         channel = DigitalLineChannel(
             physical_channel=physical_channel,
             alias=alias,
@@ -773,7 +791,9 @@ class InstroDAQ(Instrument):
         self._require_open()
         logic = _coerce_enum(logic, Logic, "logic")
         alias = alias if alias else physical_channel
+        # Channel validation
         self._reject_duplicate_channel(alias)
+        self._verify_not_running(alias)
         channel = DigitalLineChannel(
             physical_channel=physical_channel,
             alias=alias,
@@ -877,6 +897,7 @@ class InstroDAQ(Instrument):
         # we add other channel type capabilities that are hardware timed.
 
         self._driver.start(channel_type=channel_type)
+        self._running = True
 
         if background:
             self._define_background_daemon()
@@ -885,6 +906,7 @@ class InstroDAQ(Instrument):
     def stop(self, **kwargs):
         """Stop hardware acquisition and the background daemon; tolerant teardown when not open."""
         super().stop()
+        self._running = False
         # Skip the device stop when not open: some drivers' stop() issues a transport
         # command (e.g. Keysight's ABORt) that raises if the session isn't open. close()
         # routes through here, so this gate keeps close-before-open from raising.

--- a/instro/daq/daq.py
+++ b/instro/daq/daq.py
@@ -9,11 +9,11 @@ from typing import Any, Mapping
 from instro.daq.scaling.scaling import Scaler
 from instro.daq.scaling.thermocouple import TC_TYPE, TC_UNIT
 from instro.daq.types import (
-    CJC_SOURCE,
     AnalogChannel,
     AnalogCurrentChannel,
     AnalogThermocoupleChannel,
     AnalogVoltageChannel,
+    CJCSource,
     DAQChannel,
     DigitalChannel,
     DigitalLineChannel,
@@ -631,7 +631,7 @@ class InstroDAQ(Instrument):
         alias: str | None = None,
         range_min: float = 0.0,
         range_max: float = 100.0,
-        cjc_source: CJC_SOURCE = CJC_SOURCE.INTERNAL,
+        cjc_source: CJCSource = CJCSource.INTERNAL,
         cjc_temp: float | None = None,
         cjc_channel: str | None = None,
         unit: TC_UNIT = TC_UNIT.CELSIUS,

--- a/instro/daq/daq.py
+++ b/instro/daq/daq.py
@@ -379,6 +379,24 @@ class DAQDriverBase(abc.ABC):
         ...
 
 
+def _channel_kind(channel: DAQChannel) -> str:
+    """Short kind label (e.g. ``voltage_input``) describing an already-configured channel for error messages."""
+    direction = channel.direction.value.lower()
+    match channel:
+        case AnalogThermocoupleChannel():
+            return "thermocouple_input"
+        case AnalogVoltageChannel():
+            return f"voltage_{direction}"
+        case AnalogCurrentChannel():
+            return f"current_{direction}"
+        case DigitalChannel():
+            return f"digital_{direction}"
+        case AnalogChannel():
+            return f"analog_{direction}"
+        case _:
+            return f"channel_{direction}"
+
+
 class InstroDAQ(Instrument):
     def __init__(
         self,
@@ -479,6 +497,15 @@ class InstroDAQ(Instrument):
         if not self._is_open:
             raise InstrumentNotOpenError(f"InstroDAQ '{self.name}' is not open. Call open() first.")
 
+    def _reject_duplicate_channel(self, alias: str) -> None:
+        """Raise if ``alias`` is already configured on the driver, so a channel can't be silently reconfigured."""
+        for existing in self._driver.channels:
+            if existing.alias == alias:
+                raise ValueError(
+                    f"channel '{alias}' is already configured "
+                    f"({_channel_kind(existing)} on {existing.physical_channel}); remove it before reconfiguring."
+                )
+
     def open(self):
         """Open the underlying driver."""
         logger.info("Opening DAQ '%s'", self.name)
@@ -517,9 +544,11 @@ class InstroDAQ(Instrument):
             terminal_config: Terminal wiring (RSE / NRSE / DIFF) for the channel.
         """
         self._require_open()
+        alias = alias if alias else physical_channel
+        self._reject_duplicate_channel(alias)
         channel = AnalogVoltageChannel(
             physical_channel=physical_channel,
-            alias=alias if alias else physical_channel,
+            alias=alias,
             direction=Direction.INPUT,
             range_min=range_min,
             range_max=range_max,
@@ -548,9 +577,11 @@ class InstroDAQ(Instrument):
             scaler: Optional ``Scaler`` for the channel.
         """
         self._require_open()
+        alias = alias if alias else physical_channel
+        self._reject_duplicate_channel(alias)
         channel = AnalogVoltageChannel(
             physical_channel=physical_channel,
-            alias=alias if alias else physical_channel,
+            alias=alias,
             direction=Direction.OUTPUT,
             range_min=range_min,
             range_max=range_max,
@@ -580,9 +611,11 @@ class InstroDAQ(Instrument):
             scaler: Optional ``Scaler`` applied to AI samples after read.
         """
         self._require_open()
+        alias = alias if alias else physical_channel
+        self._reject_duplicate_channel(alias)
         channel = AnalogCurrentChannel(
             physical_channel=physical_channel,
-            alias=alias if alias else physical_channel,
+            alias=alias,
             direction=Direction.INPUT,
             range_min=range_min,
             range_max=range_max,
@@ -610,9 +643,11 @@ class InstroDAQ(Instrument):
             scaler: Optional ``Scaler`` for the channel.
         """
         self._require_open()
+        alias = alias if alias else physical_channel
+        self._reject_duplicate_channel(alias)
         channel = AnalogCurrentChannel(
             physical_channel=physical_channel,
-            alias=alias if alias else physical_channel,
+            alias=alias,
             direction=Direction.OUTPUT,
             range_min=range_min,
             range_max=range_max,
@@ -652,9 +687,11 @@ class InstroDAQ(Instrument):
             unit: Temperature unit for returned readings.
         """
         self._require_open()
+        alias = alias if alias else physical_channel
+        self._reject_duplicate_channel(alias)
         channel = AnalogThermocoupleChannel(
             physical_channel=physical_channel,
-            alias=alias if alias else physical_channel,
+            alias=alias,
             direction=Direction.INPUT,
             range_min=range_min,
             range_max=range_max,
@@ -687,9 +724,11 @@ class InstroDAQ(Instrument):
             alias: Friendly name; defaults to ``physical_channel``.
         """
         self._require_open()
+        alias = alias if alias else physical_channel
+        self._reject_duplicate_channel(alias)
         channel = DigitalLineChannel(
             physical_channel=physical_channel,
-            alias=alias if alias else physical_channel,
+            alias=alias,
             direction=Direction.INPUT,
             logic=logic,
             logic_level=logic_level,
@@ -714,9 +753,11 @@ class InstroDAQ(Instrument):
             alias: Friendly name; defaults to ``physical_channel``.
         """
         self._require_open()
+        alias = alias if alias else physical_channel
+        self._reject_duplicate_channel(alias)
         channel = DigitalLineChannel(
             physical_channel=physical_channel,
-            alias=alias if alias else physical_channel,
+            alias=alias,
             direction=Direction.OUTPUT,
             logic=logic,
             logic_level=logic_level,

--- a/instro/daq/daq.py
+++ b/instro/daq/daq.py
@@ -7,7 +7,7 @@ from types import MappingProxyType
 from typing import Any, Mapping
 
 from instro.daq.scaling.scaling import Scaler
-from instro.daq.scaling.thermocouple import TC_UNIT, TC_TYPE
+from instro.daq.scaling.thermocouple import TC_TYPE, TC_UNIT
 from instro.daq.types import (
     CJC_SOURCE,
     AnalogChannel,
@@ -16,6 +16,7 @@ from instro.daq.types import (
     AnalogVoltageChannel,
     DAQChannel,
     DigitalChannel,
+    DigitalLineChannel,
     DigitalPortWidth,
     Direction,
     HWTimingConfig,
@@ -251,6 +252,14 @@ class DAQDriverBase(abc.ABC):
         """Parse, program, and register a DO port channel. Override if the driver supports port-mode digital output."""
         raise NotImplementedError("Digital Output port mode has not been configured for this driver")
 
+    def configure_di_channel(self, channel: DigitalLineChannel):
+        """Register a DI line channel. Override if the driver supports digital input."""
+        raise NotImplementedError("Digital input has not been configured for this driver")
+
+    def configure_do_channel(self, channel: DigitalLineChannel):
+        """Register a DO line channel. Override if the driver supports digital output."""
+        raise NotImplementedError("Digital output has not been configured for this driver")
+
     @abc.abstractmethod
     def start(self, **kwargs):
         """Start hardware-timed acquisition.
@@ -485,7 +494,7 @@ class InstroDAQ(Instrument):
         self._is_open = False
         logger.info("Closed DAQ '%s'", self.name)
 
-    # ========  Analog Input  ===========
+    # ========  Voltage Channels  ===========
 
     def configure_voltage_input(
         self,
@@ -550,6 +559,8 @@ class InstroDAQ(Instrument):
         self._driver.configure_ao_voltage_channel(channel)
         logger.info("Configured voltage output channel on DAQ '%s'", self.name)
 
+    # ========  Current Channels  ===========
+
     def configure_current_input(
         self,
         physical_channel: str,
@@ -610,6 +621,8 @@ class InstroDAQ(Instrument):
         self._driver.configure_ao_current_channel(channel)
         logger.info("Configured current output channel on DAQ '%s'", self.name)
 
+    # ========  Thermocouple Channels  ===========
+
     def configure_thermocouple_input(
         self,
         physical_channel: str,
@@ -651,6 +664,62 @@ class InstroDAQ(Instrument):
         )
         self._driver.configure_ai_thermocouple_channel(channel)
         logger.info("Configured thermocouple input channel on DAQ '%s'", self.name)
+
+    # ========  Digital Channels  ===========
+
+    def configure_digital_input(
+        self,
+        physical_channel: str,
+        *,
+        logic: Logic = Logic.HIGH,
+        logic_level: float | None = None,
+        alias: str | None = None,
+    ):
+        """Configure a digital input line channel.
+
+        Args:
+            physical_channel: Vendor-specific line id (e.g. ``"port0/line3"`` on NI, ``"FIO0"`` on LabJack).
+            logic: Active-``HIGH`` or active-``LOW``.
+            logic_level: Voltage threshold (volts); the driver default is used when ``None``.
+            alias: Friendly name; defaults to ``physical_channel``.
+        """
+        self._require_open()
+        channel = DigitalLineChannel(
+            physical_channel=physical_channel,
+            alias=alias if alias else physical_channel,
+            direction=Direction.INPUT,
+            logic=logic,
+            logic_level=logic_level,
+        )
+        self._driver.configure_di_channel(channel)
+        logger.info("Configured digital input channel on DAQ '%s'", self.name)
+
+    def configure_digital_output(
+        self,
+        physical_channel: str,
+        *,
+        logic: Logic = Logic.HIGH,
+        logic_level: float | None = None,
+        alias: str | None = None,
+    ):
+        """Configure a digital output line channel.
+
+        Args:
+            physical_channel: Vendor-specific line id (e.g. ``"port0/line3"`` on NI, ``"FIO0"`` on LabJack).
+            logic: Active-``HIGH`` or active-``LOW``.
+            logic_level: Voltage threshold (volts); the driver default is used when ``None``.
+            alias: Friendly name; defaults to ``physical_channel``.
+        """
+        self._require_open()
+        channel = DigitalLineChannel(
+            physical_channel=physical_channel,
+            alias=alias if alias else physical_channel,
+            direction=Direction.OUTPUT,
+            logic=logic,
+            logic_level=logic_level,
+        )
+        self._driver.configure_do_channel(channel)
+        logger.info("Configured digital output channel on DAQ '%s'", self.name)
 
     def configure_analog_channel(
         self,

--- a/instro/daq/daq.py
+++ b/instro/daq/daq.py
@@ -631,6 +631,7 @@ class InstroDAQ(Instrument):
         alias: str | None = None,
         range_min: float = 0.0,
         range_max: float = 100.0,
+        scaler: Scaler | None = None,
         cjc_source: CJCSource = CJCSource.INTERNAL,
         cjc_temp: float | None = None,
         cjc_channel: str | None = None,
@@ -643,6 +644,7 @@ class InstroDAQ(Instrument):
             alias: Friendly name; defaults to ``physical_channel``.
             range_min: Lower temperature range (in ``unit``).
             range_max: Upper temperature range (in ``unit``).
+            scaler: Optional ``Scaler`` applied to AI samples after read.
             tc_type: Type of thermocouple used
             cjc_source: Cold-junction compensation source (internal / constant / channel).
             cjc_temp: Cold-junction temperature when ``cjc_source`` is ``CONSTANT``.
@@ -656,6 +658,7 @@ class InstroDAQ(Instrument):
             direction=Direction.INPUT,
             range_min=range_min,
             range_max=range_max,
+            scaler=scaler,
             tc_type=tc_type,
             cjc_source=cjc_source,
             cjc_temp=cjc_temp,

--- a/instro/daq/daq.py
+++ b/instro/daq/daq.py
@@ -7,8 +7,13 @@ from types import MappingProxyType
 from typing import Any, Mapping
 
 from instro.daq.scaling.scaling import Scaler
+from instro.daq.scaling.thermocouple import TC_UNIT, TC_TYPE
 from instro.daq.types import (
+    CJC_SOURCE,
     AnalogChannel,
+    AnalogCurrentChannel,
+    AnalogThermocoupleChannel,
+    AnalogVoltageChannel,
     DAQChannel,
     DigitalChannel,
     DigitalPortWidth,
@@ -168,6 +173,26 @@ class DAQDriverBase(abc.ABC):
     ):
         """Register an AO channel. Override if the driver supports analog output."""
         raise NotImplementedError("Analog Output has not been configured for this driver")
+
+    def configure_ai_voltage_channel(self, channel: AnalogVoltageChannel):
+        """Register an AI voltage channel. Override if the driver supports analog voltage input."""
+        raise NotImplementedError("Analog voltage input has not been configured for this driver")
+
+    def configure_ao_voltage_channel(self, channel: AnalogVoltageChannel):
+        """Register an AO voltage channel. Override if the driver supports analog voltage output."""
+        raise NotImplementedError("Analog voltage output has not been configured for this driver")
+
+    def configure_ai_current_channel(self, channel: AnalogCurrentChannel):
+        """Register an AI current channel. Override if the driver supports analog current input."""
+        raise NotImplementedError("Analog current input has not been configured for this driver")
+
+    def configure_ao_current_channel(self, channel: AnalogCurrentChannel):
+        """Register an AO current channel. Override if the driver supports analog current output."""
+        raise NotImplementedError("Analog current output has not been configured for this driver")
+
+    def configure_ai_thermocouple_channel(self, channel: AnalogThermocoupleChannel):
+        """Register an AI thermocouple channel. Override if the driver supports thermocouple input."""
+        raise NotImplementedError("Thermocouple input has not been configured for this driver")
 
     @abc.abstractmethod
     def configure_ai_hw_timing(
@@ -461,6 +486,171 @@ class InstroDAQ(Instrument):
         logger.info("Closed DAQ '%s'", self.name)
 
     # ========  Analog Input  ===========
+
+    def configure_voltage_input(
+        self,
+        physical_channel: str,
+        *,
+        alias: str | None = None,
+        range_min: float = -10.0,
+        range_max: float = 10.0,
+        scaler: Scaler | None = None,
+        terminal_config: TerminalConfig | None = None,
+    ):
+        """Configure an analog voltage input channel.
+
+        Args:
+            physical_channel: Vendor-specific channel id (e.g. ``"ai0"`` or ``"Dev1/ai0"``).
+            alias: Friendly name; defaults to ``physical_channel``.
+            range_min: Lower voltage range (volts).
+            range_max: Upper voltage range (volts).
+            scaler: Optional ``Scaler`` applied to AI samples after read.
+            terminal_config: Terminal wiring (RSE / NRSE / DIFF) for the channel.
+        """
+        self._require_open()
+        channel = AnalogVoltageChannel(
+            physical_channel=physical_channel,
+            alias=alias if alias else physical_channel,
+            direction=Direction.INPUT,
+            range_min=range_min,
+            range_max=range_max,
+            scaler=scaler,
+            terminal_config=terminal_config,
+        )
+        self._driver.configure_ai_voltage_channel(channel)
+        logger.info("Configured voltage input channel on DAQ '%s'", self.name)
+
+    def configure_voltage_output(
+        self,
+        physical_channel: str,
+        *,
+        alias: str | None = None,
+        range_min: float = -10.0,
+        range_max: float = 10.0,
+        scaler: Scaler | None = None,
+    ):
+        """Configure an analog voltage output channel.
+
+        Args:
+            physical_channel: Vendor-specific channel id (e.g. ``"ao0"`` or ``"Dev1/ao0"``).
+            alias: Friendly name; defaults to ``physical_channel``.
+            range_min: Lower voltage range (volts).
+            range_max: Upper voltage range (volts).
+            scaler: Optional ``Scaler`` for the channel.
+        """
+        self._require_open()
+        channel = AnalogVoltageChannel(
+            physical_channel=physical_channel,
+            alias=alias if alias else physical_channel,
+            direction=Direction.OUTPUT,
+            range_min=range_min,
+            range_max=range_max,
+            scaler=scaler,
+        )
+        self._driver.configure_ao_voltage_channel(channel)
+        logger.info("Configured voltage output channel on DAQ '%s'", self.name)
+
+    def configure_current_input(
+        self,
+        physical_channel: str,
+        *,
+        alias: str | None = None,
+        range_min: float = 0.0,
+        range_max: float = 0.02,
+        scaler: Scaler | None = None,
+    ):
+        """Configure an analog current input channel.
+
+        Args:
+            physical_channel: Vendor-specific channel id (e.g. ``"ai0"`` or ``"Dev1/ai0"``).
+            alias: Friendly name; defaults to ``physical_channel``.
+            range_min: Lower current range (amps).
+            range_max: Upper current range (amps).
+            scaler: Optional ``Scaler`` applied to AI samples after read.
+        """
+        self._require_open()
+        channel = AnalogCurrentChannel(
+            physical_channel=physical_channel,
+            alias=alias if alias else physical_channel,
+            direction=Direction.INPUT,
+            range_min=range_min,
+            range_max=range_max,
+            scaler=scaler,
+        )
+        self._driver.configure_ai_current_channel(channel)
+        logger.info("Configured current input channel on DAQ '%s'", self.name)
+
+    def configure_current_output(
+        self,
+        physical_channel: str,
+        *,
+        alias: str | None = None,
+        range_min: float = 0.0,
+        range_max: float = 0.02,
+        scaler: Scaler | None = None,
+    ):
+        """Configure an analog current output channel.
+
+        Args:
+            physical_channel: Vendor-specific channel id (e.g. ``"ao0"`` or ``"Dev1/ao0"``).
+            alias: Friendly name; defaults to ``physical_channel``.
+            range_min: Lower current range (amps).
+            range_max: Upper current range (amps).
+            scaler: Optional ``Scaler`` for the channel.
+        """
+        self._require_open()
+        channel = AnalogCurrentChannel(
+            physical_channel=physical_channel,
+            alias=alias if alias else physical_channel,
+            direction=Direction.OUTPUT,
+            range_min=range_min,
+            range_max=range_max,
+            scaler=scaler,
+        )
+        self._driver.configure_ao_current_channel(channel)
+        logger.info("Configured current output channel on DAQ '%s'", self.name)
+
+    def configure_thermocouple_input(
+        self,
+        physical_channel: str,
+        tc_type: TC_TYPE,
+        *,
+        alias: str | None = None,
+        range_min: float = 0.0,
+        range_max: float = 100.0,
+        cjc_source: CJC_SOURCE = CJC_SOURCE.INTERNAL,
+        cjc_temp: float | None = None,
+        cjc_channel: str | None = None,
+        unit: TC_UNIT = TC_UNIT.CELSIUS,
+    ):
+        """Configure a thermocouple input channel.
+
+        Args:
+            physical_channel: Vendor-specific channel id (e.g. ``"ai0"`` or ``"Dev1/ai0"``).
+            alias: Friendly name; defaults to ``physical_channel``.
+            range_min: Lower temperature range (in ``unit``).
+            range_max: Upper temperature range (in ``unit``).
+            tc_type: Type of thermocouple used
+            cjc_source: Cold-junction compensation source (internal / constant / channel).
+            cjc_temp: Cold-junction temperature when ``cjc_source`` is ``CONSTANT``.
+            cjc_channel: Channel supplying cold-junction temperature when ``cjc_source`` is ``CHANNEL``.
+            unit: Temperature unit for returned readings.
+        """
+        self._require_open()
+        channel = AnalogThermocoupleChannel(
+            physical_channel=physical_channel,
+            alias=alias if alias else physical_channel,
+            direction=Direction.INPUT,
+            range_min=range_min,
+            range_max=range_max,
+            tc_type=tc_type,
+            cjc_source=cjc_source,
+            cjc_temp=cjc_temp,
+            cjc_channel=cjc_channel,
+            unit=unit,
+        )
+        self._driver.configure_ai_thermocouple_channel(channel)
+        logger.info("Configured thermocouple input channel on DAQ '%s'", self.name)
 
     def configure_analog_channel(
         self,

--- a/instro/daq/scaling/thermocouple.py
+++ b/instro/daq/scaling/thermocouple.py
@@ -1,13 +1,13 @@
 """Thermocouple scaling for DAQ: voltage → °C with cold-junction compensation."""
 
-import enum
+from enum import Enum
 
 import thermocouples as tc
 
 from instro.daq.scaling.scaling import Scaler
 
 
-class TC_TYPE(enum.Enum):
+class TC_TYPE(Enum):
     B = "B"
     E = "E"
     J = "J"
@@ -16,6 +16,13 @@ class TC_TYPE(enum.Enum):
     R = "R"
     S = "S"
     T = "T"
+
+
+class TC_UNIT(Enum):
+    CELSIUS = "CELSIUS"
+    KELVIN = "KELVIN"
+    FAHRENHEIT = "FAHRENHEIT"
+    RANKINE = "RANKINE"
 
 
 class ThermocoupleSensor(Scaler):

--- a/instro/daq/types.py
+++ b/instro/daq/types.py
@@ -90,6 +90,7 @@ class AnalogCurrentChannel(DAQChannel):
 class AnalogThermocoupleChannel(DAQChannel):
     range_max: float
     range_min: float
+    scaler: Scaler | None
     tc_type: TC_TYPE
     cjc_source: CJCSource | None
     cjc_temp: float | None

--- a/instro/daq/types.py
+++ b/instro/daq/types.py
@@ -39,7 +39,7 @@ class TerminalConfig(Enum):
     RSE = "RSE"
 
 
-class CJC_SOURCE(Enum):
+class CJCSource(Enum):
     INTERNAL = "INTERNAL"
     CONSTANT = "CONSTANT"
     CHANNEL = "CHANNEL"
@@ -91,7 +91,7 @@ class AnalogThermocoupleChannel(DAQChannel):
     range_max: float
     range_min: float
     tc_type: TC_TYPE
-    cjc_source: CJC_SOURCE | None
+    cjc_source: CJCSource | None
     cjc_temp: float | None
     cjc_channel: str | None
     unit: TC_UNIT | None

--- a/instro/daq/types.py
+++ b/instro/daq/types.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from enum import Enum, IntEnum
 
 from instro.daq.scaling.scaling import Scaler
+from instro.daq.scaling.thermocouple import TC_TYPE, TC_UNIT
 
 
 class DAQVendor(Enum):
@@ -38,6 +39,12 @@ class TerminalConfig(Enum):
     RSE = "RSE"
 
 
+class CJC_SOURCE(Enum):
+    INTERNAL = "INTERNAL"
+    CONSTANT = "CONSTANT"
+    CHANNEL = "CHANNEL"
+
+
 @dataclass(frozen=True)
 class HWTimingConfig:
     sample_rate: float
@@ -53,12 +60,44 @@ class DAQChannel:
     direction: Direction
 
 
+# ========  Analog Channel Types  ===========
+
+
 @dataclass(frozen=True)
 class AnalogChannel(DAQChannel):
     range_max: float
     range_min: float
     scaler: Scaler | None
     terminal_config: TerminalConfig | None = None
+
+
+@dataclass(frozen=True)
+class AnalogVoltageChannel(DAQChannel):
+    range_max: float
+    range_min: float
+    scaler: Scaler | None
+    terminal_config: TerminalConfig | None = None
+
+
+@dataclass(frozen=True)
+class AnalogCurrentChannel(DAQChannel):
+    range_max: float
+    range_min: float
+    scaler: Scaler | None
+
+
+@dataclass(frozen=True)
+class AnalogThermocoupleChannel(DAQChannel):
+    range_max: float
+    range_min: float
+    tc_type: TC_TYPE
+    cjc_source: CJC_SOURCE | None
+    cjc_temp: float | None
+    cjc_channel: str | None
+    unit: TC_UNIT | None
+
+
+# ========  Digital Channel Types  ===========
 
 
 class DigitalPortWidth(IntEnum):

--- a/tests/daq/test_daq_drivers.py
+++ b/tests/daq/test_daq_drivers.py
@@ -420,6 +420,31 @@ def test_duplicate_channel_guard_is_global_across_configure_methods():
         daq.configure_current_input("ai1", alias="shared")
 
 
+def test_configure_while_running_raises():
+    """A new configure_* method refuses to configure a channel while acquisition is running (nothing recorded)."""
+    daq = InstroDAQ(name="ut", driver=_make_mock_driver())
+    daq.open()
+    daq.start(background=False)
+
+    with pytest.raises(RuntimeError, match=r"cannot configure channel 'v0' while 'ut' is running; call stop\(\)"):
+        daq.configure_voltage_input("ai0", alias="v0")
+    assert not daq.ai_channels
+
+    daq.stop()
+
+
+def test_configure_after_stop_succeeds():
+    """stop() clears the running guard so channels can be configured again."""
+    daq = InstroDAQ(name="ut", driver=_make_mock_driver())
+    daq.open()
+    daq.start(background=False)
+    daq.stop()
+
+    daq.configure_voltage_input("ai0", alias="v0")
+
+    assert "v0" in daq.ai_channels
+
+
 # ---------------------------------------------------------------------------
 # open() guard
 # ---------------------------------------------------------------------------

--- a/tests/daq/test_daq_drivers.py
+++ b/tests/daq/test_daq_drivers.py
@@ -7,6 +7,7 @@ import pytest
 
 from instro.daq import DAQDriverBase, InstroDAQ
 from instro.daq.drivers import HWTimestamper
+from instro.daq.scaling.thermocouple import TC_TYPE
 from instro.daq.types import (
     DigitalLineChannel,
     DigitalPortChannel,
@@ -65,6 +66,27 @@ class _RecordingDriver(DAQDriverBase):
 
     def configure_ao_channel(self, channel):
         self._ao_channels[channel.alias] = channel
+
+    def configure_ai_voltage_channel(self, channel):
+        self._ai_channels[channel.alias] = channel
+
+    def configure_ao_voltage_channel(self, channel):
+        self._ao_channels[channel.alias] = channel
+
+    def configure_ai_current_channel(self, channel):
+        self._ai_channels[channel.alias] = channel
+
+    def configure_ao_current_channel(self, channel):
+        self._ao_channels[channel.alias] = channel
+
+    def configure_ai_thermocouple_channel(self, channel):
+        self._ai_channels[channel.alias] = channel
+
+    def configure_di_channel(self, channel):
+        self._di_channels[channel.alias] = channel
+
+    def configure_do_channel(self, channel):
+        self._do_channels[channel.alias] = channel
 
     def configure_ai_hw_timing(self, hw_timing_config):
         self._ai_hw_timing_config = hw_timing_config
@@ -332,6 +354,59 @@ def test_read_digital_port_unconfigured_channel():
         daq.read_digital_port("unconfigured_port")
 
     mock_driver.read_digital_port.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# duplicate-channel guard (new configure_* surface)
+# ---------------------------------------------------------------------------
+
+
+_NEW_CONFIGURE_CALLS = [
+    ("configure_voltage_input", lambda daq, alias: daq.configure_voltage_input("ai0", alias=alias)),
+    ("configure_voltage_output", lambda daq, alias: daq.configure_voltage_output("ao0", alias=alias)),
+    ("configure_current_input", lambda daq, alias: daq.configure_current_input("ai1", alias=alias)),
+    ("configure_current_output", lambda daq, alias: daq.configure_current_output("ao1", alias=alias)),
+    (
+        "configure_thermocouple_input",
+        lambda daq, alias: daq.configure_thermocouple_input("ai2", TC_TYPE.K, alias=alias),
+    ),
+    ("configure_digital_input", lambda daq, alias: daq.configure_digital_input("port0/line0", alias=alias)),
+    ("configure_digital_output", lambda daq, alias: daq.configure_digital_output("port0/line1", alias=alias)),
+]
+
+
+@pytest.mark.parametrize("name,call", _NEW_CONFIGURE_CALLS, ids=[name for name, _ in _NEW_CONFIGURE_CALLS])
+def test_configure_same_alias_twice_raises(name, call):
+    """Every new configure_* method rejects reconfiguring an already-configured alias."""
+    daq = InstroDAQ(name="ut", driver=_make_mock_driver())
+    daq.open()
+
+    call(daq, "dup")
+    with pytest.raises(ValueError, match="channel 'dup' is already configured"):
+        call(daq, "dup")
+
+
+def test_duplicate_channel_error_names_existing_kind_and_physical_channel():
+    """The duplicate error reports the existing channel's kind and physical channel."""
+    daq = InstroDAQ(name="ut", driver=_make_mock_driver())
+    daq.open()
+    daq.configure_voltage_input("cDAQ1Mod1/ai0", alias="v_in")
+
+    with pytest.raises(
+        ValueError,
+        match=r"channel 'v_in' is already configured \(voltage_input on cDAQ1Mod1/ai0\); remove it before reconfiguring.",
+    ):
+        daq.configure_voltage_input("cDAQ1Mod1/ai1", alias="v_in")
+
+
+def test_duplicate_channel_guard_is_global_across_configure_methods():
+    """An alias is unique across the whole driver: a different configure_* method can't reuse it."""
+    daq = InstroDAQ(name="ut", driver=_make_mock_driver())
+    daq.open()
+    daq.configure_voltage_input("ai0", alias="shared")
+
+    with pytest.raises(ValueError, match=r"channel 'shared' is already configured \(voltage_input on ai0\)"):
+        daq.configure_current_input("ai1", alias="shared")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/daq/test_daq_drivers.py
+++ b/tests/daq/test_daq_drivers.py
@@ -7,7 +7,6 @@ import pytest
 
 from instro.daq import DAQDriverBase, InstroDAQ
 from instro.daq.drivers import HWTimestamper
-from instro.daq.scaling.thermocouple import TC_TYPE
 from instro.daq.types import (
     DigitalLineChannel,
     DigitalPortChannel,
@@ -361,17 +360,29 @@ def test_read_digital_port_unconfigured_channel():
 # ---------------------------------------------------------------------------
 
 
+# Enum args are passed as plain strings so these also confirm the new methods accept string enum values.
 _NEW_CONFIGURE_CALLS = [
-    ("configure_voltage_input", lambda daq, alias: daq.configure_voltage_input("ai0", alias=alias)),
+    (
+        "configure_voltage_input",
+        lambda daq, alias: daq.configure_voltage_input("ai0", alias=alias, terminal_config="RSE"),
+    ),
     ("configure_voltage_output", lambda daq, alias: daq.configure_voltage_output("ao0", alias=alias)),
     ("configure_current_input", lambda daq, alias: daq.configure_current_input("ai1", alias=alias)),
     ("configure_current_output", lambda daq, alias: daq.configure_current_output("ao1", alias=alias)),
     (
         "configure_thermocouple_input",
-        lambda daq, alias: daq.configure_thermocouple_input("ai2", TC_TYPE.K, alias=alias),
+        lambda daq, alias: daq.configure_thermocouple_input(
+            "ai2", "K", alias=alias, cjc_source="INTERNAL", unit="CELSIUS"
+        ),
     ),
-    ("configure_digital_input", lambda daq, alias: daq.configure_digital_input("port0/line0", alias=alias)),
-    ("configure_digital_output", lambda daq, alias: daq.configure_digital_output("port0/line1", alias=alias)),
+    (
+        "configure_digital_input",
+        lambda daq, alias: daq.configure_digital_input("port0/line0", alias=alias, logic="HIGH"),
+    ),
+    (
+        "configure_digital_output",
+        lambda daq, alias: daq.configure_digital_output("port0/line1", alias=alias, logic="LOW"),
+    ),
 ]
 
 


### PR DESCRIPTION
## Summary

This PR adds explicit input and output methods for typed analog channels and digital channels to `InstroDAQ` and the corresponding `configure_*` methods to `DAQDriverBase`. These changes are purely additive and surface level meaning there is no functionality hooked up to them yet. Docs document the methods but call out that they have not been hooked up to any of our packaged drivers yet.

This also adds verification at the `InstroDAQ` level so we fail fast and with clear error messages.

Closes INSTRO-500

## Type of change

- [ ] Bug fix (`fix`)
- [ ] New feature (`feat`)
- [ ] Breaking change (`feat!` / `fix!`)
- [x] Refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] Chore / tooling (`chore`)

## Verification

<img width="1284" height="132" alt="ver 500" src="https://github.com/user-attachments/assets/2f9eaa6b-9118-4f7f-b046-feaf2ed01e05" />

## Tests

- [x] Unit tests added or updated
- [ ] Existing tests cover this change
- [ ] No tests — explain why:

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(driver): add support for Keysight E36300`)
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] Documentation updated if user-facing behavior changed
- [x] Code follows the style/conventions of the surrounding code