### PR TITLE
feat(cli): add scopes to idn map

### DIFF
--- a/instro/cli/discover.py
+++ b/instro/cli/discover.py
@@ -48,22 +48,6 @@ _IDN_MAP = {
 }
 
 
-# _IDN_MAP: dict[tuple[str, str], tuple[str, str, str | None, int | None]] = {
-#     ("AGILENT TECHNOLOGIES", "34401A"): ("dmm", "Agilent34401A", None, None),
-#     ("HEWLETT-PACKARD", "34401A"): ("dmm", "Agilent34401A", None, None),
-#     ("KEITHLEY INSTRUMENTS", "2400"): ("dmm", "Keithley2400", None, None),
-#     ("B&K PRECISION", "9115"): ("psu", "BK9115", "bk_9115", 1),
-#     ("B&K PRECISION", "9140"): ("psu", "BK914X", "bk_914x", 3),
-#     ("RIGOL TECHNOLOGIES", "DP811"): ("psu", "RigolDP800", "rigol_dp800", 1),
-#     ("RIGOL TECHNOLOGIES", "DP821"): ("psu", "RigolDP800", "rigol_dp800", 2),
-#     ("RIGOL TECHNOLOGIES", "DP831"): ("psu", "RigolDP800", "rigol_dp800", 3),
-#     ("RIGOL TECHNOLOGIES", "DP832"): ("psu", "RigolDP800", "rigol_dp800", 3),
-#     ("SIGLENT TECHNOLOGIES", "SPD3303"): ("psu", "SiglentSPD3303", "siglent_spd3303", 3),
-#     ("GENESYS", "GEN"): ("psu", "TDKLambdaGenesys", "tdk_lambda_genesys", 1),
-#     ("B&K PRECISION", "BK85"): ("eload", "BK85XXB", None, None),
-# }
-
-
 def _degraded_interfaces(rm: pyvisa.ResourceManager) -> list[tuple[str, str]]:
     """Return (interface family, reason) for pyvisa-py interfaces that are not Available."""
     get_debug_info = getattr(rm.visalib, "get_debug_info", None)

--- a/instro/cli/discover.py
+++ b/instro/cli/discover.py
@@ -38,6 +38,13 @@ _IDN_MAP = {
     ("RIGOL TECHNOLOGIES", "DP832"): ("psu", "RigolDP800"),
     ("SIGLENT TECHNOLOGIES", "SPD3303"): ("psu", "SiglentSPD3303"),
     ("B&K PRECISION", "BK85"): ("eload", "BK85XXB"),
+    ("KEYSIGHT TECHNOLOGIES", "DSOX120"): ("scope", "Keysight1200X"),
+    ("KEYSIGHT TECHNOLOGIES", "EDUX105"): ("scope", "Keysight1200X"),
+    ("TEKTRONIX", "MSO22"): ("scope", "Tektronix2SeriesMSO"),
+    ("TEKTRONIX", "MSO24"): ("scope", "Tektronix2SeriesMSO"),
+    ("SIGLENT TECHNOLOGIES", "SDS1104X-E"): ("scope", "SiglentSDS1000XE"),
+    ("SIGLENT TECHNOLOGIES", "SDS1202X-E"): ("scope", "SiglentSDS1000XE"),
+    ("SIGLENT TECHNOLOGIES", "SDS1204X-E"): ("scope", "SiglentSDS1000XE"),
 }
 
 

--- a/instro/cli/discover.py
+++ b/instro/cli/discover.py
@@ -48,6 +48,22 @@ _IDN_MAP = {
 }
 
 
+# _IDN_MAP: dict[tuple[str, str], tuple[str, str, str | None, int | None]] = {
+#     ("AGILENT TECHNOLOGIES", "34401A"): ("dmm", "Agilent34401A", None, None),
+#     ("HEWLETT-PACKARD", "34401A"): ("dmm", "Agilent34401A", None, None),
+#     ("KEITHLEY INSTRUMENTS", "2400"): ("dmm", "Keithley2400", None, None),
+#     ("B&K PRECISION", "9115"): ("psu", "BK9115", "bk_9115", 1),
+#     ("B&K PRECISION", "9140"): ("psu", "BK914X", "bk_914x", 3),
+#     ("RIGOL TECHNOLOGIES", "DP811"): ("psu", "RigolDP800", "rigol_dp800", 1),
+#     ("RIGOL TECHNOLOGIES", "DP821"): ("psu", "RigolDP800", "rigol_dp800", 2),
+#     ("RIGOL TECHNOLOGIES", "DP831"): ("psu", "RigolDP800", "rigol_dp800", 3),
+#     ("RIGOL TECHNOLOGIES", "DP832"): ("psu", "RigolDP800", "rigol_dp800", 3),
+#     ("SIGLENT TECHNOLOGIES", "SPD3303"): ("psu", "SiglentSPD3303", "siglent_spd3303", 3),
+#     ("GENESYS", "GEN"): ("psu", "TDKLambdaGenesys", "tdk_lambda_genesys", 1),
+#     ("B&K PRECISION", "BK85"): ("eload", "BK85XXB", None, None),
+# }
+
+
 def _degraded_interfaces(rm: pyvisa.ResourceManager) -> list[tuple[str, str]]:
     """Return (interface family, reason) for pyvisa-py interfaces that are not Available."""
     get_debug_info = getattr(rm.visalib, "get_debug_info", None)

--- a/tests/cli/test_discover.py
+++ b/tests/cli/test_discover.py
@@ -118,17 +118,25 @@ def test_discover_mixed_bench():
     assert "UNRECOGNIZED" in result.output
 
 
-def test_discover_recognizes_scope():
-    mock_rm = _rm_mock(("USB0::0xF4EC::0xEE38::INSTR",))
+@pytest.mark.parametrize(
+    "idn,driver_class",
+    [
+        ("Keysight Technologies,EDUX1052A,SN,1.0", "Keysight1200X"),
+        ("TEKTRONIX,MSO24,C012345,CF:91.1CT FV:1.20", "Tektronix2SeriesMSO"),
+        ("Siglent Technologies,SDS1104X-E,SN,1.0", "SiglentSDS1000XE"),
+    ],
+)
+def test_discover_recognizes_scope(idn, driver_class):
+    mock_rm = _rm_mock(("USB0::0x0957::0x1755::INSTR",))
     with patch("instro.cli.discover.pyvisa.ResourceManager", side_effect=[mock_rm, Exception(), mock_rm]):
         with patch("instro.cli.discover.list_ports") as mock_lp:
             with patch("instro.cli.discover.VisaDriver") as mock_driver_cls:
                 mock_lp.comports.return_value = []
-                mock_driver_cls.return_value.query.return_value = "Siglent Technologies,SDS1104X-E,SN,1.0"
+                mock_driver_cls.return_value.query.return_value = idn
                 result = runner.invoke(app, ["discover"])
     assert result.exit_code == 0
     assert "RECOGNIZED" in result.output
-    assert "SiglentSDS1000XE" in result.output
+    assert driver_class in result.output
     assert "scope" in result.output
 
 

--- a/tests/cli/test_discover.py
+++ b/tests/cli/test_discover.py
@@ -118,6 +118,20 @@ def test_discover_mixed_bench():
     assert "UNRECOGNIZED" in result.output
 
 
+def test_discover_recognizes_scope():
+    mock_rm = _rm_mock(("USB0::0xF4EC::0xEE38::INSTR",))
+    with patch("instro.cli.discover.pyvisa.ResourceManager", side_effect=[mock_rm, Exception(), mock_rm]):
+        with patch("instro.cli.discover.list_ports") as mock_lp:
+            with patch("instro.cli.discover.VisaDriver") as mock_driver_cls:
+                mock_lp.comports.return_value = []
+                mock_driver_cls.return_value.query.return_value = "Siglent Technologies,SDS1104X-E,SN,1.0"
+                result = runner.invoke(app, ["discover"])
+    assert result.exit_code == 0
+    assert "RECOGNIZED" in result.output
+    assert "SiglentSDS1000XE" in result.output
+    assert "scope" in result.output
+
+
 def test_discover_failed_probe():
     mock_rm = _rm_mock(("USB0::0x1234::INSTR",))
     with patch("instro.cli.discover.pyvisa.ResourceManager", side_effect=[mock_rm, Exception(), mock_rm]):


### PR DESCRIPTION
## Summary

Updating the IDN map in discover.py to include the newly added oscilloscopes in instro.

## Type of change

- [ ] Bug fix (`fix`)
- [x] New feature (`feat`)
- [ ] Breaking change (`feat!` / `fix!`)
- [ ] Refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] Chore / tooling (`chore`)

## Verification
<img width="1245" height="203" alt="Recognize SiglentSDS1000X_E" src="https://github.com/user-attachments/assets/21794259-06ee-41c0-9533-8df8d9e05dc6" />

<img width="1243" height="205" alt="Recognize Tektronix2Series" src="https://github.com/user-attachments/assets/952cd891-eb3b-4d42-b739-ec0d25b99073" />

<img width="1549" height="506" alt="Screenshot 2026-07-31 at 9 39 15 AM" src="https://github.com/user-attachments/assets/ff72f3a1-ea5c-4221-bd95-5daceb184535" />

## Tests

- [x] Unit tests added or updated
- [ ] Existing tests cover this change
- [ ] No tests — explain why: 

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(driver): add support for Keysight E36300`)
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] Documentation updated if user-facing behavior changed
- [x] Code follows the style/conventions of the surrounding code