### PR TITLE
refactor(opcua): infallible user token ctors

### DIFF
--- a/crates/instro-opcua/README.md
+++ b/crates/instro-opcua/README.md
@@ -28,7 +28,7 @@ use open62541::ua;
 
 fn main() -> anyhow::Result<()> {
     let client = OpcUaClientBuilder::new()
-        .user_identity_token(OpcUaUserToken::anonymous("anonymous".to_owned())?)
+        .user_identity_token(OpcUaUserToken::anonymous("anonymous".to_owned()))
         .security_mode(OpcUaSecurityMode::None)
         .security_policy(OpcUaSecurityPolicy::None)
         .pki(OpcUaPki::None)

--- a/crates/instro-opcua/src/types.rs
+++ b/crates/instro-opcua/src/types.rs
@@ -249,32 +249,29 @@ pub struct OpcUaUserToken {
 }
 
 impl OpcUaUserToken {
-    fn new(policy_id: String, inner: OpcUaUserTokenInner) -> Self {
+    const fn new(policy_id: String, inner: OpcUaUserTokenInner) -> Self {
         Self { policy_id, inner }
     }
 
     /// Creates a new user token for anonymous authentication.
-    pub fn anonymous(policy_id: String) -> Result<Self> {
-        Ok(Self::new(policy_id, OpcUaUserTokenInner::Anonymous))
+    pub const fn anonymous(policy_id: String) -> Self {
+        Self::new(policy_id, OpcUaUserTokenInner::Anonymous)
     }
 
     /// Creates a new user token for basic authentication.
-    pub fn basic(user: String, pass: String, policy_id: String) -> Result<Self> {
-        Ok(Self::new(
+    pub const fn basic(user: String, pass: String, policy_id: String) -> Self {
+        Self::new(
             policy_id,
             OpcUaUserTokenInner::Basic {
                 username: user,
                 password: pass,
             },
-        ))
+        )
     }
 
     /// Creates a new user token for certificate-based authentication.
-    pub fn certificate(cert: Vec<u8>, policy_id: String) -> Result<Self> {
-        Ok(Self::new(
-            policy_id,
-            OpcUaUserTokenInner::Certificate { cert },
-        ))
+    pub const fn certificate(cert: Vec<u8>, policy_id: String) -> Self {
+        Self::new(policy_id, OpcUaUserTokenInner::Certificate { cert })
     }
 }
 
@@ -1899,7 +1896,7 @@ mod tests {
 
     #[test]
     fn user_token_anonymous_serializes_with_flattened_kind() {
-        let token = OpcUaUserToken::anonymous("anon".into()).expect("token");
+        let token = OpcUaUserToken::anonymous("anon".into());
 
         let json = serde_json::to_value(&token).expect("serialize");
         assert_eq!(
@@ -1915,8 +1912,7 @@ mod tests {
 
     #[test]
     fn user_token_basic_serializes_with_flattened_kind_and_credentials() {
-        let token =
-            OpcUaUserToken::basic("user".into(), "pw".into(), "basic".into()).expect("token");
+        let token = OpcUaUserToken::basic("user".into(), "pw".into(), "basic".into());
 
         let json = serde_json::to_value(&token).expect("serialize");
         assert_eq!(
@@ -1934,7 +1930,7 @@ mod tests {
 
     #[test]
     fn user_token_certificate_serializes_with_flattened_kind_and_cert() {
-        let token = OpcUaUserToken::certificate(vec![1, 2, 3], "cert".into()).expect("token");
+        let token = OpcUaUserToken::certificate(vec![1, 2, 3], "cert".into());
 
         let json = serde_json::to_value(&token).expect("serialize");
         assert_eq!(

--- a/crates/instro-opcua/tests/client_harness.rs
+++ b/crates/instro-opcua/tests/client_harness.rs
@@ -35,7 +35,7 @@ use tokio::sync::mpsc;
 
 fn connect_client(server: &TestServer) -> Result<Arc<OpcUaClient>> {
     OpcUaClientBuilder::new()
-        .user_identity_token(OpcUaUserToken::anonymous("anonymous".to_owned())?)
+        .user_identity_token(OpcUaUserToken::anonymous("anonymous".to_owned()))
         .security_mode(OpcUaSecurityMode::None)
         .security_policy(OpcUaSecurityPolicy::None)
         .timeout(LIFETIME_TIMEOUT)


### PR DESCRIPTION
## Summary

_Briefly describe what this PR does and why. If it fixes an existing issue, link it (e.g. `Fixes #123`)._
Fixes noop `Result<Self>`s that were just noise in the `OpcUaUserToken` api.

## Type of change

- [ ] Bug fix (`fix`)
- [ ] New feature (`feat`)
- [ ] Breaking change (`feat!` / `fix!`)
- [x] Refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] Chore / tooling (`chore`)

## Verification

_How did you verify this change works? Provide evidence the reviewer can evaluate without reproducing your setup — e.g. test output, screenshots, logs, repro steps + result. If the change is hardware-specific and you don't have the device, say so._
All tests pass, updated downstream callers (mostly in tests). Is a breaking change, in theory, but we're not concerned w/ that at this point.

## Tests

- [ ] Unit tests added or updated
- [ ] Existing tests cover this change
- [ ] No tests — explain why:

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(driver): add support for Keysight E36300`)
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] Documentation updated if user-facing behavior changed
- [x] Code follows the style/conventions of the surrounding code

## Notes for reviewers

_Optional — call out specific files, edge cases, or decisions you'd like eyes on._
