### PR TITLE
feat(psu): implement get_voltage_setpoint()/get_current_setpoint() for RigolDP800

### DIFF
--- a/instro/psu/drivers/rigol_dp800.py
+++ b/instro/psu/drivers/rigol_dp800.py
@@ -61,6 +61,12 @@ class RigolDP800(PSUDriverBase):
     def get_output_status(self, channel: int) -> bool:
         return self._query_checked_bool(f":OUTP? CH{channel}")
 
+    def get_voltage_setpoint(self, channel: int) -> float:
+        return self._query_checked_float(f":SOUR{channel}:VOLT?")
+
+    def get_current_setpoint(self, channel: int) -> float:
+        return self._query_checked_float(f":SOUR{channel}:CURR?")
+
     def set_overvoltage_protection_level(self, voltage: float, channel: int) -> None:
         if (limits := self._limits.get(channel)) is not None:
             self._validate_in_range(voltage, limits.ovp, channel, "overvoltage protection level")

--- a/tests/psu/rigol/test_rigol_dp800_hardware.py
+++ b/tests/psu/rigol/test_rigol_dp800_hardware.py
@@ -338,6 +338,24 @@ def test_get_current(driver: RigolDP800, channel_config: ChannelConfig) -> None:
 
 
 @pytest.mark.parametrize("channel_config", CHANNELS, ids=lambda config: f"channel_{config.channel}")
+def test_get_voltage_setpoint(driver: RigolDP800, channel_config: ChannelConfig) -> None:
+    driver.set_voltage(channel_config.programmed_voltage, channel=channel_config.channel)
+
+    setpoint = driver.get_voltage_setpoint(channel=channel_config.channel)
+    _stream(f"ch{channel_config.channel}.voltage_setpoint_v", setpoint)
+    assert setpoint == pytest.approx(channel_config.programmed_voltage)
+
+
+@pytest.mark.parametrize("channel_config", CHANNELS, ids=lambda config: f"channel_{config.channel}")
+def test_get_current_setpoint(driver: RigolDP800, channel_config: ChannelConfig) -> None:
+    driver.set_current_limit(channel_config.programmed_current_limit, channel=channel_config.channel)
+
+    setpoint = driver.get_current_setpoint(channel=channel_config.channel)
+    _stream(f"ch{channel_config.channel}.current_setpoint_a", setpoint)
+    assert setpoint == pytest.approx(channel_config.programmed_current_limit)
+
+
+@pytest.mark.parametrize("channel_config", CHANNELS, ids=lambda config: f"channel_{config.channel}")
 def test_output_enable(driver: RigolDP800, channel_config: ChannelConfig) -> None:
     driver.set_current_limit(channel_config.programmed_current_limit, channel=channel_config.channel)
     driver.set_voltage(channel_config.programmed_voltage, channel=channel_config.channel)

--- a/tests/psu/rigol/test_rigol_dp800_software.py
+++ b/tests/psu/rigol/test_rigol_dp800_software.py
@@ -136,6 +136,20 @@ def test_rigol_get_current_uses_meas_command(rigol: RigolDP800, rigol_visa: Magi
     assert rigol_visa.query.call_args_list == [call(":MEAS:CURR? CH1"), call(":SYST:ERR?")]
 
 
+def test_rigol_get_voltage_setpoint_uses_sour_query(rigol: RigolDP800, rigol_visa: MagicMock) -> None:
+    rigol_visa.query.side_effect = ["12.000", '0,"No error"']
+
+    assert rigol.get_voltage_setpoint(channel=3) == pytest.approx(12.0)
+    assert rigol_visa.query.call_args_list == [call(":SOUR3:VOLT?"), call(":SYST:ERR?")]
+
+
+def test_rigol_get_current_setpoint_uses_sour_query(rigol: RigolDP800, rigol_visa: MagicMock) -> None:
+    rigol_visa.query.side_effect = ["0.500", '0,"No error"']
+
+    assert rigol.get_current_setpoint(channel=2) == pytest.approx(0.5)
+    assert rigol_visa.query.call_args_list == [call(":SOUR2:CURR?"), call(":SYST:ERR?")]
+
+
 def test_rigol_output_enable_formats_per_channel(rigol: RigolDP800, rigol_visa: MagicMock) -> None:
     rigol.output_enable(True, channel=1)
     rigol.output_enable(False, channel=2)


### PR DESCRIPTION
## Summary
- Implements the two optional `PSUDriverBase` setpoint getters (added in #308) for `RigolDP800`: reads back the programmed voltage setpoint and current setpoint via plain `:SOUR<n>:VOLT?`/`:SOUR<n>:CURR?` queries, distinct from `get_voltage()`/`get_current()`'s `:MEAS:...?` measured-output queries.
- `_load_limits()` already used these same SCPI commands (with MIN/MAX suffixes) for range validation, confirming they're valid on this instrument family.
- **Tested against a real Rigol DP832A**: full hardware suite passed 63/63 (6 new + 57 pre-existing, no regressions). Also spot-checked outside the test harness (CH1 readback: voltage setpoint 10.0 V, current setpoint 1.0 A, matching what was programmed on the unit).

## Test plan
- [x] `just check` passes
- [x] Mocked software tests (`tests/psu/rigol/test_rigol_dp800_software.py`) — new tests for both methods, full suite passing
- [x] Hardware validation against a real DP832A (`tests/psu/rigol/test_rigol_dp800_hardware.py`) — 63/63 passed, marked `@pytest.mark.hardware` so it's deselected in CI by design