### PR TITLE
fix(publishers): fix BufferedPublisher retains its buffer after close

### DIFF
--- a/instro/lib/publishers/publisher.py
+++ b/instro/lib/publishers/publisher.py
@@ -21,20 +21,36 @@ class BufferedPublisher(abc.ABC):
         self.publisher = publisher
         self.buffer: list[Measurement | Command] = []
         self.buffer_size = buffer_size
+        self._closed = False
+        self._lock = threading.Lock()
 
     def publish(self, data: Measurement | Command, **kwargs) -> None:
-        self.buffer.append(data)
-        if len(self.buffer) >= self.buffer_size:
-            self.publish_batch()
-            self.buffer.clear()
+        with self._lock:
+            if self._closed:
+                logger.warning(
+                    "Dropping publish request because %s is closed (publisher=%s)",
+                    self.__class__.__name__,
+                    self.publisher.__class__.__name__,
+                )
+                return
+            self.buffer.append(data)
+            if len(self.buffer) >= self.buffer_size:
+                self.publish_batch()
+                self.buffer.clear()
 
     @abc.abstractmethod
     def publish_batch(self) -> None:
         pass
 
     def close(self) -> None:
-        self.publish_batch()
-        self.publisher.close()
+        with self._lock:
+            if self._closed:
+                return
+            if self.buffer:
+                self.publish_batch()
+                self.buffer.clear()
+            self.publisher.close()
+            self._closed = True
 
 
 class BasicBufferedPublisher(BufferedPublisher):

--- a/instro/lib/publishers/publisher.py
+++ b/instro/lib/publishers/publisher.py
@@ -46,9 +46,8 @@ class BufferedPublisher(abc.ABC):
                 self.publisher.__class__.__name__,
             )
             return
-        if self.buffer:
-            self.publish_batch()
-            self.buffer.clear()
+        self.publish_batch()
+        self.buffer.clear()
         self.publisher.close()
         self._closed = True
 

--- a/instro/lib/publishers/publisher.py
+++ b/instro/lib/publishers/publisher.py
@@ -22,35 +22,27 @@ class BufferedPublisher(abc.ABC):
         self.buffer: list[Measurement | Command] = []
         self.buffer_size = buffer_size
         self._closed = False
-        self._lock = threading.Lock()
 
     def publish(self, data: Measurement | Command, **kwargs) -> None:
-        with self._lock:
-            if self._closed:
-                logger.warning(
-                    "Dropping publish request because %s is closed (publisher=%s)",
-                    self.__class__.__name__,
-                    self.publisher.__class__.__name__,
-                )
-                return
-            self.buffer.append(data)
-            if len(self.buffer) >= self.buffer_size:
-                self.publish_batch()
-                self.buffer.clear()
+        if self._closed:
+            return
+        self.buffer.append(data)
+        if len(self.buffer) >= self.buffer_size:
+            self.publish_batch()
+            self.buffer.clear()
 
     @abc.abstractmethod
     def publish_batch(self) -> None:
         pass
 
     def close(self) -> None:
-        with self._lock:
-            if self._closed:
-                return
-            if self.buffer:
-                self.publish_batch()
-                self.buffer.clear()
-            self.publisher.close()
-            self._closed = True
+        if self._closed:
+            return
+        if self.buffer:
+            self.publish_batch()
+            self.buffer.clear()
+        self.publisher.close()
+        self._closed = True
 
 
 class BasicBufferedPublisher(BufferedPublisher):

--- a/instro/lib/publishers/publisher.py
+++ b/instro/lib/publishers/publisher.py
@@ -25,6 +25,10 @@ class BufferedPublisher(abc.ABC):
 
     def publish(self, data: Measurement | Command, **kwargs) -> None:
         if self._closed:
+            logger.warning(
+                "Dropping publish request because BufferedPublisher is closed (publisher=%s)",
+                self.publisher.__class__.__name__,
+            )
             return
         self.buffer.append(data)
         if len(self.buffer) >= self.buffer_size:
@@ -37,6 +41,10 @@ class BufferedPublisher(abc.ABC):
 
     def close(self) -> None:
         if self._closed:
+            logger.warning(
+                "Dropping close request because BufferedPublisher is already closed (publisher=%s)",
+                self.publisher.__class__.__name__,
+            )
             return
         if self.buffer:
             self.publish_batch()

--- a/tests/lib/test_buffered_publisher.py
+++ b/tests/lib/test_buffered_publisher.py
@@ -2,7 +2,7 @@ import sys
 import threading
 
 from instro.lib import Command, Measurement
-from instro.lib.publishers import BasicBufferedPublisher, Publisher
+from instro.lib.publishers import BasicBufferedPublisher, FilePublisher, Publisher
 
 
 class RecordingPublisher(Publisher):
@@ -153,3 +153,21 @@ def test_concurrent_publish_and_close_is_thread_safe():
     assert publisher.buffer == []
     # Whatever did reach the sink got there exactly once: no double-processing.
     assert len(seen_timestamps) == len(set(seen_timestamps))
+
+
+def test_double_close_does_not_replay_buffer_into_closed_file(tmp_path):
+    # Regression test for #232: close() used to leave the drained buffer in place, so a
+    # second close() (e.g. an explicit close() followed by __exit__) replayed it into the
+    # already-closed file writer, raising "ValueError: I/O operation on closed file" for
+    # handle-based writers like jsonl/avro.
+    measurement = Measurement(channel_data={"voltage": [1.0]}, timestamps=[100])
+    publisher = BasicBufferedPublisher(
+        FilePublisher(tmp_path, format="jsonl", custom_file_name="capture"), buffer_size=1000
+    )
+
+    publisher.publish(measurement)  # buffered, below threshold
+    publisher.close()  # drains buffer, closes the file
+    publisher.close()  # must be a no-op, not a replay into the closed file
+
+    lines = (tmp_path / "capture.jsonl").read_text().splitlines()
+    assert len(lines) == 1

--- a/tests/lib/test_buffered_publisher.py
+++ b/tests/lib/test_buffered_publisher.py
@@ -1,0 +1,155 @@
+import sys
+import threading
+
+from instro.lib import Command, Measurement
+from instro.lib.publishers import BasicBufferedPublisher, Publisher
+
+
+class RecordingPublisher(Publisher):
+    def __init__(self):
+        self.close_count = 0
+        self.published: list[Measurement | Command] = []
+
+    def publish(self, data: Measurement | Command, **kwargs: object) -> None:
+        self.published.append(data)
+
+    def close(self) -> None:
+        self.close_count += 1
+
+
+class StrictRecordingPublisher(Publisher):
+    """Raises if used after close, like a real closed file/socket would.
+
+    Its own writes are serialized with a lock so the test isolates races in
+    ``BufferedPublisher`` itself rather than in this test double.
+    """
+
+    def __init__(self):
+        self.close_count = 0
+        self.closed = False
+        self.published: list[Measurement | Command] = []
+        self._lock = threading.Lock()
+
+    def publish(self, data: Measurement | Command, **kwargs: object) -> None:
+        with self._lock:
+            if self.closed:
+                raise RuntimeError("publish() called after close()")
+            self.published.append(data)
+
+    def close(self) -> None:
+        with self._lock:
+            if self.closed:
+                raise RuntimeError("close() called twice")
+            self.closed = True
+            self.close_count += 1
+
+
+def test_close_flushes_remaining_buffer_and_closes_underlying():
+    sink = RecordingPublisher()
+    measurement = Measurement(channel_data={"voltage": [1.0]}, timestamps=[100])
+    publisher = BasicBufferedPublisher(sink, buffer_size=1000)
+
+    publisher.publish(measurement)
+    publisher.close()
+
+    assert sink.published == [measurement]
+    assert sink.close_count == 1
+
+
+def test_repeated_close_is_idempotent():
+    sink = RecordingPublisher()
+    measurement = Measurement(channel_data={"voltage": [1.0]}, timestamps=[100])
+    publisher = BasicBufferedPublisher(sink, buffer_size=1000)
+
+    publisher.publish(measurement)
+    publisher.close()
+    publisher.close()
+
+    assert sink.published == [measurement]
+    assert sink.close_count == 1
+
+
+def test_publish_after_close_is_dropped():
+    sink = RecordingPublisher()
+    m1 = Measurement(channel_data={"voltage": [1.0]}, timestamps=[100])
+    m2 = Measurement(channel_data={"voltage": [2.0]}, timestamps=[200])
+    publisher = BasicBufferedPublisher(sink, buffer_size=1000)
+
+    publisher.publish(m1)
+    publisher.close()
+    publisher.publish(m2)
+    publisher.close()
+
+    assert sink.published == [m1]
+    assert sink.close_count == 1
+
+
+def test_concurrent_publish_is_thread_safe():
+    # A smaller switch interval forces frequent thread interleaving so a race in the
+    # buffer-size-triggered flush reproduces reliably instead of only on unlucky runs.
+    thread_count = 8
+    iterations = 500
+    original_switch_interval = sys.getswitchinterval()
+    sys.setswitchinterval(1e-6)
+    try:
+        sink = StrictRecordingPublisher()
+        publisher = BasicBufferedPublisher(sink, buffer_size=8)
+
+        def publish_loop(offset: int):
+            for i in range(iterations):
+                publisher.publish(Measurement(channel_data={"voltage": [float(offset + i)]}, timestamps=[offset + i]))
+
+        threads = [threading.Thread(target=publish_loop, args=(t * iterations,)) for t in range(thread_count)]
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join()
+        publisher.close()
+    finally:
+        sys.setswitchinterval(original_switch_interval)
+
+    seen_timestamps = [m.timestamps[0] for m in sink.published if isinstance(m, Measurement)]
+    assert publisher.buffer == []
+    # Every measurement reached the sink exactly once: no data lost or double-processed
+    # by concurrent buffer-size-triggered flushes racing each other.
+    assert len(seen_timestamps) == len(set(seen_timestamps)) == thread_count * iterations
+
+
+def test_concurrent_publish_and_close_is_thread_safe():
+    # close() races the in-flight publish loops on purpose here, so some publishes are
+    # expected to be dropped as "closed" - the invariant is no crash/double-close/double-add,
+    # not that every message gets through.
+    thread_count = 8
+    iterations = 300
+    original_switch_interval = sys.getswitchinterval()
+    sys.setswitchinterval(1e-6)
+    try:
+        sink = StrictRecordingPublisher()
+        publisher = BasicBufferedPublisher(sink, buffer_size=8)
+        errors: list[BaseException] = []
+
+        def publish_loop(offset: int):
+            for i in range(iterations):
+                try:
+                    publisher.publish(
+                        Measurement(channel_data={"voltage": [float(offset + i)]}, timestamps=[offset + i])
+                    )
+                except BaseException as exc:  # noqa: BLE001
+                    errors.append(exc)
+
+        threads = [threading.Thread(target=publish_loop, args=(t * iterations,)) for t in range(thread_count)]
+        for thread in threads:
+            thread.start()
+        publisher.close()
+        for thread in threads:
+            thread.join()
+        publisher.close()
+    finally:
+        sys.setswitchinterval(original_switch_interval)
+
+    seen_timestamps = [m.timestamps[0] for m in sink.published if isinstance(m, Measurement)]
+    assert errors == []
+    assert sink.close_count == 1
+    assert publisher.buffer == []
+    # Whatever did reach the sink got there exactly once: no double-processing.
+    assert len(seen_timestamps) == len(set(seen_timestamps))

--- a/tests/lib/test_buffered_publisher.py
+++ b/tests/lib/test_buffered_publisher.py
@@ -54,6 +54,7 @@ def test_close_flushes_remaining_buffer_and_closes_underlying():
 
     assert sink.published == [measurement]
     assert sink.close_count == 1
+    assert publisher.buffer == []
 
 
 def test_repeated_close_is_idempotent():
@@ -84,75 +85,60 @@ def test_publish_after_close_is_dropped():
     assert sink.close_count == 1
 
 
-def test_concurrent_publish_is_thread_safe():
-    # A smaller switch interval forces frequent thread interleaving so a race in the
-    # buffer-size-triggered flush reproduces reliably instead of only on unlucky runs.
-    thread_count = 8
-    iterations = 500
-    original_switch_interval = sys.getswitchinterval()
-    sys.setswitchinterval(1e-6)
-    try:
-        sink = StrictRecordingPublisher()
-        publisher = BasicBufferedPublisher(sink, buffer_size=8)
+def test_threshold_triggered_flush_clears_buffer_before_close():
+    # The auto-flush inside publish() (buffer_size reached) has its own buffer.clear(),
+    # separate from the one in close(). Cover that path too: a full batch flushed by
+    # publish(), a trailing item left for close() to drain, and no duplication either way.
+    sink = RecordingPublisher()
+    measurements = [Measurement(channel_data={"voltage": [float(i)]}, timestamps=[i]) for i in range(4)]
+    publisher = BasicBufferedPublisher(sink, buffer_size=3)
 
-        def publish_loop(offset: int):
-            for i in range(iterations):
-                publisher.publish(Measurement(channel_data={"voltage": [float(offset + i)]}, timestamps=[offset + i]))
+    for m in measurements[:3]:
+        publisher.publish(m)  # 3rd publish() hits buffer_size and auto-flushes
+    assert publisher.buffer == []  # auto-flush clears the buffer on its own, before any close()
 
-        threads = [threading.Thread(target=publish_loop, args=(t * iterations,)) for t in range(thread_count)]
-        for thread in threads:
-            thread.start()
-        for thread in threads:
-            thread.join()
-        publisher.close()
-    finally:
-        sys.setswitchinterval(original_switch_interval)
+    publisher.publish(measurements[3])  # buffered again, below threshold
+    publisher.close()  # drains the trailing item
+    publisher.close()  # must not replay anything
 
-    seen_timestamps = [m.timestamps[0] for m in sink.published if isinstance(m, Measurement)]
+    assert sink.published == measurements
     assert publisher.buffer == []
-    # Every measurement reached the sink exactly once: no data lost or double-processed
-    # by concurrent buffer-size-triggered flushes racing each other.
-    assert len(seen_timestamps) == len(set(seen_timestamps)) == thread_count * iterations
-
-
-def test_concurrent_publish_and_close_is_thread_safe():
-    # close() races the in-flight publish loops on purpose here, so some publishes are
-    # expected to be dropped as "closed" - the invariant is no crash/double-close/double-add,
-    # not that every message gets through.
-    thread_count = 8
-    iterations = 300
-    original_switch_interval = sys.getswitchinterval()
-    sys.setswitchinterval(1e-6)
-    try:
-        sink = StrictRecordingPublisher()
-        publisher = BasicBufferedPublisher(sink, buffer_size=8)
-        errors: list[BaseException] = []
-
-        def publish_loop(offset: int):
-            for i in range(iterations):
-                try:
-                    publisher.publish(
-                        Measurement(channel_data={"voltage": [float(offset + i)]}, timestamps=[offset + i])
-                    )
-                except BaseException as exc:  # noqa: BLE001
-                    errors.append(exc)
-
-        threads = [threading.Thread(target=publish_loop, args=(t * iterations,)) for t in range(thread_count)]
-        for thread in threads:
-            thread.start()
-        publisher.close()
-        for thread in threads:
-            thread.join()
-        publisher.close()
-    finally:
-        sys.setswitchinterval(original_switch_interval)
-
-    seen_timestamps = [m.timestamps[0] for m in sink.published if isinstance(m, Measurement)]
-    assert errors == []
     assert sink.close_count == 1
+
+
+def test_repeated_close_never_touches_underlying_publisher_twice():
+    sink = StrictRecordingPublisher()
+    measurement = Measurement(channel_data={"voltage": [1.0]}, timestamps=[100])
+    publisher = BasicBufferedPublisher(sink, buffer_size=1000)
+
+    publisher.publish(measurement)
+    publisher.close()
+    publisher.close()
+    publisher.close()
+
+    assert sink.published == [measurement]
+    assert sink.close_count == 1
+
+
+def test_publish_after_close_never_reaches_underlying_publisher():
+    # RecordingPublisher can't tell "never called after close" from "called and happened
+    # to look fine"; StrictRecordingPublisher raises if publish()/close() lands on it once
+    # closed, so this proves the dropped writes never reach the wrapped publisher at all.
+    sink = StrictRecordingPublisher()
+    m1 = Measurement(channel_data={"voltage": [1.0]}, timestamps=[100])
+    late = [Measurement(channel_data={"voltage": [float(i)]}, timestamps=[i]) for i in range(200, 205)]
+    publisher = BasicBufferedPublisher(sink, buffer_size=1000)
+
+    publisher.publish(m1)
+    publisher.close()
+    for m in late:
+        publisher.publish(m)
+    publisher.close()
+
+    assert sink.published == [m1]
+    assert sink.close_count == 1
+    # Late publishes must be actively dropped, not merely stuck unflushed in the buffer.
     assert publisher.buffer == []
-    # Whatever did reach the sink got there exactly once: no double-processing.
-    assert len(seen_timestamps) == len(set(seen_timestamps))
 
 
 def test_double_close_does_not_replay_buffer_into_closed_file(tmp_path):
@@ -171,3 +157,4 @@ def test_double_close_does_not_replay_buffer_into_closed_file(tmp_path):
 
     lines = (tmp_path / "capture.jsonl").read_text().splitlines()
     assert len(lines) == 1
+    assert publisher.buffer == []


### PR DESCRIPTION
## Summary

In the original implementation, BufferedPublisher would close by calling `publish_batch()` then `close()`. However, `publish_batch()` did not clear the buffer and when `close()` is called twice, a ValueError occurs. 

This PR introduces a `_closed` flag in the init of the BufferedPublisher. This flag is used to check the closed state of the publisher. If we are closed, then we will avoid touching the buffer, making close() be idempotent. Additionally, we add a `self.buffer.close()` call to clear the buffer when `close()` is called so the buffer ends in an empty state.

## Type of change

- [x] Bug fix (`fix`)
- [ ] New feature (`feat`)
- [ ] Breaking change (`feat!` / `fix!`)
- [ ] Refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] Chore / tooling (`chore`)

## Verification
<img width="1590" height="277" alt="Screenshot 2026-08-04 at 10 27 18 AM" src="https://github.com/user-attachments/assets/7dc0779c-6ce5-42ee-88f2-4cb1dd7551eb" />

## Tests

- [x] Unit tests added or updated
- [ ] Existing tests cover this change
- [ ] No tests — explain why:

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(driver): add support for Keysight E36300`)
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] Documentation updated if user-facing behavior changed
- [x] Code follows the style/conventions of the surrounding code

## Notes for reviewers

Adding a logger warning when attempting to call `close()` or `publish()` after the BufferedPublisher is closed to keep consistency with the other publishers. 