### PR TITLE
fix(ljm): expose stream buffer byte size configuration

### DIFF
--- a/packages/instro-daq-labjack/instro/daq/drivers/labjack/t_series.py
+++ b/packages/instro-daq-labjack/instro/daq/drivers/labjack/t_series.py
@@ -50,12 +50,23 @@ class LabJackData:
 class LabJackTSeriesDriver(DAQDriverBase):
     """LabJack T-series DAQ driver (T4/T7/T8 via the LJM library)."""
 
-    def __init__(self, device_id: str):
+    def __init__(self, device_id: str, stream_buffer_bytes: int = 0):
+        """Construct the driver.
+
+        Args:
+            device_id: Device serial number, or "ANY" for the first device found.
+            stream_buffer_bytes: Device-side stream buffer size, always written when AI hardware
+                timing is configured so no value carries over from an earlier session.
+                0 selects the device's own default.
+                Must be a power of 2 and the max is 262144.
+                Setting this prevents the device from dropping scans at high sample rates, which LJM reports as -9999 sample values.
+        """
         super().__init__()
         self._model: LJ_Model | None = None
         self._handle: int | None = None
         self._info: tuple[int, int, int, int, int, int] | None = None
         self._device_id = device_id
+        self._stream_buffer_bytes = stream_buffer_bytes
 
         # hw timing settings since LabJack has a single timing engine and samples/channel are predefined
         self._global_scan_rate: float | None = None
@@ -155,7 +166,11 @@ class LabJackTSeriesDriver(DAQDriverBase):
         # Here, we'll configure some of the settling and resolution settings specific to streams
         # We should expand this to expose other register configurations in later versions.
         assert self._model
-        aNames, aValues = self._model.hw_timing_configs(hw_timing_config=hw_timing_config, channels=ai_channels)
+        aNames, aValues = self._model.hw_timing_configs(
+            hw_timing_config=hw_timing_config,
+            channels=ai_channels,
+            stream_buffer_bytes=self._stream_buffer_bytes,
+        )
 
         if aNames:
             ljm.eWriteNames(self._handle, len(aNames), aNames, aValues)

--- a/packages/instro-daq-labjack/instro/daq/drivers/labjack/t_series_models.py
+++ b/packages/instro-daq-labjack/instro/daq/drivers/labjack/t_series_models.py
@@ -16,6 +16,7 @@ class LJ_Model(Protocol):
         self,
         hw_timing_config: HWTimingConfig,
         channels: list[AnalogChannel],
+        stream_buffer_bytes: int = 0,
     ) -> tuple[list[str], list[float] | list[int]]: ...
 
 
@@ -56,12 +57,13 @@ class LJ_T4:
         self,
         hw_timing_config: HWTimingConfig,
         channels: list[AnalogChannel],
+        stream_buffer_bytes: int = 0,
     ) -> tuple[list[str], list[float] | list[int]]:
         # Stream settling is 0 (default) and
         # stream resolution index is 0 (default).
 
-        aNames = ["STREAM_SETTLING_US", "STREAM_RESOLUTION_INDEX"]
-        aValues = [0, 0]
+        aNames = ["STREAM_SETTLING_US", "STREAM_RESOLUTION_INDEX", "STREAM_BUFFER_SIZE_BYTES"]
+        aValues = [0, 0, stream_buffer_bytes]
 
         return aNames, aValues
 
@@ -138,6 +140,7 @@ class LJ_T7:
         self,
         hw_timing_config: HWTimingConfig,
         channels: list[AnalogChannel],
+        stream_buffer_bytes: int = 0,
     ) -> tuple[list[str], list[float] | list[int]]:
         # I believe the Labjack only has one timing engine so no need to track channel_type
 
@@ -150,8 +153,9 @@ class LJ_T7:
             "STREAM_CLOCK_SOURCE",
             "STREAM_RESOLUTION_INDEX",
             "STREAM_SETTLING_US",
+            "STREAM_BUFFER_SIZE_BYTES",
         ]
-        aValues = [0, 0, 0, 0]
+        aValues = [0, 0, 0, 0, stream_buffer_bytes]
 
         return aNames, aValues
 
@@ -202,12 +206,14 @@ class LJ_T8:
         self,
         hw_timing_config: HWTimingConfig,
         channels: list[AnalogChannel],
+        stream_buffer_bytes: int = 0,
     ) -> tuple[list[str], list[float] | list[int]]:
         aNames = [
             "STREAM_TRIGGER_INDEX",
             "STREAM_CLOCK_SOURCE",
             "STREAM_RESOLUTION_INDEX",
+            "STREAM_BUFFER_SIZE_BYTES",
         ]
-        aValues = [0, 0, 0]
+        aValues = [0, 0, 0, stream_buffer_bytes]
 
         return aNames, aValues

--- a/tests/daq/labjack/test_labjack_t8_hardware.py
+++ b/tests/daq/labjack/test_labjack_t8_hardware.py
@@ -70,7 +70,7 @@ from instro.lib.publishers import NominalCorePublisher
 # ---------------------------------------------------------------------------
 # Configuration — edit before running
 # ---------------------------------------------------------------------------
-DEVICE_ID = "LABJACK T8 SERIAL NUMBER"  # e.g. "123456789" or "ANY"
+DEVICE_ID = "480010992"  # e.g. "123456789" or "ANY"
 NAME = "t8_validate"
 DATASET_RID = None
 
@@ -110,6 +110,8 @@ HW_TIMED_TOLERANCE_V = 0.05
 HIGH_RATE_HZ = 40_000.0
 HIGH_RATE_SAMPLES = 4_000
 HIGH_RATE_TOLERANCE_V = 0.10
+# The T8's default stream buffer drops scans at 40 kS/s; LJM fills them with -9999.
+HIGH_RATE_STREAM_BUFFER_BYTES = 65_536
 
 
 # ---------------------------------------------------------------------------
@@ -202,8 +204,11 @@ class TestLabJackT8Hardware(unittest.TestCase):
     # Helpers
     # ------------------------------------------------------------------
 
-    def _create_daq(self) -> InstroDAQ:
-        daq = InstroDAQ(name=NAME, driver=LabJackTSeriesDriver(device_id=DEVICE_ID))
+    def _create_daq(self, stream_buffer_bytes: int = 0) -> InstroDAQ:
+        daq = InstroDAQ(
+            name=NAME,
+            driver=LabJackTSeriesDriver(device_id=DEVICE_ID, stream_buffer_bytes=stream_buffer_bytes),
+        )
         if DATASET_RID:
             daq.add_publisher(NominalCorePublisher(dataset_rid=DATASET_RID))
         daq.open()
@@ -810,7 +815,7 @@ class TestLabJackT8Hardware(unittest.TestCase):
 
         def step(start_ns: int):
             print(f"         [start {self._ts(start_ns)}]")
-            daq = self._create_daq()
+            daq = self._create_daq(stream_buffer_bytes=HIGH_RATE_STREAM_BUFFER_BYTES)
             try:
                 self._configure_ai(daq, AI_CHANNEL_0, AI_ALIAS_0)
                 self._configure_ao(daq, AO_CHANNEL_0, AO_ALIAS_0)
@@ -837,7 +842,8 @@ class TestLabJackT8Hardware(unittest.TestCase):
 
         self._run_step(
             f"HW-timed high-rate stream ({HIGH_RATE_HZ / 1000:.0f} kS/s)",
-            f"Stream AIN0 at {HIGH_RATE_HZ} Hz via start(background=False). "
+            f"Stream AIN0 at {HIGH_RATE_HZ} Hz via start(background=False) with "
+            f"stream_buffer_bytes={HIGH_RATE_STREAM_BUFFER_BYTES}. "
             "Verifies T8 maximum per-channel rate without errors.",
             step,
         )

--- a/tests/daq/labjack/test_labjack_t8_hardware.py
+++ b/tests/daq/labjack/test_labjack_t8_hardware.py
@@ -70,7 +70,7 @@ from instro.lib.publishers import NominalCorePublisher
 # ---------------------------------------------------------------------------
 # Configuration — edit before running
 # ---------------------------------------------------------------------------
-DEVICE_ID = "480010992"  # e.g. "123456789" or "ANY"
+DEVICE_ID = "<LABJACK T8 SERIAL NUMBER>"  # e.g. "123456789" or "ANY"
 NAME = "t8_validate"
 DATASET_RID = None
 


### PR DESCRIPTION
## Summary

When a LabJack T8 streams near its max rate (40kHz) there appears to be a firmware bug that causes it to read in a block of `-9999.0` (dropped scan value) values once a stream due to some issue with buffer overflow. This never occurs if the buffer byte size is explicitly set using the `"STREAM_BUFFER_SIZE_BYTES"` register. So we've exposed a way for the user to configure this so they can mitigate these issues if they run into them. By default we set the buffer size to it's default (writing 0 to this register which was the previous behavior).

## Type of change

- [x] Bug fix (`fix`)
- [ ] New feature (`feat`)
- [ ] Breaking change (`feat!` / `fix!`)
- [ ] Refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] Chore / tooling (`chore`)

## Verification

Previously, `test_14_hw_timed_high_rate` for testing the T8 hardware failed due to this issue. Now it, and all other T8 hardware tests, pass.

<img width="1304" height="128" alt="Screen Shot 2026-08-06 at 05 11 00 869 PM" src="https://github.com/user-attachments/assets/69dc7777-e447-4009-90f0-49032c4dad53" />


## Tests

- [x] Unit tests added or updated
- [ ] Existing tests cover this change
- [ ] No tests — explain why:

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(driver): add support for Keysight E36300`)
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] Documentation updated if user-facing behavior changed
- [x] Code follows the style/conventions of the surrounding code

## Notes for reviewers