### PR TITLE
chore(instrument): log warning when background daemon cant run at requested rate

### DIFF
--- a/instro/lib/instrument.py
+++ b/instro/lib/instrument.py
@@ -100,7 +100,7 @@ class Instrument:
         self._background_stop_event = threading.Event()
         self._background_methods: list[tuple[Callable, tuple, dict]] = []
         # Used to determine whether requested interval is achievable or not
-        self._daemon_loop_times: deque[float] = deque(maxlen=10)
+        self._daemon_work_times: deque[float] = deque(maxlen=10)
         self._interval_warning_issued = False
 
         self._channel_buffer_length: int = 10
@@ -242,7 +242,7 @@ class Instrument:
 
     def _reset_daemon_timing(self):
         """Drop the timing window and re-arm the warning so cycles are judged against the current interval."""
-        self._daemon_loop_times.clear()
+        self._daemon_work_times.clear()
         self._interval_warning_issued = False
 
     def add_background_daemon_function(self, method: Callable, *args, **kwargs):
@@ -372,32 +372,36 @@ class Instrument:
             daemon_work_stop = time.time_ns()
 
             daemon_work_time_s = (daemon_work_stop - daemon_loop_start) * 1e-9
+            self._check_achievable_interval(daemon_work_time_s)
             self._background_stop_event.wait(max(0, self._background_config.interval - daemon_work_time_s))
 
             daemon_loop_stop = time.time_ns()
             daemon_loop_time_s = (daemon_loop_stop - daemon_loop_start) * 1e-9
-            self._check_achievable_interval(daemon_loop_time_s)
             self._publish_daemon_timing(daemon_loop_time_s, daemon_work_time_s, daemon_loop_stop)
 
-    def _check_achievable_interval(self, loop_time_s: float):
-        """Warn once if the averaged loop time shows the requested interval isn't being achieved."""
-        self._daemon_loop_times.append(loop_time_s)
-        if self._interval_warning_issued or len(self._daemon_loop_times) != self._daemon_loop_times.maxlen:
+    def _check_achievable_interval(self, work_time_s: float):
+        """Warn once if the averaged work time shows the requested interval isn't achievable.
+
+        This doesn't give timing guarantees about the background daemon rate,
+        just warn when work_time > requested interval.
+        """
+        self._daemon_work_times.append(work_time_s)
+        if self._interval_warning_issued or len(self._daemon_work_times) != self._daemon_work_times.maxlen:
             return
 
-        average_loop_time_s = sum(self._daemon_loop_times) / len(self._daemon_loop_times)
-        if average_loop_time_s <= self._background_config.interval:
+        average_work_time_s = sum(self._daemon_work_times) / len(self._daemon_work_times)
+        if average_work_time_s <= self._background_config.interval:
             return
 
-        self._interval_warning_issued = True
         logger.warning(
             "Background daemon for instrument '%s' cannot achieve the requested interval of %.6f s; "
-            "average loop time over %d cycles is %.6f s, which is the fastest achievable interval.",
+            "average work time over %d cycles is %.6f s, which is the fastest achievable interval.",
             self.name,
             self._background_config.interval,
-            len(self._daemon_loop_times),
-            average_loop_time_s,
+            len(self._daemon_work_times),
+            average_work_time_s,
         )
+        self._interval_warning_issued = True
 
     def _background_daemon(self):
         """Invoke each registered daemon function once.

--- a/instro/lib/instrument.py
+++ b/instro/lib/instrument.py
@@ -248,6 +248,7 @@ class Instrument:
     def add_background_daemon_function(self, method: Callable, *args, **kwargs):
         """Append ``method`` to the daemon's call list. Use ``define_background_daemon`` to replace instead."""
         self._background_methods.append((method, args, kwargs))
+        self._reset_daemon_timing()
 
     def _setup_channel_buffer(self, buffer_length: int):
         # Create a channel buffer if one doesn't already exist. Add it to list of publishers.
@@ -385,6 +386,10 @@ class Instrument:
         This doesn't give timing guarantees about the background daemon rate,
         just warn when work_time > requested interval.
         """
+        # An interval of 0 asks for free-running, so there is no rate to fall short of.
+        if self._background_config.interval <= 0:
+            return
+
         self._daemon_work_times.append(work_time_s)
         if self._interval_warning_issued or len(self._daemon_work_times) != self._daemon_work_times.maxlen:
             return
@@ -395,10 +400,9 @@ class Instrument:
 
         logger.warning(
             "Background daemon for instrument '%s' cannot achieve the requested interval of %.6f s; "
-            "average work time over %d cycles is %.6f s, which is the fastest achievable interval.",
+            "set background daemon interval to value greater than %.6f, which was the average work time.",
             self.name,
             self._background_config.interval,
-            len(self._daemon_work_times),
             average_work_time_s,
         )
         self._interval_warning_issued = True

--- a/instro/lib/instrument.py
+++ b/instro/lib/instrument.py
@@ -242,7 +242,8 @@ class Instrument:
 
     def _reset_daemon_timing(self):
         """Drop the timing window and re-arm the warning so cycles are judged against the current interval."""
-        self._daemon_work_times.clear()
+        # Create new deque so we don't risk clearing the queue used by the daemon for averaging
+        self._daemon_work_times = deque(maxlen=self._daemon_work_times.maxlen)
         self._interval_warning_issued = False
 
     def add_background_daemon_function(self, method: Callable, *args, **kwargs):
@@ -390,11 +391,13 @@ class Instrument:
         if self._background_config.interval <= 0:
             return
 
-        self._daemon_work_times.append(work_time_s)
-        if self._interval_warning_issued or len(self._daemon_work_times) != self._daemon_work_times.maxlen:
+        # Grab current version of work times so we don't have race condition between length check and division
+        work_times = self._daemon_work_times
+        work_times.append(work_time_s)
+        if self._interval_warning_issued or len(work_times) != work_times.maxlen:
             return
 
-        average_work_time_s = sum(self._daemon_work_times) / len(self._daemon_work_times)
+        average_work_time_s = sum(work_times) / len(work_times)
         if average_work_time_s <= self._background_config.interval:
             return
 

--- a/instro/lib/instrument.py
+++ b/instro/lib/instrument.py
@@ -4,6 +4,7 @@ import functools
 import logging
 import threading
 import time
+from collections import deque
 from importlib.metadata import version
 from typing import Callable
 
@@ -98,6 +99,9 @@ class Instrument:
         self._background_thread: threading.Thread | None = None
         self._background_stop_event = threading.Event()
         self._background_methods: list[tuple[Callable, tuple, dict]] = []
+        # Used to determine whether requested interval is achievable or not
+        self._daemon_loop_times: deque[float] = deque(maxlen=10)
+        self._interval_warning_issued = False
 
         self._channel_buffer_length: int = 10
         self._channel_buffer: DequeInMemoryPublisher | None = None
@@ -234,6 +238,12 @@ class Instrument:
     @background_interval.setter
     def background_interval(self, seconds: float):
         self._background_config.interval = seconds
+        self._reset_daemon_timing()
+
+    def _reset_daemon_timing(self):
+        """Drop the timing window and re-arm the warning so cycles are judged against the current interval."""
+        self._daemon_loop_times.clear()
+        self._interval_warning_issued = False
 
     def add_background_daemon_function(self, method: Callable, *args, **kwargs):
         """Append ``method`` to the daemon's call list. Use ``define_background_daemon`` to replace instead."""
@@ -255,6 +265,8 @@ class Instrument:
             return
 
         self._setup_channel_buffer(self._channel_buffer_length)
+
+        self._reset_daemon_timing()
 
         self._background_stop_event.clear()
         self._background_thread = threading.Thread(
@@ -364,7 +376,28 @@ class Instrument:
 
             daemon_loop_stop = time.time_ns()
             daemon_loop_time_s = (daemon_loop_stop - daemon_loop_start) * 1e-9
+            self._check_achievable_interval(daemon_loop_time_s)
             self._publish_daemon_timing(daemon_loop_time_s, daemon_work_time_s, daemon_loop_stop)
+
+    def _check_achievable_interval(self, loop_time_s: float):
+        """Warn once if the averaged loop time shows the requested interval isn't being achieved."""
+        self._daemon_loop_times.append(loop_time_s)
+        if self._interval_warning_issued or len(self._daemon_loop_times) != self._daemon_loop_times.maxlen:
+            return
+
+        average_loop_time_s = sum(self._daemon_loop_times) / len(self._daemon_loop_times)
+        if average_loop_time_s <= self._background_config.interval:
+            return
+
+        self._interval_warning_issued = True
+        logger.warning(
+            "Background daemon for instrument '%s' cannot achieve the requested interval of %.6f s; "
+            "average loop time over %d cycles is %.6f s, which is the fastest achievable interval.",
+            self.name,
+            self._background_config.interval,
+            len(self._daemon_loop_times),
+            average_loop_time_s,
+        )
 
     def _background_daemon(self):
         """Invoke each registered daemon function once.

--- a/tests/lib/test_instrumentation.py
+++ b/tests/lib/test_instrumentation.py
@@ -148,3 +148,18 @@ def test_warns_only_when_requested_interval_is_unachievable(caplog):
 
     assert len(caplog.records) == 1
     assert "cannot achieve the requested interval" in caplog.records[0].getMessage()
+
+
+def test_free_running_interval_never_warns(caplog):
+    instrument = Instrument(name="ut")
+    instrument.define_background_daemon(lambda: time.sleep(0.005))
+
+    with caplog.at_level(logging.WARNING, logger="instro.lib.instrument"):
+        try:
+            instrument.background_interval = 0
+            instrument.start()
+            instrument.get_channel("loop_time", length=10, wait_for_new_samples=True, timeout=5.0)
+        finally:
+            instrument.stop()
+
+    assert not caplog.records, "warned about a free-running daemon, which has no requested rate"

--- a/tests/lib/test_instrumentation.py
+++ b/tests/lib/test_instrumentation.py
@@ -131,7 +131,8 @@ def test_channel_names_includes_published_channels():
 
 def test_warns_only_when_requested_interval_is_unachievable(caplog):
     instrument = Instrument(name="ut")
-    instrument.define_background_daemon(lambda: time.sleep(0.05))
+    # Work is kept far from both intervals so scheduling jitter can't flip either assertion.
+    instrument.define_background_daemon(lambda: time.sleep(0.005))
 
     with caplog.at_level(logging.WARNING, logger="instro.lib.instrument"):
         try:

--- a/tests/lib/test_instrumentation.py
+++ b/tests/lib/test_instrumentation.py
@@ -1,3 +1,4 @@
+import logging
 import time
 from importlib.metadata import version
 
@@ -126,3 +127,23 @@ def test_channel_names_includes_published_channels():
         assert "ut.loop_time" in names
     finally:
         instrument.stop()
+
+
+def test_warns_only_when_requested_interval_is_unachievable(caplog):
+    instrument = Instrument(name="ut")
+    instrument.define_background_daemon(lambda: time.sleep(0.05))
+
+    with caplog.at_level(logging.WARNING, logger="instro.lib.instrument"):
+        try:
+            instrument.background_interval = 0.1
+            instrument.start()
+            instrument.get_channel("loop_time", length=10, wait_for_new_samples=True, timeout=5.0)
+            assert not caplog.records, "warned about an interval the daemon can achieve"
+
+            instrument.background_interval = 0.001
+            instrument.get_channel("loop_time", length=10, wait_for_new_samples=True, timeout=5.0)
+        finally:
+            instrument.stop()
+
+    assert len(caplog.records) == 1
+    assert "cannot achieve the requested interval" in caplog.records[0].getMessage()

--- a/uv.lock
+++ b/uv.lock
@@ -362,7 +362,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -527,7 +527,7 @@ wheels = [
 
 [[package]]
 name = "instro"
-version = "1.4.0"
+version = "1.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastavro", extra = ["snappy"] },
@@ -698,7 +698,7 @@ requires-dist = [
 
 [[package]]
 name = "instro-daq-ni"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "packages/instro-daq-ni" }
 dependencies = [
     { name = "instro" },
@@ -713,7 +713,7 @@ requires-dist = [
 
 [[package]]
 name = "instro-ethernetip"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "packages/instro-ethernetip" }
 dependencies = [
     { name = "instro" },
@@ -750,7 +750,7 @@ requires-dist = [{ name = "instro", editable = "." }]
 
 [[package]]
 name = "instro-unstable"
-version = "1.1.0"
+version = "1.2.0"
 source = { editable = "packages/instro-unstable" }
 dependencies = [
     { name = "instro" },

--- a/uv.lock
+++ b/uv.lock
@@ -362,7 +362,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -527,7 +527,7 @@ wheels = [
 
 [[package]]
 name = "instro"
-version = "1.5.0"
+version = "1.4.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastavro", extra = ["snappy"] },
@@ -698,7 +698,7 @@ requires-dist = [
 
 [[package]]
 name = "instro-daq-ni"
-version = "1.0.1"
+version = "1.0.0"
 source = { editable = "packages/instro-daq-ni" }
 dependencies = [
     { name = "instro" },
@@ -713,7 +713,7 @@ requires-dist = [
 
 [[package]]
 name = "instro-ethernetip"
-version = "1.0.1"
+version = "1.0.0"
 source = { editable = "packages/instro-ethernetip" }
 dependencies = [
     { name = "instro" },
@@ -750,7 +750,7 @@ requires-dist = [{ name = "instro", editable = "." }]
 
 [[package]]
 name = "instro-unstable"
-version = "1.2.0"
+version = "1.1.0"
 source = { editable = "packages/instro-unstable" }
 dependencies = [
     { name = "instro" },


### PR DESCRIPTION
## Summary

Based on the average work time of 10 cycles of the background daemon, warn the user if their requested rate isn't achievable (avg_work_time > requested_rate). We only warn once per instrument run.

## Type of change

- [ ] Bug fix (`fix`)
- [ ] New feature (`feat`)
- [ ] Breaking change (`feat!` / `fix!`)
- [ ] Refactor (`refactor`)
- [ ] Documentation (`docs`)
- [x] Chore / tooling (`chore`)

## Verification

<img width="848" height="136" alt="ver" src="https://github.com/user-attachments/assets/908b9c6d-d4f1-4e51-92c2-910a9f9b6f9d" />

Entire test suite passes

## Tests

- [x] Unit tests added or updated
- [ ] Existing tests cover this change
- [ ] No tests — explain why:

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(driver): add support for Keysight E36300`)
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] Documentation updated if user-facing behavior changed
- [x] Code follows the style/conventions of the surrounding code

## Notes for reviewers

Because of the way we pace the loop by calling `wait()` and the GIL, the daemon loop often runs at a slightly slower rate than the requested interval (loop_time = work_time + sw_latency). This is a pitfall of a sw timed loop in Python that we can't really get around. I just wanted to bring attention to the fact that this is only checking if the work time of the daemon is higher than the requested rate, not that the daemon is delivering on the requested loop interval (loop_time > requested_interval?)
