### PR TITLE
chore(release): sync instro-ethernetip manifest with shipped v1.0.1 tag

### DIFF
--- a/.github/release-please-manifest.json
+++ b/.github/release-please-manifest.json
@@ -5,7 +5,7 @@
   "packages/instro-daq-ni": "1.0.1",
   "packages/instro-i2c-aardvark": "1.0.0",
   "packages/instro-unstable": "1.4.0",
-  "packages/instro-ethernetip": "1.0.0",
+  "packages/instro-ethernetip": "1.0.1",
   "packages/instro-contrib": "1.0.0",
   "crates/instro-ethernetip": "1.0.0",
   "crates/instro-opcua": "1.1.0"


### PR DESCRIPTION
Fixes nominal-io/instro#350.

Sets `packages/instro-ethernetip` to `1.0.1` in the release-please manifest, matching the tag already shipped by nominal-io/instro#291 (whose diff missed this update). Stops release-please from recreating the spurious 1.0.1 release PR ([#333](<https://github.com/nominal-io/instro/issues/333>)) on every push to main. No commits touch the package since v1.0.1, so no release will be proposed after this lands.