### PR TITLE
fix(scope): remove loop from scope check_errors()

### DIFF
--- a/instro/scope/drivers/keysight_1200x.py
+++ b/instro/scope/drivers/keysight_1200x.py
@@ -96,13 +96,11 @@ class Keysight1200X(ScopeDriverBase):
         self._visa.close()
 
     def check_errors(self) -> None:
-        """Drain ``:SYSTem:ERRor?`` and raise on the first non-zero code."""
-        while True:
-            resp = self._visa.query(":SYSTem:ERRor?")
-            parts = resp.split(",", 1)
-            code = int(parts[0])
-            if code == 0:
-                return
+        """Query ``:SYSTem:ERRor?`` once and raise on a non-zero code. Does not drain the queue."""
+        resp = self._visa.query(":SYSTem:ERRor?")
+        parts = resp.split(",", 1)
+        code = int(parts[0])
+        if code != 0:
             msg = parts[1].strip().strip('"') if len(parts) > 1 else "Unknown error"
             raise RuntimeError(f"Keysight SCPI error {code}: {msg}")
 


### PR DESCRIPTION
## Summary

Removing dead code from the Keysight 1200X scope driver where the while True loop only ever runs once. 

## Type of change

- [x] Bug fix (`fix`)
- [ ] New feature (`feat`)
- [ ] Breaking change (`feat!` / `fix!`)
- [ ] Refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] Chore / tooling (`chore`)

## Verification

<img width="1607" height="344" alt="Screenshot 2026-08-03 at 10 44 06 AM" src="https://github.com/user-attachments/assets/c0309249-312c-4c24-8b6c-4ce748fede42" />


## Tests

- [ ] Unit tests added or updated
- [ ] Existing tests cover this change
- [x] No tests — explain why: Existing tests were used to validate that previous functionality was not lost. See above images for passing test results.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(driver): add support for Keysight E36300`)
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] Documentation updated if user-facing behavior changed
- [x] Code follows the style/conventions of the surrounding code

## Notes for reviewers

Changes to `check_errors()` was not needed for the `siglent_sds1000x_e` or the `tektronix_2series` drivers. The Siglient does not hold an error queue so it checks for errors once by default. The Tektronix offers a unique command that either returns 1 or returns all the error messages, so there is no dead code since we return early with no errors and correctly loop through error messages when `self._visa.query("ALLEv?")` returns error messages.