### PR TITLE
feat(psu): implement get_voltage_setpoint()/get_current_setpoint() for SiglentSPD3303

### DIFF
--- a/instro/psu/drivers/siglent_spd3303.py
+++ b/instro/psu/drivers/siglent_spd3303.py
@@ -33,6 +33,14 @@ class SiglentSPD3303(PSUDriverBase):
         _require_programmable_channel("get_current", channel)
         return self._query_checked_float(f"MEAS:CURR? CH{channel}")
 
+    def get_voltage_setpoint(self, channel: int) -> float:
+        _require_programmable_channel("get_voltage_setpoint", channel)
+        return self._query_checked_float(f"CH{channel}:VOLT?")
+
+    def get_current_setpoint(self, channel: int) -> float:
+        _require_programmable_channel("get_current_setpoint", channel)
+        return self._query_checked_float(f"CH{channel}:CURR?")
+
     def output_enable(self, enable: bool, channel: int) -> None:
         _require_programmable_channel("output_enable", channel)
         cmd = f"OUTP CH{channel},ON" if enable else f"OUTP CH{channel},OFF"

--- a/tests/psu/siglent/test_siglent_spd3303_hardware.py
+++ b/tests/psu/siglent/test_siglent_spd3303_hardware.py
@@ -145,6 +145,24 @@ def test_get_current(driver: SiglentSPD3303, channel_config: ChannelConfig) -> N
 
 
 @pytest.mark.parametrize("channel_config", CHANNELS, ids=lambda config: f"channel_{config.channel}")
+def test_get_voltage_setpoint(driver: SiglentSPD3303, channel_config: ChannelConfig) -> None:
+    driver.set_voltage(channel_config.programmed_voltage(), channel=channel_config.channel)
+
+    setpoint = driver.get_voltage_setpoint(channel=channel_config.channel)
+
+    assert setpoint == pytest.approx(channel_config.programmed_voltage(), abs=0.001)
+
+
+@pytest.mark.parametrize("channel_config", CHANNELS, ids=lambda config: f"channel_{config.channel}")
+def test_get_current_setpoint(driver: SiglentSPD3303, channel_config: ChannelConfig) -> None:
+    driver.set_current_limit(channel_config.programmed_current_limit(), channel=channel_config.channel)
+
+    setpoint = driver.get_current_setpoint(channel=channel_config.channel)
+
+    assert setpoint == pytest.approx(channel_config.programmed_current_limit(), abs=0.001)
+
+
+@pytest.mark.parametrize("channel_config", CHANNELS, ids=lambda config: f"channel_{config.channel}")
 def test_output_enable(driver: SiglentSPD3303, channel_config: ChannelConfig) -> None:
     driver.output_enable(True, channel=channel_config.channel)
     assert driver.get_output_status(channel=channel_config.channel) is True
@@ -284,6 +302,16 @@ def test_get_current_channel_three_unsupported(driver: SiglentSPD3303) -> None:
         driver.get_current(channel=3)
 
 
+def test_get_voltage_setpoint_channel_three_unsupported(driver: SiglentSPD3303) -> None:
+    with pytest.raises(FeatureNotSupportedError, match="get_voltage_setpoint is not supported for channel 3"):
+        driver.get_voltage_setpoint(channel=3)
+
+
+def test_get_current_setpoint_channel_three_unsupported(driver: SiglentSPD3303) -> None:
+    with pytest.raises(FeatureNotSupportedError, match="get_current_setpoint is not supported for channel 3"):
+        driver.get_current_setpoint(channel=3)
+
+
 def test_output_enable_channel_three_unsupported(driver: SiglentSPD3303) -> None:
     with pytest.raises(FeatureNotSupportedError, match="output_enable is not supported for channel 3"):
         driver.output_enable(True, channel=3)
@@ -312,6 +340,16 @@ def test_set_current_limit_invalid_channel(driver: SiglentSPD3303) -> None:
 def test_get_current_invalid_channel(driver: SiglentSPD3303) -> None:
     with pytest.raises(ValueError, match="channel must be 1, 2, or 3"):
         driver.get_current(channel=4)
+
+
+def test_get_voltage_setpoint_invalid_channel(driver: SiglentSPD3303) -> None:
+    with pytest.raises(ValueError, match="channel must be 1, 2, or 3"):
+        driver.get_voltage_setpoint(channel=4)
+
+
+def test_get_current_setpoint_invalid_channel(driver: SiglentSPD3303) -> None:
+    with pytest.raises(ValueError, match="channel must be 1, 2, or 3"):
+        driver.get_current_setpoint(channel=4)
 
 
 def test_output_enable_invalid_channel(driver: SiglentSPD3303) -> None:

--- a/tests/psu/siglent/test_siglent_spd3303_software.py
+++ b/tests/psu/siglent/test_siglent_spd3303_software.py
@@ -69,6 +69,20 @@ def test_siglent_get_current_returns_float(siglent: SiglentSPD3303, siglent_visa
     assert siglent_visa.query.call_args_list == [call("MEAS:CURR? CH1"), call("SYST:ERR?")]
 
 
+def test_siglent_get_voltage_setpoint_uses_ch_query(siglent: SiglentSPD3303, siglent_visa: MagicMock) -> None:
+    siglent_visa.query.side_effect = ["25.000", '+0,"No error"']
+
+    assert siglent.get_voltage_setpoint(channel=1) == pytest.approx(25.0)
+    assert siglent_visa.query.call_args_list == [call("CH1:VOLT?"), call("SYST:ERR?")]
+
+
+def test_siglent_get_current_setpoint_uses_ch_query(siglent: SiglentSPD3303, siglent_visa: MagicMock) -> None:
+    siglent_visa.query.side_effect = ["0.500", '+0,"No error"']
+
+    assert siglent.get_current_setpoint(channel=2) == pytest.approx(0.5)
+    assert siglent_visa.query.call_args_list == [call("CH2:CURR?"), call("SYST:ERR?")]
+
+
 def test_siglent_output_enable_formats_on_per_channel(siglent: SiglentSPD3303, siglent_visa: MagicMock) -> None:
     siglent.output_enable(True, channel=2)
 
@@ -168,6 +182,28 @@ def test_siglent_get_current_channel_three_unsupported_does_not_send_scpi(
 ) -> None:
     with pytest.raises(FeatureNotSupportedError, match="get_current is not supported for channel 3"):
         siglent.get_current(channel=3)
+
+    siglent_visa.write.assert_not_called()
+    siglent_visa.query.assert_not_called()
+
+
+def test_siglent_get_voltage_setpoint_channel_three_unsupported_does_not_send_scpi(
+    siglent: SiglentSPD3303,
+    siglent_visa: MagicMock,
+) -> None:
+    with pytest.raises(FeatureNotSupportedError, match="get_voltage_setpoint is not supported for channel 3"):
+        siglent.get_voltage_setpoint(channel=3)
+
+    siglent_visa.write.assert_not_called()
+    siglent_visa.query.assert_not_called()
+
+
+def test_siglent_get_current_setpoint_channel_three_unsupported_does_not_send_scpi(
+    siglent: SiglentSPD3303,
+    siglent_visa: MagicMock,
+) -> None:
+    with pytest.raises(FeatureNotSupportedError, match="get_current_setpoint is not supported for channel 3"):
+        siglent.get_current_setpoint(channel=3)
 
     siglent_visa.write.assert_not_called()
     siglent_visa.query.assert_not_called()


### PR DESCRIPTION

<img width="1260" height="1025" alt="Screenshot 2026-08-12 at 2 03 07 PM" src="https://github.com/user-attachments/assets/d739b1de-af8b-4a13-a343-d601127e4078" />
<img width="1260" height="262" alt="Screenshot 2026-08-12 at 2 04 58 PM" src="https://github.com/user-attachments/assets/197028e9-b549-4d31-8473-b62d772a6c36" />
Closes #320.

Implements `get_voltage_setpoint(channel)` / `get_current_setpoint(channel)` on `SiglentSPD3303`, mirroring the `RigolDP800` pattern of reading back the same command node as the `set_*` call, without an argument, rather than the measured value.

## Manual verification

The issue explicitly flagged that this driver has no existing precedent for a non-`MEAS:`-prefixed query, so the command needed confirming against real documentation before writing any hardware-facing code. Found in the Siglent SPD3303X/3303X-E Quick Start manual's SCPI command table:

- Item 7 "VOLTage": `[{CH1|CH2}:]VOLTage?` -- example `CH1:VOLTage?`, typical return `25.000`
- Item 6 "CURRent": `[{CH1|CH2}:]CURRent?` -- example `CH1:CURRent?`, typical return `0.500`

Both are bare floats, same shape as the existing `MEAS:` queries, so no parsing changes were needed -- both new methods go through the existing `_query_checked_float` helper.

## Test plan
- [x] `just check` passes
- [x] Mocked software tests added (`tests/psu/siglent/test_siglent_spd3303_software.py`): happy path for both getters, plus channel-3-unsupported cases
- [x] Hardware test scaffolding added (`tests/psu/siglent/test_siglent_spd3303_hardware.py`), mirroring `RigolDP800`'s setpoint tests -- channel-3/invalid-channel cases too
- [x] Hardware validation against a real SPD3303X/X-E -- passed

## Aside (not fixed here, out of scope)
While reading the manual, noticed its documented `SYSTem:ERRor?` typical return is `0 No Error` (no leading `+`), but this driver's existing `_check_errors` checks for a `+0` prefix. That's pre-existing behavior unrelated to this change -- didn't touch it, but flagging in case it's worth its own ticket (filed as #378).