### PR TITLE
fix(awg): change check_errors() from required to optional in awg

### DIFF
--- a/docs/guides/instrumentation/awg.mdx
+++ b/docs/guides/instrumentation/awg.mdx
@@ -227,9 +227,6 @@ def open(self) -> None:
 def close(self) -> None:
     """Close the underlying transport."""
 
-def check_errors(self) -> None:
-    """Drain the instrument error queue; raise if any error is pending."""
-
 def set_waveform(self, channel: int, waveform: Waveform) -> None:
     """Program channel with the waveform definition; raise ValueError if the definition is unsupported."""
 
@@ -257,6 +254,7 @@ def get_output_state(self, channel: int) -> bool:
 
 Optional overrides (raise `NotImplementedError` if not supported):
 
+- **`check_errors()`**: Drain the instrument error queue; raise if any error is pending. `InstroAWG` calls this after every write and tolerates it being unimplemented.
 - **`set_output_load(channel, load)`** / **`get_output_load(channel)`**: Set or read the output load impedance; `None` means high-Z.
 - **`align_phase()`**: Sync the phase of all channels.
 - **`set_modulation(channel, mod_type, shape, magnitude)`**: Configure a channel's modulation. Call `modulation_enable()` to activate it.

--- a/packages/instro-unstable/instro/unstable/awg/awg.py
+++ b/packages/instro-unstable/instro/unstable/awg/awg.py
@@ -41,10 +41,6 @@ class AWGDriverBase(abc.ABC):
         """Close the underlying transport."""
 
     @abc.abstractmethod
-    def check_errors(self) -> None:
-        """Check the instrument error queue."""
-
-    @abc.abstractmethod
     def set_waveform(self, channel: int, waveform: Waveform) -> None:
         """Program channel with the waveform definition."""
 
@@ -75,6 +71,10 @@ class AWGDriverBase(abc.ABC):
     @abc.abstractmethod
     def get_output_state(self, channel: int) -> bool:
         """Return True if the output on channel is enabled."""
+
+    def check_errors(self) -> None:
+        """Check the instrument error queue."""
+        raise NotImplementedError(f"check_errors is not implemented for {type(self).__name__}")
 
     def set_output_load(self, channel: int, load: float | None) -> None:
         """Set the output load impedance; None means high-Z."""
@@ -166,7 +166,10 @@ class InstroAWG(Instrument):
 
     def _check_errors(self) -> None:
         """Raise if the driver's error queue holds anything."""
-        self._driver.check_errors()
+        try:
+            self._driver.check_errors()
+        except NotImplementedError:
+            pass
 
     @publish_command
     def _execute_command(

--- a/tests/unstable/awg/test_awg.py
+++ b/tests/unstable/awg/test_awg.py
@@ -32,9 +32,6 @@ class _MinimalAWGDriver(AWGDriverBase):
     def close(self) -> None:
         pass
 
-    def check_errors(self) -> None:
-        pass
-
     def set_waveform(self, channel: int, waveform: Waveform) -> None:
         pass
 
@@ -84,6 +81,7 @@ def test_01_awg_driver_base_contract_enforces_instantiation_rules() -> None:
 @pytest.mark.parametrize(
     ("method_name", "args"),
     [
+        ("check_errors", ()),
         ("set_output_load", (1, 50.0)),
         ("get_output_load", (1,)),
         ("align_phase", ()),
@@ -187,6 +185,14 @@ def test_04_check_errors_called_propagates_and_helper_tags_avoid_collision(
     with pytest.raises(RuntimeError, match="instrument error queue not empty"):
         awg.set_waveform(2, Sine(frequency_hz=1000.0))
     assert 2 not in awg._channel_waveforms
+
+
+def test_04b_check_errors_is_optional(mock_driver: MagicMock) -> None:
+    """A driver that doesn't implement check_errors must not break other calls."""
+    mock_driver.check_errors.side_effect = NotImplementedError("check_errors is not implemented for _NoErrorCheck")
+    awg = InstroAWG(name="test_awg", driver=mock_driver, num_channels=2)
+    awg.set_waveform(1, Sine(frequency_hz=1000.0))
+    awg.get_output_state(1)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Updating the requirements of the functions in awg. Since we want to allow for broad support of AWGs in the future, we want to avoid using SCPI/VISA specific requirements. `check_errors()` is not universal across non-SCPI instruments. So we make this function optional and simply raise NotImplementedError() and update the documentation to reflect.

## Type of change

- [x] Bug fix (`fix`)
- [ ] New feature (`feat`)
- [ ] Breaking change (`feat!` / `fix!`)
- [ ] Refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] Chore / tooling (`chore`)

## Verification

<img width="1205" height="727" alt="Screenshot 2026-08-07 at 1 07 52 PM" src="https://github.com/user-attachments/assets/f9938391-83d8-480a-b425-b9c07f603091" />

## Tests

- [ ] Unit tests added or updated
- [ ] Existing tests cover this change
- [x] No tests — explain why: Existing tests were use to verify that this change is non-breaking.


## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(driver): add support for Keysight E36300`)
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] Documentation updated if user-facing behavior changed
- [x] Code follows the style/conventions of the surrounding code