### PR TITLE
feat(psu): add get_voltage_setpoint() and get_current_setpoint() to PSUDriverBase

### DIFF
--- a/docs/guides/instrumentation/psu.mdx
+++ b/docs/guides/instrumentation/psu.mdx
@@ -226,6 +226,8 @@ Every measurement/command call produces a channel keyed under `{name}.{descripto
 | `get_current(channel=N)` | `ch{N}.current` | telemetry |
 | `output_enable(channel=N)` | `ch{N}.enabled.cmd` | command |
 | `get_output_status(channel=N)` | `ch{N}.enabled` | telemetry |
+| `get_voltage_setpoint(channel=N)` | `ch{N}.voltage.setpoint` | telemetry |
+| `get_current_limit(channel=N)` | `ch{N}.current.limit` | telemetry |
 | `set_overvoltage_protection_level(channel=N)` | `ch{N}.ovp.cmd` | command |
 | `get_overvoltage_protection_level(channel=N)` | `ch{N}.ovp` | telemetry |
 | `set_overvoltage_protection_enabled(channel=N)` | `ch{N}.ovp.enabled.cmd` | command |
@@ -252,6 +254,8 @@ Every measurement/command call produces a channel keyed under `{name}.{descripto
 | `get_current(channel=N)` | Read measured output current in amperes |
 | `output_enable(enable, channel=N)` | Enable (True) or disable (False) the output |
 | `get_output_status(channel=N)` | Query output enable state (returns Measurement with bool value) |
+| `get_voltage_setpoint(channel=N)` | Read the configured voltage setpoint in volts (not the measured output) |
+| `get_current_limit(channel=N)` | Read the configured current limit in amperes (not the measured output) |
 | `set_overvoltage_protection_level(voltage, channel=N)` | Set the overvoltage protection threshold in volts |
 | `get_overvoltage_protection_level(channel=N)` | Read the overvoltage protection threshold in volts |
 | `set_overvoltage_protection_enabled(enabled, channel=N)` | Enable or disable overvoltage protection |
@@ -329,6 +333,12 @@ def output_enable(self, enable: bool, channel: int) -> None:
 
 def get_output_status(self, channel: int) -> bool:
     """Query and return the output enable status on `channel`."""
+
+def get_voltage_setpoint(self, channel: int) -> float:
+    """Query and return the configured voltage setpoint in volts (not the measured output)."""
+
+def get_current_limit(self, channel: int) -> float:
+    """Query and return the configured current limit in amperes (not the measured output)."""
 
 def set_overvoltage_protection_level(self, voltage: float, channel: int) -> None:
     """Set the overvoltage protection threshold (volts) on `channel`."""

--- a/docs/guides/instrumentation/psu.mdx
+++ b/docs/guides/instrumentation/psu.mdx
@@ -227,7 +227,7 @@ Every measurement/command call produces a channel keyed under `{name}.{descripto
 | `output_enable(channel=N)` | `ch{N}.enabled.cmd` | command |
 | `get_output_status(channel=N)` | `ch{N}.enabled` | telemetry |
 | `get_voltage_setpoint(channel=N)` | `ch{N}.voltage.setpoint` | telemetry |
-| `get_current_limit(channel=N)` | `ch{N}.current.limit` | telemetry |
+| `get_current_setpoint(channel=N)` | `ch{N}.current.setpoint` | telemetry |
 | `set_overvoltage_protection_level(channel=N)` | `ch{N}.ovp.cmd` | command |
 | `get_overvoltage_protection_level(channel=N)` | `ch{N}.ovp` | telemetry |
 | `set_overvoltage_protection_enabled(channel=N)` | `ch{N}.ovp.enabled.cmd` | command |
@@ -255,7 +255,7 @@ Every measurement/command call produces a channel keyed under `{name}.{descripto
 | `output_enable(enable, channel=N)` | Enable (True) or disable (False) the output |
 | `get_output_status(channel=N)` | Query output enable state (returns Measurement with bool value) |
 | `get_voltage_setpoint(channel=N)` | Read the configured voltage setpoint in volts (not the measured output) |
-| `get_current_limit(channel=N)` | Read the configured current limit in amperes (not the measured output) |
+| `get_current_setpoint(channel=N)` | Read the configured current-limit setpoint in amperes (not the measured output) |
 | `set_overvoltage_protection_level(voltage, channel=N)` | Set the overvoltage protection threshold in volts |
 | `get_overvoltage_protection_level(channel=N)` | Read the overvoltage protection threshold in volts |
 | `set_overvoltage_protection_enabled(enabled, channel=N)` | Enable or disable overvoltage protection |
@@ -337,8 +337,8 @@ def get_output_status(self, channel: int) -> bool:
 def get_voltage_setpoint(self, channel: int) -> float:
     """Query and return the configured voltage setpoint in volts (not the measured output)."""
 
-def get_current_limit(self, channel: int) -> float:
-    """Query and return the configured current limit in amperes (not the measured output)."""
+def get_current_setpoint(self, channel: int) -> float:
+    """Query and return the configured current-limit setpoint in amperes (not the measured output)."""
 
 def set_overvoltage_protection_level(self, voltage: float, channel: int) -> None:
     """Set the overvoltage protection threshold (volts) on `channel`."""

--- a/instro/psu/psu.py
+++ b/instro/psu/psu.py
@@ -58,6 +58,14 @@ class PSUDriverBase(abc.ABC):
         """Query whether the output on `channel` is enabled."""
         raise NotImplementedError(f"get_output_status is not implemented for {type(self).__name__}")
 
+    def get_voltage_setpoint(self, channel: int) -> float:
+        """Query the configured voltage setpoint (volts) on `channel`."""
+        raise NotImplementedError(f"get_voltage_setpoint is not implemented for {type(self).__name__}")
+
+    def get_current_limit(self, channel: int) -> float:
+        """Query the configured current limit (amperes) on `channel`."""
+        raise NotImplementedError(f"get_current_limit is not implemented for {type(self).__name__}")
+
     def set_overvoltage_protection_level(self, voltage: float, channel: int) -> None:
         """Set the overvoltage protection threshold (volts) on `channel`."""
         raise NotImplementedError(f"set_overvoltage_protection_level is not implemented for {type(self).__name__}")
@@ -250,6 +258,26 @@ class InstroPSU(Instrument):
             channel=channel,
             channel_suffix="enabled",
             legacy_suffix="en",
+            **kwargs,
+        )
+
+    def get_voltage_setpoint(self, channel: int, **kwargs) -> Measurement | None:
+        """Query the configured voltage setpoint (volts) on ``channel``. Returns ``None`` if unavailable."""
+        return self._execute_measurement(
+            self._driver.get_voltage_setpoint,
+            channel=channel,
+            channel_suffix="voltage.setpoint",
+            legacy_suffix="v_set",
+            **kwargs,
+        )
+
+    def get_current_limit(self, channel: int, **kwargs) -> Measurement | None:
+        """Query the configured current limit (amperes) on ``channel``. Returns ``None`` if unavailable."""
+        return self._execute_measurement(
+            self._driver.get_current_limit,
+            channel=channel,
+            channel_suffix="current.limit",
+            legacy_suffix="i_lim",
             **kwargs,
         )
 

--- a/instro/psu/psu.py
+++ b/instro/psu/psu.py
@@ -62,9 +62,9 @@ class PSUDriverBase(abc.ABC):
         """Query the configured voltage setpoint (volts) on `channel`."""
         raise NotImplementedError(f"get_voltage_setpoint is not implemented for {type(self).__name__}")
 
-    def get_current_limit(self, channel: int) -> float:
-        """Query the configured current limit (amperes) on `channel`."""
-        raise NotImplementedError(f"get_current_limit is not implemented for {type(self).__name__}")
+    def get_current_setpoint(self, channel: int) -> float:
+        """Query the configured current-limit setpoint (amperes) on `channel`."""
+        raise NotImplementedError(f"get_current_setpoint is not implemented for {type(self).__name__}")
 
     def set_overvoltage_protection_level(self, voltage: float, channel: int) -> None:
         """Set the overvoltage protection threshold (volts) on `channel`."""
@@ -271,13 +271,13 @@ class InstroPSU(Instrument):
             **kwargs,
         )
 
-    def get_current_limit(self, channel: int, **kwargs) -> Measurement | None:
-        """Query the configured current limit (amperes) on ``channel``. Returns ``None`` if unavailable."""
+    def get_current_setpoint(self, channel: int, **kwargs) -> Measurement | None:
+        """Query the configured current-limit setpoint (amperes) on ``channel``. Returns ``None`` if unavailable."""
         return self._execute_measurement(
-            self._driver.get_current_limit,
+            self._driver.get_current_setpoint,
             channel=channel,
-            channel_suffix="current.limit",
-            legacy_suffix="i_lim",
+            channel_suffix="current.setpoint",
+            legacy_suffix="i_set",
             **kwargs,
         )
 

--- a/tests/psu/test_psu_drivers.py
+++ b/tests/psu/test_psu_drivers.py
@@ -43,6 +43,22 @@ def base_only_psu_driver() -> _BaseOnlyPSUDriver:
 @pytest.mark.parametrize(
     ("method_name", "args"),
     [
+        ("get_voltage_setpoint", ()),
+        ("get_current_limit", ()),
+    ],
+)
+def test_psu_driver_base_setpoint_getters_raise_not_implemented(
+    base_only_psu_driver: _BaseOnlyPSUDriver,
+    method_name: str,
+    args: tuple[object, ...],
+) -> None:
+    with pytest.raises(NotImplementedError, match=f"{method_name} is not implemented for _BaseOnlyPSUDriver"):
+        getattr(base_only_psu_driver, method_name)(*args, channel=1)
+
+
+@pytest.mark.parametrize(
+    ("method_name", "args"),
+    [
         ("set_overvoltage_protection_level", (12.0,)),
         ("get_overvoltage_protection_level", ()),
         ("set_overvoltage_protection_enabled", (True,)),
@@ -102,6 +118,8 @@ def _stub_driver() -> MagicMock:
     driver.get_voltage.return_value = 12.0
     driver.get_current.return_value = 0.5
     driver.get_output_status.return_value = True
+    driver.get_voltage_setpoint.return_value = 5.0
+    driver.get_current_limit.return_value = 1.5
     driver.get_overvoltage_protection_level.return_value = 15.0
     driver.get_overvoltage_protection_enabled.return_value = True
     driver.get_overvoltage_protection_delay.return_value = 0.25
@@ -168,6 +186,24 @@ def test_nominal_psu_output_enable_delegates() -> None:
     psu = InstroPSU(name="ut", driver=driver, num_channels=1)
     psu.output_enable(True, channel=1)
     driver.output_enable.assert_called_once_with(True, channel=1)
+
+
+def test_nominal_psu_get_voltage_setpoint_returns_measurement() -> None:
+    driver = _stub_driver()
+    psu = InstroPSU(name="ut", driver=driver, num_channels=1)
+    measurement = psu.get_voltage_setpoint(channel=1)
+    driver.get_voltage_setpoint.assert_called_once_with(channel=1)
+    assert measurement is not None
+    assert measurement.channel_data["ut.ch1.voltage.setpoint"] == [5.0]
+
+
+def test_nominal_psu_get_current_limit_returns_measurement() -> None:
+    driver = _stub_driver()
+    psu = InstroPSU(name="ut", driver=driver, num_channels=1)
+    measurement = psu.get_current_limit(channel=1)
+    driver.get_current_limit.assert_called_once_with(channel=1)
+    assert measurement is not None
+    assert measurement.channel_data["ut.ch1.current.limit"] == [1.5]
 
 
 def test_nominal_psu_set_current_limit_delegates() -> None:

--- a/tests/psu/test_psu_drivers.py
+++ b/tests/psu/test_psu_drivers.py
@@ -44,7 +44,7 @@ def base_only_psu_driver() -> _BaseOnlyPSUDriver:
     ("method_name", "args"),
     [
         ("get_voltage_setpoint", ()),
-        ("get_current_limit", ()),
+        ("get_current_setpoint", ()),
     ],
 )
 def test_psu_driver_base_setpoint_getters_raise_not_implemented(
@@ -119,7 +119,7 @@ def _stub_driver() -> MagicMock:
     driver.get_current.return_value = 0.5
     driver.get_output_status.return_value = True
     driver.get_voltage_setpoint.return_value = 5.0
-    driver.get_current_limit.return_value = 1.5
+    driver.get_current_setpoint.return_value = 1.5
     driver.get_overvoltage_protection_level.return_value = 15.0
     driver.get_overvoltage_protection_enabled.return_value = True
     driver.get_overvoltage_protection_delay.return_value = 0.25
@@ -197,13 +197,13 @@ def test_nominal_psu_get_voltage_setpoint_returns_measurement() -> None:
     assert measurement.channel_data["ut.ch1.voltage.setpoint"] == [5.0]
 
 
-def test_nominal_psu_get_current_limit_returns_measurement() -> None:
+def test_nominal_psu_get_current_setpoint_returns_measurement() -> None:
     driver = _stub_driver()
     psu = InstroPSU(name="ut", driver=driver, num_channels=1)
-    measurement = psu.get_current_limit(channel=1)
-    driver.get_current_limit.assert_called_once_with(channel=1)
+    measurement = psu.get_current_setpoint(channel=1)
+    driver.get_current_setpoint.assert_called_once_with(channel=1)
     assert measurement is not None
-    assert measurement.channel_data["ut.ch1.current.limit"] == [1.5]
+    assert measurement.channel_data["ut.ch1.current.setpoint"] == [1.5]
 
 
 def test_nominal_psu_set_current_limit_delegates() -> None:


### PR DESCRIPTION
## Summary
- Adds two new optional `PSUDriverBase` methods, `get_voltage_setpoint()` and `get_current_setpoint()`, plus matching `InstroPSU` wrapper methods — same pattern as the existing OVP/OCP getters (default `NotImplementedError`; drivers opt in).
- These read back the *configured* voltage setpoint and current setpoint (typically a plain `VOLT?`/`CURR?` SCPI query), distinct from `get_voltage()`/`get_current()` which measure actual output (`MEAS:VOLT?`/`MEAS:CURR?`).
- No concrete driver implements them yet — each vendor driver needs its own override before this is usable against real hardware. Verified the general pattern against BK914X's existing `get_overcurrent_protection_level` shape but didn't have hardware on hand to validate a concrete implementation.

## Test plan
- [x] `just check` (format, mypy, lint) passes
- [x] `tests/psu/test_psu_drivers.py` — new parametrized `NotImplementedError` tests for both methods, plus `InstroPSU`-level delegation tests (33/33 passing)
- [x] Full `tests/psu/` suite passes (492 tests)
- [x] Docs updated: Published channels table, Method Reference table, and the `PSUDriverBase` interface listing in `docs/guides/instrumentation/psu.mdx`
- [ ] Hardware validation against a concrete driver implementation — deferred until hardware is available

🤖 Generated with [Claude Code](https://claude.com/claude-code)