### PR TITLE
chore: sync uv.lock with instro 1.8.0

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -582,7 +582,7 @@ wheels = [
 
 [[package]]
 name = "instro"
-version = "1.7.0"
+version = "1.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastavro", extra = ["snappy"] },


### PR DESCRIPTION
Fixes #364

Release #354 bumped `pyproject.toml` to 1.8.0 without regenerating `uv.lock`, so `uv lock --check` currently fails on main and blocks the CI lockfile gate for every open PR. This is the one-line version sync (`uv lock` output, no dependency changes).

The recurring root cause (release-please not updating the lock in release PRs) is tracked in #364.