### PR TITLE
fix(awg): move check_errors() into driver level instead of outer abstraction

### DIFF
--- a/docs/guides/instrumentation/awg.mdx
+++ b/docs/guides/instrumentation/awg.mdx
@@ -254,7 +254,6 @@ def get_output_state(self, channel: int) -> bool:
 
 Optional overrides (raise `NotImplementedError` if not supported):
 
-- **`check_errors()`**: Drain the instrument error queue; raise if any error is pending. `InstroAWG` calls this after every write and tolerates it being unimplemented.
 - **`set_output_load(channel, load)`** / **`get_output_load(channel)`**: Set or read the output load impedance; `None` means high-Z.
 - **`align_phase()`**: Sync the phase of all channels.
 - **`set_modulation(channel, mod_type, shape, magnitude)`**: Configure a channel's modulation. Call `modulation_enable()` to activate it.
@@ -270,6 +269,8 @@ Concrete drivers should hide transport details behind private attributes. For VI
 - **`self._visa.query(command)`**: Send a SCPI query and receive the response string.
 
 `VisaDriver` owns the resource lock. Concurrent `write` / `query` calls against the same driver are serialized automatically. Use `with self._visa.lock():` when a sequence of writes and their error check need to execute atomically.
+
+Error checking (e.g. SCPI's `SYST:ERR?` queue) is a protocol concept, not an instrument concept, so `AWGDriverBase` has no `check_errors` hook — `InstroAWG` never checks for errors itself. Drivers that talk to an instrument with an explicit error queue own that entirely with a private `_check_errors()`. Drivers on transports with no error-queue concept (most non-SCPI protocols raise immediately on a bad command) simply don't need this at all.
 
 See the [VisaDriver guide](/instrumentation/transports/visa) for the full transport reference, covering configuration, terminators, timeouts, serial settings, and the raw-byte I/O path.
 
@@ -297,12 +298,6 @@ class RigolDG1022Z(AWGDriverBase):
     def close(self) -> None:
         self._visa.close()
 
-    def check_errors(self) -> None:
-        err = self._visa.query(":SYST:ERR?")
-        code = err.strip().split(",", 1)[0].lstrip("+")
-        if code != "0":
-            raise RuntimeError(f"Rigol DG1022Z reported error: {err.strip()}")
-
     def set_waveform(self, channel: int, waveform: Waveform) -> None:
         with self._visa.lock():
             if isinstance(waveform, Sine):
@@ -312,6 +307,7 @@ class RigolDG1022Z(AWGDriverBase):
             # ... other Waveform shapes ...
             else:
                 raise ValueError(f"unsupported waveform definition {type(waveform).__name__}")
+            self._check_errors()  # one check per call, not one per write — see note above
 
     def set_amplitude(self, channel: int, amplitude: float, unit: AmplitudeMeasurementUnit) -> None:
         if unit is AmplitudeMeasurementUnit.VP:
@@ -319,8 +315,15 @@ class RigolDG1022Z(AWGDriverBase):
         with self._visa.lock():
             self._visa.write(f":SOUR{channel}:VOLT:UNIT {unit.value}")
             self._visa.write(f":SOUR{channel}:VOLT {amplitude}")
+            self._check_errors()
 
     # ... other required and optional methods ...
+
+    def _check_errors(self) -> None:
+        err = self._visa.query(":SYST:ERR?")
+        code = err.strip().split(",", 1)[0].lstrip("+")
+        if code != "0":
+            raise RuntimeError(f"Rigol DG1022Z reported error: {err.strip()}")
 ```
 
 ## Using a Custom Driver
@@ -346,14 +349,10 @@ class MyCustomAWGDriver(AWGDriverBase):
     def close(self) -> None:
         self._visa.close()
 
-    def check_errors(self) -> None:
-        err = self._visa.query("ERR?")
-        if err != "OK":
-            raise RuntimeError(f"AWG error: {err}")
-
     def set_waveform(self, channel: int, waveform: Waveform) -> None:
         if isinstance(waveform, Sine):
             self._visa.write(f"CH{channel}:WAVE SIN,{waveform.frequency_hz}")
+            self._check_errors()
         else:
             raise ValueError(f"unsupported waveform definition {type(waveform).__name__}")
 
@@ -361,6 +360,11 @@ class MyCustomAWGDriver(AWGDriverBase):
 
     def get_output_state(self, channel: int) -> bool:
         return self._visa.query(f"CH{channel}:OUTP?") == "ON"
+
+    def _check_errors(self) -> None:
+        err = self._visa.query("ERR?")
+        if err != "OK":
+            raise RuntimeError(f"AWG error: {err}")
 
 
 awg = InstroAWG(

--- a/docs/guides/instrumentation/awg.mdx
+++ b/docs/guides/instrumentation/awg.mdx
@@ -270,8 +270,6 @@ Concrete drivers should hide transport details behind private attributes. For VI
 
 `VisaDriver` owns the resource lock. Concurrent `write` / `query` calls against the same driver are serialized automatically. Use `with self._visa.lock():` when a sequence of writes and their error check need to execute atomically.
 
-Error checking (e.g. SCPI's `SYST:ERR?` queue) is a protocol concept, not an instrument concept, so `AWGDriverBase` has no `check_errors` hook — `InstroAWG` never checks for errors itself. Drivers that talk to an instrument with an explicit error queue own that entirely with a private `_check_errors()`. Drivers on transports with no error-queue concept (most non-SCPI protocols raise immediately on a bad command) simply don't need this at all.
-
 See the [VisaDriver guide](/instrumentation/transports/visa) for the full transport reference, covering configuration, terminators, timeouts, serial settings, and the raw-byte I/O path.
 
 For non-VISA instruments, follow the same shape with the protocol client your driver needs. The important part is that the public constructor describes the instrument connection, while the transport object remains an implementation detail.

--- a/docs/guides/instrumentation/awg.mdx
+++ b/docs/guides/instrumentation/awg.mdx
@@ -254,7 +254,6 @@ def get_output_state(self, channel: int) -> bool:
 
 Optional overrides (raise `NotImplementedError` if not supported):
 
-- **`check_errors()`**: Drain the instrument error queue; raise if any error is pending. `InstroAWG` calls this after every write and tolerates it being unimplemented.
 - **`set_output_load(channel, load)`** / **`get_output_load(channel)`**: Set or read the output load impedance; `None` means high-Z.
 - **`align_phase()`**: Sync the phase of all channels.
 - **`set_modulation(channel, mod_type, shape, magnitude)`**: Configure a channel's modulation. Call `modulation_enable()` to activate it.

--- a/docs/guides/instrumentation/awg.mdx
+++ b/docs/guides/instrumentation/awg.mdx
@@ -227,9 +227,6 @@ def open(self) -> None:
 def close(self) -> None:
     """Close the underlying transport."""
 
-def check_errors(self) -> None:
-    """Drain the instrument error queue; raise if any error is pending."""
-
 def set_waveform(self, channel: int, waveform: Waveform) -> None:
     """Program channel with the waveform definition; raise ValueError if the definition is unsupported."""
 
@@ -257,6 +254,7 @@ def get_output_state(self, channel: int) -> bool:
 
 Optional overrides (raise `NotImplementedError` if not supported):
 
+- **`check_errors()`**: Drain the instrument error queue; raise if any error is pending. `InstroAWG` calls this after every write and tolerates it being unimplemented.
 - **`set_output_load(channel, load)`** / **`get_output_load(channel)`**: Set or read the output load impedance; `None` means high-Z.
 - **`align_phase()`**: Sync the phase of all channels.
 - **`set_modulation(channel, mod_type, shape, magnitude)`**: Configure a channel's modulation. Call `modulation_enable()` to activate it.

--- a/packages/instro-unstable/instro/unstable/awg/awg.py
+++ b/packages/instro-unstable/instro/unstable/awg/awg.py
@@ -41,10 +41,6 @@ class AWGDriverBase(abc.ABC):
         """Close the underlying transport."""
 
     @abc.abstractmethod
-    def check_errors(self) -> None:
-        """Check the instrument error queue."""
-
-    @abc.abstractmethod
     def set_waveform(self, channel: int, waveform: Waveform) -> None:
         """Program channel with the waveform definition."""
 
@@ -75,6 +71,10 @@ class AWGDriverBase(abc.ABC):
     @abc.abstractmethod
     def get_output_state(self, channel: int) -> bool:
         """Return True if the output on channel is enabled."""
+
+    def check_errors(self) -> None:
+        """Check the instrument error queue."""
+        raise NotImplementedError(f"check_errors is not implemented for {type(self).__name__}")
 
     def set_output_load(self, channel: int, load: float | None) -> None:
         """Set the output load impedance; None means high-Z."""
@@ -166,7 +166,10 @@ class InstroAWG(Instrument):
 
     def _check_errors(self) -> None:
         """Raise if the driver's error queue holds anything."""
-        self._driver.check_errors()
+        try:
+            self._driver.check_errors()
+        except NotImplementedError:
+            pass
 
     @publish_command
     def _execute_command(

--- a/packages/instro-unstable/instro/unstable/awg/awg.py
+++ b/packages/instro-unstable/instro/unstable/awg/awg.py
@@ -72,10 +72,6 @@ class AWGDriverBase(abc.ABC):
     def get_output_state(self, channel: int) -> bool:
         """Return True if the output on channel is enabled."""
 
-    def check_errors(self) -> None:
-        """Check the instrument error queue."""
-        raise NotImplementedError(f"check_errors is not implemented for {type(self).__name__}")
-
     def set_output_load(self, channel: int, load: float | None) -> None:
         """Set the output load impedance; None means high-Z."""
         raise NotImplementedError(f"set_output_load is not implemented for {type(self).__name__}")
@@ -164,13 +160,6 @@ class InstroAWG(Instrument):
         if not 1 <= channel <= self._num_channels:
             raise ValueError(f"channel {channel} out of range for '{self.name}' (1-{self._num_channels})")
 
-    def _check_errors(self) -> None:
-        """Raise if the driver's error queue holds anything."""
-        try:
-            self._driver.check_errors()
-        except NotImplementedError:
-            pass
-
     @publish_command
     def _execute_command(
         self,
@@ -184,7 +173,6 @@ class InstroAWG(Instrument):
         with self._resource_lock:
             driver_method(channel, value)
             timestamp = time.time_ns()
-            self._check_errors()
         descriptor = f"ch{channel}.{channel_suffix}.cmd"
         return self._package_command(descriptor, value, timestamp, **kwargs)
 
@@ -200,7 +188,6 @@ class InstroAWG(Instrument):
         with self._resource_lock:
             val = driver_method(channel=channel)
             timestamp = time.time_ns()
-            self._check_errors()
         descriptor = f"ch{channel}.{channel_suffix}"
         return self._package_measurement(descriptor, val, timestamp, **kwargs)
 
@@ -237,7 +224,6 @@ class InstroAWG(Instrument):
         with self._resource_lock:
             self._driver.set_waveform(channel=channel, waveform=waveform)
             timestamp = time.time_ns()
-            self._check_errors()
             self._channel_waveforms[channel] = waveform
         published_name = _PUBLISHED_NAMES[type(waveform)]
         params = _waveform_param_channels(waveform)
@@ -259,7 +245,6 @@ class InstroAWG(Instrument):
         self._check_channel(channel)
         with self._resource_lock:
             waveform = self._driver.get_waveform(channel=channel)
-            self._check_errors()
         return waveform
 
     @publish_command
@@ -271,7 +256,6 @@ class InstroAWG(Instrument):
         with self._resource_lock:
             self._driver.set_amplitude(channel=channel, amplitude=amplitude, unit=unit)
             timestamp = time.time_ns()
-            self._check_errors()
         descriptor = f"ch{channel}.amplitude.cmd"
         return self._package_command(descriptor, amplitude, timestamp, unit=unit.value, **kwargs)
 
@@ -280,7 +264,6 @@ class InstroAWG(Instrument):
         self._check_channel(channel)
         with self._resource_lock:
             amplitude = self._driver.get_amplitude(channel=channel)
-            self._check_errors()
         return amplitude
 
     def convert_amplitude(
@@ -310,8 +293,6 @@ class InstroAWG(Instrument):
                     impedance_ohms = self._driver.get_output_load(channel=channel)
                 except NotImplementedError:
                     impedance_ohms = None
-                else:
-                    self._check_errors()
                 if impedance_ohms is None:
                     raise ValueError(f"channel {channel} has no known output load; pass impedance_ohms explicitly")
         return convert_amplitude(amplitude, from_unit, to_unit, waveform, impedance_ohms=impedance_ohms)
@@ -333,7 +314,6 @@ class InstroAWG(Instrument):
         with self._resource_lock:
             self._driver.set_output_load(channel=channel, load=load)
             timestamp = time.time_ns()
-            self._check_errors()
         descriptor = f"ch{channel}.load.cmd"
         load_value = float("inf") if load is None else load
         return self._package_command(descriptor, load_value, timestamp, **kwargs)
@@ -344,7 +324,6 @@ class InstroAWG(Instrument):
         with self._resource_lock:
             self._driver.align_phase()
             timestamp = time.time_ns()
-            self._check_errors()
         descriptor = "phase.align.cmd"
         return self._package_command(descriptor, "ALIGN", timestamp, **kwargs)
 
@@ -365,7 +344,6 @@ class InstroAWG(Instrument):
         with self._resource_lock:
             val = self._driver.get_output_load(channel=channel)
             timestamp = time.time_ns()
-            self._check_errors()
         load_float = float("inf") if val is None else val
         descriptor = f"ch{channel}.load"
         return self._package_measurement(descriptor, load_float, timestamp, **kwargs)
@@ -389,7 +367,6 @@ class InstroAWG(Instrument):
         with self._resource_lock:
             self._driver.set_modulation(channel=channel, mod_type=mod_type, shape=shape, magnitude=magnitude)
             timestamp = time.time_ns()
-            self._check_errors()
         descriptor = f"ch{channel}.modulation.cmd"
         return self._package_command(descriptor, magnitude, timestamp, mod_type=mod_type.value, **kwargs)
 
@@ -400,7 +377,6 @@ class InstroAWG(Instrument):
         with self._resource_lock:
             self._driver.modulation_enable(channel=channel, enable=enable)
             timestamp = time.time_ns()
-            self._check_errors()
         descriptor = f"ch{channel}.modulation_enabled.cmd"
         return self._package_command(descriptor, enable, timestamp, **kwargs)
 
@@ -409,7 +385,6 @@ class InstroAWG(Instrument):
         self._check_channel(channel)
         with self._resource_lock:
             mod_type = self._driver.get_modulation_type(channel=channel)
-            self._check_errors()
         return mod_type
 
     def get_modulation_state(self, channel: int, **kwargs) -> Measurement | None:

--- a/packages/instro-unstable/instro/unstable/awg/awg.py
+++ b/packages/instro-unstable/instro/unstable/awg/awg.py
@@ -72,10 +72,6 @@ class AWGDriverBase(abc.ABC):
     def get_output_state(self, channel: int) -> bool:
         """Return True if the output on channel is enabled."""
 
-    def check_errors(self) -> None:
-        """Check the instrument error queue."""
-        raise NotImplementedError(f"check_errors is not implemented for {type(self).__name__}")
-
     def set_output_load(self, channel: int, load: float | None) -> None:
         """Set the output load impedance; None means high-Z."""
         raise NotImplementedError(f"set_output_load is not implemented for {type(self).__name__}")

--- a/packages/instro-unstable/instro/unstable/awg/drivers/rigol_dg1022z.py
+++ b/packages/instro-unstable/instro/unstable/awg/drivers/rigol_dg1022z.py
@@ -46,13 +46,6 @@ class RigolDG1022Z(AWGDriverBase):
     def close(self) -> None:
         self._visa.close()
 
-    def check_errors(self) -> None:
-        """Query ``:SYSTem:ERRor?`` once and raise on a non-zero code. Does not drain the queue."""
-        err = self._visa.query(":SYST:ERR?")
-        code = err.strip().split(",", 1)[0].lstrip("+")
-        if code != "0":
-            raise RuntimeError(f"Rigol DG1022Z reported error: {err.strip()}")
-
     def set_waveform(self, channel: int, waveform: Waveform) -> None:
         _check_channel(channel)
         with self._visa.lock():
@@ -77,7 +70,6 @@ class RigolDG1022Z(AWGDriverBase):
                 self._visa.write(f":SOUR{channel}:FUNC PULS")
                 self._visa.write(f":SOUR{channel}:FREQ {waveform.frequency_hz}")
                 self._visa.write(f":SOUR{channel}:FUNC:PULS:WIDT {waveform.width_s}")
-
             elif isinstance(waveform, Arbitrary):
                 # Use per-point downloads to allow both USB and Ethernet compatibility and a higher download size ceiling.
                 num_points = len(waveform.samples)
@@ -86,21 +78,21 @@ class RigolDG1022Z(AWGDriverBase):
                         f"the DG1022Z accepts {_ARB_MIN_POINTS} to {_ARB_MAX_POINTS} arbitrary points"
                         f" per download, got {num_points}"
                     )
-                self._visa.write(f":SOUR{channel}:APPL:ARB {waveform.sample_rate_hz}")
-                self.check_errors()
-                self._visa.write(f":SOUR{channel}:TRAC:DATA:POIN VOLATILE,{num_points}")
-                self.check_errors()
+                self._write_checked(f":SOUR{channel}:APPL:ARB {waveform.sample_rate_hz}")
+                self._write_checked(f":SOUR{channel}:TRAC:DATA:POIN VOLATILE,{num_points}")
                 for point, sample in enumerate(waveform.samples, start=1):
                     decimal_value = round((sample + 1) / 2 * 16383)
-                    self._visa.write(f":SOUR{channel}:TRAC:DATA:VAL VOLATILE,{point},{decimal_value}")
                     # error queue is not drained, so checking every point avoids lost error messages in exchange for a longer runtime
-                    self.check_errors()
+                    self._write_checked(f":SOUR{channel}:TRAC:DATA:VAL VOLATILE,{point},{decimal_value}")
                 self._arb_waveforms[channel] = waveform
             elif isinstance(waveform, StaticValue):
                 self._visa.write(f":SOUR{channel}:FUNC DC")
                 self._visa.write(f":SOUR{channel}:VOLT:OFFS {waveform.value}")
             else:
                 raise ValueError(f"unsupported waveform definition {type(waveform).__name__}")
+
+            if not isinstance(waveform, Arbitrary):
+                self._check_errors()
 
     def get_waveform(self, channel: int) -> Waveform:
         _check_channel(channel)
@@ -109,29 +101,33 @@ class RigolDG1022Z(AWGDriverBase):
             fields = resp.split(",")
             name = fields[0]
             if name == "SIN":
-                return Sine(frequency_hz=float(fields[1]), phase_deg=float(fields[4]))
-            if name == "SQU":
+                result: Waveform = Sine(frequency_hz=float(fields[1]), phase_deg=float(fields[4]))
+            elif name == "SQU":
                 duty = float(self._visa.query(f":SOUR{channel}:FUNC:SQU:DCYC?"))
-                return Square(frequency_hz=float(fields[1]), duty_cycle_pct=duty, phase_deg=float(fields[4]))
-            if name == "RAMP":
+                result = Square(frequency_hz=float(fields[1]), duty_cycle_pct=duty, phase_deg=float(fields[4]))
+            elif name == "RAMP":
                 symmetry = float(self._visa.query(f":SOUR{channel}:FUNC:RAMP:SYMM?"))
                 if symmetry == float(_SAWTOOTH_SYMMETRY_PCT):
-                    return Sawtooth(frequency_hz=float(fields[1]), phase_deg=float(fields[4]))
-                return Triangle(frequency_hz=float(fields[1]), phase_deg=float(fields[4]))
-            if name == "PULSE":
+                    result = Sawtooth(frequency_hz=float(fields[1]), phase_deg=float(fields[4]))
+                else:
+                    result = Triangle(frequency_hz=float(fields[1]), phase_deg=float(fields[4]))
+            elif name == "PULSE":
                 width = float(self._visa.query(f":SOUR{channel}:FUNC:PULS:WIDT?"))
-                return Pulse(frequency_hz=float(fields[1]), width_s=width)
-            if name == "DC":
-                return StaticValue(value=float(fields[3]))
-            if name == "USER":
+                result = Pulse(frequency_hz=float(fields[1]), width_s=width)
+            elif name == "DC":
+                result = StaticValue(value=float(fields[3]))
+            elif name == "USER":
                 arb = self._arb_waveforms.get(channel)
                 if arb is None:
                     raise RuntimeError(
                         f"channel {channel} outputs an arbitrary waveform not programmed by this driver;"
                         " sample data is not readable"
                     )
-                return arb
-            raise ValueError(f"Rigol DG1022Z reported unsupported waveform '{name}'")
+                result = arb
+            else:
+                raise ValueError(f"Rigol DG1022Z reported unsupported waveform '{name}'")
+            self._check_errors()
+            return result
 
     def set_amplitude(self, channel: int, amplitude: float, unit: AmplitudeMeasurementUnit) -> None:
         _check_channel(channel)
@@ -140,17 +136,21 @@ class RigolDG1022Z(AWGDriverBase):
         with self._visa.lock():
             self._visa.write(f":SOUR{channel}:VOLT:UNIT {unit.value}")
             self._visa.write(f":SOUR{channel}:VOLT {amplitude}")
+            self._check_errors()
 
     def get_amplitude(self, channel: int) -> tuple[float, AmplitudeMeasurementUnit]:
         _check_channel(channel)
         with self._visa.lock():
             unit = AmplitudeMeasurementUnit(self._visa.query(f":SOUR{channel}:VOLT:UNIT?").strip())
             amplitude = float(self._visa.query(f":SOUR{channel}:VOLT?"))
+            self._check_errors()
         return amplitude, unit
 
     def set_offset(self, channel: int, offset: float) -> None:
         _check_channel(channel)
-        self._visa.write(f":SOUR{channel}:VOLT:OFFS {offset}")
+        with self._visa.lock():
+            self._visa.write(f":SOUR{channel}:VOLT:OFFS {offset}")
+            self._check_errors()
 
     def get_offset(self, channel: int) -> float:
         _check_channel(channel)
@@ -159,31 +159,45 @@ class RigolDG1022Z(AWGDriverBase):
             fields = resp.split(",")
             if fields[0] == "DC":
                 # In DC mode VOLT:OFFS? always reads 0 on the DG1000Z; only APPL? carries the level.
-                return float(fields[3])
-            return float(self._visa.query(f":SOUR{channel}:VOLT:OFFS?"))
+                result = float(fields[3])
+            else:
+                result = float(self._visa.query(f":SOUR{channel}:VOLT:OFFS?"))
+            self._check_errors()
+        return result
 
     def output_enable(self, channel: int, enable: bool) -> None:
         _check_channel(channel)
-        self._visa.write(f":OUTP{channel} ON" if enable else f":OUTP{channel} OFF")
+        with self._visa.lock():
+            self._visa.write(f":OUTP{channel} ON" if enable else f":OUTP{channel} OFF")
+            self._check_errors()
 
     def get_output_state(self, channel: int) -> bool:
         _check_channel(channel)
-        return self._visa.query(f":OUTP{channel}?").strip() == "ON"
+        with self._visa.lock():
+            result = self._visa.query(f":OUTP{channel}?").strip() == "ON"
+            self._check_errors()
+        return result
 
     def set_output_load(self, channel: int, load: float | None) -> None:
         _check_channel(channel)
-        if load is None:
-            self._visa.write(f":OUTP{channel}:LOAD INF")
-        else:
-            self._visa.write(f":OUTP{channel}:LOAD {load:g}")
+        with self._visa.lock():
+            if load is None:
+                self._visa.write(f":OUTP{channel}:LOAD INF")
+            else:
+                self._visa.write(f":OUTP{channel}:LOAD {load:g}")
+            self._check_errors()
 
     def get_output_load(self, channel: int) -> float | None:
         _check_channel(channel)
-        load = float(self._visa.query(f":OUTP{channel}:LOAD?"))
+        with self._visa.lock():
+            load = float(self._visa.query(f":OUTP{channel}:LOAD?"))
+            self._check_errors()
         return None if load >= _HIGH_Z_SENTINEL else load
 
     def align_phase(self) -> None:
-        self._visa.write(":SOUR1:PHAS:SYNC")
+        with self._visa.lock():
+            self._visa.write(":SOUR1:PHAS:SYNC")
+            self._check_errors()
 
     def set_modulation(self, channel: int, mod_type: ModulationType, shape: Waveform, magnitude: float) -> None:
         _check_channel(channel)
@@ -217,29 +231,43 @@ class RigolDG1022Z(AWGDriverBase):
             else:
                 raise AssertionError(f"unhandled ModulationType {mod_type}")
             self._visa.write(f":SOUR{channel}:MOD:TYP {mod_type.value}")
-            self.check_errors()
+            self._check_errors()
 
     def modulation_enable(self, channel: int, enable: bool) -> None:
         _check_channel(channel)
         with self._visa.lock():
             self._visa.write(f":SOUR{channel}:MOD:STAT {'ON' if enable else 'OFF'}")
-            self.check_errors()
+            self._check_errors()
 
     def get_modulation_type(self, channel: int) -> ModulationType:
         _check_channel(channel)
         with self._visa.lock():
-            mod_type = ModulationType(self._visa.query(f":SOUR{channel}:MOD:TYP?").strip())
-        return mod_type
+            result = ModulationType(self._visa.query(f":SOUR{channel}:MOD:TYP?").strip())
+            self._check_errors()
+        return result
 
     def get_modulation_state(self, channel: int) -> bool:
         _check_channel(channel)
         with self._visa.lock():
-            enabled = self._visa.query(f":SOUR{channel}:MOD:STAT?").strip() == "ON"
-        return enabled
+            result = self._visa.query(f":SOUR{channel}:MOD:STAT?").strip() == "ON"
+            self._check_errors()
+        return result
 
     def _write_frequency_and_phase(self, channel: int, frequency_hz: float, phase_deg: float) -> None:
         self._visa.write(f":SOUR{channel}:FREQ {frequency_hz}")
         self._visa.write(f":SOUR{channel}:PHAS {phase_deg % 360.0}")
+
+    def _write_checked(self, command: str) -> None:
+        with self._visa.lock():
+            self._visa.write(command)
+            self._check_errors()
+
+    def _check_errors(self) -> None:
+        """Query :SYSTem:ERRor? once and raise on a non-zero code. Does not drain the queue."""
+        err = self._visa.query(":SYST:ERR?")
+        code = err.strip().split(",", 1)[0].lstrip("+")
+        if code != "0":
+            raise RuntimeError(f"Rigol DG1022Z reported error: {err.strip()}")
 
 
 def _check_channel(channel: int) -> None:

--- a/tests/unstable/awg/rigol/test_rigol_dg1022z_hardware.py
+++ b/tests/unstable/awg/rigol/test_rigol_dg1022z_hardware.py
@@ -73,7 +73,7 @@ def _reset_driver(driver: RigolDG1022Z) -> None:
     driver._visa.write("*RST")
     time.sleep(0.5)
     driver._visa.write("*CLS")
-    driver.check_errors()
+    driver._check_errors()
 
 
 def _assert_waveform_matches(readback: Waveform, expected_type: type, checks: dict[str, float]) -> None:
@@ -124,7 +124,7 @@ def test_01_connect_to_awg(driver: RigolDG1022Z) -> None:
     print(f"\nIDN: {idn.strip()}")
 
     assert "DG1" in idn.upper()
-    driver.check_errors()
+    driver._check_errors()
 
 
 # ---------------------------------------------------------------------------
@@ -168,7 +168,7 @@ def test_02_set_and_get_waveform_roundtrip(
     checks: dict[str, float],
 ) -> None:
     driver.set_waveform(channel, waveform)
-    driver.check_errors()
+    driver._check_errors()
 
     readback = driver.get_waveform(channel)
     _assert_waveform_matches(readback, expected_type, checks)
@@ -188,13 +188,13 @@ def test_03_set_waveform_rejects_invalid_input(
     with pytest.raises(ValueError, match=match):
         driver.set_waveform(channel, waveform)
 
-    driver.check_errors()
+    driver._check_errors()
 
 
 def test_04_arbitrary_waveform_download_and_cached_readback(driver: RigolDG1022Z) -> None:
     arbitrary = Arbitrary(samples=_ARB_SAMPLES, sample_rate_hz=100_000.0)
     driver.set_waveform(1, arbitrary)
-    driver.check_errors()
+    driver._check_errors()
 
     assert driver.get_waveform(1) is arbitrary
 
@@ -218,7 +218,7 @@ def test_05_amplitude_roundtrip(driver: RigolDG1022Z, amplitude: float, unit: Am
     if unit is AmplitudeMeasurementUnit.DBM:
         driver.set_output_load(1, 50.0)
     driver.set_amplitude(1, amplitude, unit)
-    driver.check_errors()
+    driver._check_errors()
 
     readback_amplitude, readback_unit = driver.get_amplitude(1)
     assert readback_unit is unit
@@ -232,7 +232,7 @@ def test_06_set_amplitude_rejects_vp_unit(driver: RigolDG1022Z) -> None:
     with pytest.raises(ValueError, match="no VP amplitude unit"):
         driver.set_amplitude(1, TEST_AMPLITUDE_VPP, AmplitudeMeasurementUnit.VP)
 
-    driver.check_errors()
+    driver._check_errors()
 
 
 @pytest.mark.parametrize("channel", CHANNELS, ids=lambda channel: f"channel_{channel}")
@@ -240,7 +240,7 @@ def test_07_offset_roundtrip(driver: RigolDG1022Z, channel: int) -> None:
     driver.set_waveform(channel, Sine(frequency_hz=TEST_FREQUENCY_HZ))
     driver.set_amplitude(channel, TEST_AMPLITUDE_VPP, AmplitudeMeasurementUnit.VPP)
     driver.set_offset(channel, TEST_OFFSET_V)
-    driver.check_errors()
+    driver._check_errors()
 
     assert driver.get_offset(channel) == pytest.approx(TEST_OFFSET_V, rel=0.01)
 
@@ -251,7 +251,7 @@ def test_08_output_enable_toggle(driver: RigolDG1022Z, channel: int) -> None:
     driver.set_amplitude(channel, TEST_AMPLITUDE_VPP, AmplitudeMeasurementUnit.VPP)
     try:
         driver.output_enable(channel, True)
-        driver.check_errors()
+        driver._check_errors()
         assert driver.get_output_state(channel) is True
     finally:
         driver.output_enable(channel, False)
@@ -261,11 +261,11 @@ def test_08_output_enable_toggle(driver: RigolDG1022Z, channel: int) -> None:
 
 def test_09_output_load_roundtrip_and_high_z(driver: RigolDG1022Z) -> None:
     driver.set_output_load(1, 50.0)
-    driver.check_errors()
+    driver._check_errors()
     assert driver.get_output_load(1) == pytest.approx(50.0)
 
     driver.set_output_load(1, None)
-    driver.check_errors()
+    driver._check_errors()
     assert driver.get_output_load(1) is None
 
 
@@ -274,7 +274,7 @@ def test_10_align_phase_completes_without_error(driver: RigolDG1022Z) -> None:
         driver.set_waveform(channel, Sine(frequency_hz=TEST_FREQUENCY_HZ, phase_deg=0.0))
 
     driver.align_phase()
-    driver.check_errors()
+    driver._check_errors()
 
 
 def test_11_check_errors_raises_after_invalid_command(driver: RigolDG1022Z) -> None:
@@ -282,7 +282,7 @@ def test_11_check_errors_raises_after_invalid_command(driver: RigolDG1022Z) -> N
 
     try:
         with pytest.raises(RuntimeError, match="Rigol DG1022Z reported error"):
-            driver.check_errors()
+            driver._check_errors()
     finally:
         driver._visa.write("*CLS")
 
@@ -316,13 +316,13 @@ def test_12_set_modulation_and_modulation_enable_reports_type_specific_stat(
     driver.set_waveform(1, carrier)
     driver.set_modulation(1, mod_type, shape, magnitude)
     driver.modulation_enable(1, True)
-    driver.check_errors()
+    driver._check_errors()
 
     try:
         assert driver._visa.query(f":SOUR1:{mod_type.value}:STAT?").strip() == "ON"
     finally:
         driver.modulation_enable(1, False)
-    driver.check_errors()
+    driver._check_errors()
 
     assert driver._visa.query(f":SOUR1:{mod_type.value}:STAT?").strip() == "OFF"
 
@@ -360,7 +360,7 @@ def test_13_set_modulation_rejects_invalid_input(
     with pytest.raises(ValueError, match=match):
         driver.set_modulation(1, mod_type, shape, magnitude)
 
-    driver.check_errors()
+    driver._check_errors()
 
 
 def test_14_modulation_enable_re_arms_after_disable_without_remodulating(driver: RigolDG1022Z) -> None:
@@ -370,8 +370,8 @@ def test_14_modulation_enable_re_arms_after_disable_without_remodulating(driver:
     driver.modulation_enable(1, False)
     try:
         driver.modulation_enable(1, True)
-        driver.check_errors()
+        driver._check_errors()
         assert driver._visa.query(":SOUR1:AM:STAT?").strip() == "ON"
     finally:
         driver.modulation_enable(1, False)
-    driver.check_errors()
+    driver._check_errors()

--- a/tests/unstable/awg/rigol/test_rigol_dg1022z_software.py
+++ b/tests/unstable/awg/rigol/test_rigol_dg1022z_software.py
@@ -26,6 +26,8 @@ _SINE_CARRIER_APPL_RESPONSE = '"SIN,1.000000E+03,5.000000E+00,0.000000E+00,0.000
 _PULSE_CARRIER_APPL_RESPONSE = '"PULSE,1.000000E+03,1.000000E+00,0.000000E+00,0.000000E+00"'
 _ARBITRARY_CARRIER_APPL_RESPONSE = '"USER,1.000000E+03,1.000000E+00,0.000000E+00,0.000000E+00"'
 
+_NO_ERROR = '0,"No error"'
+
 
 @pytest.fixture
 def rigol_visa_cls() -> Iterator[MagicMock]:
@@ -35,12 +37,34 @@ def rigol_visa_cls() -> Iterator[MagicMock]:
 
 @pytest.fixture
 def rigol_visa(rigol_visa_cls: MagicMock) -> MagicMock:
-    return rigol_visa_cls.return_value
+    visa = rigol_visa_cls.return_value
+    # Every write/read the driver issues is immediately followed by its own :SYST:ERR? check now
+    # that error-checking is private to the driver; default that check to clean so tests that
+    # don't care about error handling don't have to stub it themselves.
+    visa.query.return_value = _NO_ERROR
+    return visa
 
 
 @pytest.fixture
 def rigol(rigol_visa_cls: MagicMock) -> RigolDG1022Z:
     return RigolDG1022Z("TCPIP0::rigol::INSTR")
+
+
+def _query_sequence(rigol_visa: MagicMock, real_responses: list[str]) -> None:
+    """Feed `real_responses` to the driver's real queries in order; :SYST:ERR? checks always read clean."""
+    responses = iter(real_responses)
+
+    def fake_query(command: str) -> str:
+        if command == ":SYST:ERR?":
+            return _NO_ERROR
+        return next(responses)
+
+    rigol_visa.query.side_effect = fake_query
+
+
+def _real_query_calls(rigol_visa: MagicMock) -> list:
+    """The driver's actual queries, excluding the interleaved :SYST:ERR? error checks."""
+    return [c for c in rigol_visa.query.call_args_list if c != call(":SYST:ERR?")]
 
 
 def _mock_carrier_query(
@@ -51,7 +75,7 @@ def _mock_carrier_query(
     mod_stat_response: str = "OFF",
     pulse_width_response: str = "2.000000E-04",
 ) -> None:
-    """Answer get_waveform(), check_errors(), and :MOD:TYP?/:MOD:STAT? queries for set_modulation() tests."""
+    """Answer get_waveform(), :SYST:ERR? checks, and :MOD:TYP?/:MOD:STAT? queries for set_modulation() tests."""
 
     def fake_query(command: str) -> str:
         if command == ":SYST:ERR?":
@@ -95,7 +119,7 @@ def test_02_open_close_delegate_to_visa(rigol: RigolDG1022Z, rigol_visa: MagicMo
 def test_03_check_errors_accepts_zero_codes(rigol: RigolDG1022Z, rigol_visa: MagicMock, response: str) -> None:
     rigol_visa.query.return_value = response
 
-    rigol.check_errors()
+    rigol._check_errors()
 
     rigol_visa.query.assert_called_once_with(":SYST:ERR?")
 
@@ -104,7 +128,7 @@ def test_04_check_errors_raises_on_nonzero_code(rigol: RigolDG1022Z, rigol_visa:
     rigol_visa.query.return_value = '-113,"Undefined header"'
 
     with pytest.raises(RuntimeError, match=r'Rigol DG1022Z reported error: -113,"Undefined header"'):
-        rigol.check_errors()
+        rigol._check_errors()
 
 
 # ---------------------------------------------------------------------------
@@ -267,28 +291,28 @@ def test_09_get_waveform_parses_shape_specific_fields(
     expected_queries: list,
     expected: Waveform,
 ) -> None:
-    rigol_visa.query.side_effect = responses
+    _query_sequence(rigol_visa, responses)
 
     assert rigol.get_waveform(1) == expected
-    assert rigol_visa.query.call_args_list == expected_queries
+    assert _real_query_calls(rigol_visa) == expected_queries
 
 
 def test_10_get_waveform_arbitrary_cache_and_unknown_shape_edge_cases(
     rigol: RigolDG1022Z, rigol_visa: MagicMock
 ) -> None:
     arbitrary = Arbitrary(samples=_ARB_SAMPLES, sample_rate_hz=1000000.0)
-    rigol_visa.query.return_value = '0,"No error"'
     rigol.set_waveform(1, arbitrary)
 
     # Channel 1 outputs USER and the driver has the samples cached from set_waveform above.
-    rigol_visa.query.return_value = '"USER,1.000000E+03,1.000000E+00,0.000000E+00,0.000000E+00"'
+    _query_sequence(rigol_visa, ['"USER,1.000000E+03,1.000000E+00,0.000000E+00,0.000000E+00"'])
     assert rigol.get_waveform(1) is arbitrary
 
     # Channel 2 also outputs USER, but this driver never programmed it.
+    _query_sequence(rigol_visa, ['"USER,1.000000E+03,1.000000E+00,0.000000E+00,0.000000E+00"'])
     with pytest.raises(RuntimeError, match="not programmed by this driver"):
         rigol.get_waveform(2)
 
-    rigol_visa.query.return_value = '"NOIS,DEF,1.000000E+00,0.000000E+00"'
+    _query_sequence(rigol_visa, ['"NOIS,DEF,1.000000E+00,0.000000E+00"'])
     with pytest.raises(ValueError, match="unsupported waveform 'NOIS'"):
         rigol.get_waveform(1)
 
@@ -302,9 +326,9 @@ def test_11_amplitude_roundtrip_writes_and_parses_unit_and_value(rigol: RigolDG1
     rigol.set_amplitude(1, 2.5, AmplitudeMeasurementUnit.VPP)
     assert rigol_visa.write.call_args_list == [call(":SOUR1:VOLT:UNIT VPP"), call(":SOUR1:VOLT 2.5")]
 
-    rigol_visa.query.side_effect = ["VRMS\n", "1.000000E+00"]
+    _query_sequence(rigol_visa, ["VRMS\n", "1.000000E+00"])
     amplitude, unit = rigol.get_amplitude(2)
-    assert rigol_visa.query.call_args_list == [call(":SOUR2:VOLT:UNIT?"), call(":SOUR2:VOLT?")]
+    assert _real_query_calls(rigol_visa) == [call(":SOUR2:VOLT:UNIT?"), call(":SOUR2:VOLT?")]
     assert amplitude == pytest.approx(1.0)
     assert unit is AmplitudeMeasurementUnit.VRMS
 
@@ -320,20 +344,23 @@ def test_13_offset_roundtrip_uses_offset_commands(rigol: RigolDG1022Z, rigol_vis
     rigol.set_offset(2, 0.5)
     rigol_visa.write.assert_called_once_with(":SOUR2:VOLT:OFFS 0.5")
 
-    rigol_visa.query.side_effect = [
-        '"SIN,1.000000E+03,1.000000E+00,0.000000E+00,0.000000E+00"',
-        "5.000000E-01",
-    ]
+    _query_sequence(
+        rigol_visa,
+        [
+            '"SIN,1.000000E+03,1.000000E+00,0.000000E+00,0.000000E+00"',
+            "5.000000E-01",
+        ],
+    )
     assert rigol.get_offset(2) == pytest.approx(0.5)
-    assert rigol_visa.query.call_args_list == [call(":SOUR2:APPL?"), call(":SOUR2:VOLT:OFFS?")]
+    assert _real_query_calls(rigol_visa) == [call(":SOUR2:APPL?"), call(":SOUR2:VOLT:OFFS?")]
 
 
 def test_14_get_offset_dc_mode_uses_apply_reply(rigol: RigolDG1022Z, rigol_visa: MagicMock) -> None:
     # In DC mode VOLT:OFFS? always reads 0 on the DG1000Z; only APPL? carries the level.
-    rigol_visa.query.return_value = '"DC,DEF,DEF,7.500000E-01"'
+    _query_sequence(rigol_visa, ['"DC,DEF,DEF,7.500000E-01"'])
 
     assert rigol.get_offset(1) == pytest.approx(0.75)
-    rigol_visa.query.assert_called_once_with(":SOUR1:APPL?")
+    assert _real_query_calls(rigol_visa) == [call(":SOUR1:APPL?")]
 
 
 def test_15_output_enable_formats_on_off_and_parses_state(rigol: RigolDG1022Z, rigol_visa: MagicMock) -> None:
@@ -341,11 +368,11 @@ def test_15_output_enable_formats_on_off_and_parses_state(rigol: RigolDG1022Z, r
     rigol.output_enable(2, False)
     assert rigol_visa.write.call_args_list == [call(":OUTP1 ON"), call(":OUTP2 OFF")]
 
-    rigol_visa.query.return_value = "ON\n"
+    _query_sequence(rigol_visa, ["ON\n"])
     assert rigol.get_output_state(1) is True
-    rigol_visa.query.assert_called_once_with(":OUTP1?")
+    assert _real_query_calls(rigol_visa) == [call(":OUTP1?")]
 
-    rigol_visa.query.return_value = "OFF\n"
+    _query_sequence(rigol_visa, ["OFF\n"])
     assert rigol.get_output_state(1) is False
 
 
@@ -354,11 +381,11 @@ def test_16_output_load_roundtrip_and_high_z(rigol: RigolDG1022Z, rigol_visa: Ma
     rigol.set_output_load(1, None)
     assert rigol_visa.write.call_args_list == [call(":OUTP1:LOAD 50"), call(":OUTP1:LOAD INF")]
 
-    rigol_visa.query.return_value = "5.000000E+01"
+    _query_sequence(rigol_visa, ["5.000000E+01"])
     assert rigol.get_output_load(1) == pytest.approx(50.0)
-    rigol_visa.query.assert_called_once_with(":OUTP1:LOAD?")
+    assert _real_query_calls(rigol_visa) == [call(":OUTP1:LOAD?")]
 
-    rigol_visa.query.return_value = "9.900000E+37"
+    _query_sequence(rigol_visa, ["9.900000E+37"])
     assert rigol.get_output_load(1) is None
 
 
@@ -565,7 +592,7 @@ def test_22_get_modulation_type_and_get_modulation_state_are_independent_per_cha
         ":SOUR2:MOD:TYP?": "FSK",
         ":SOUR2:MOD:STAT?": "ON",
     }
-    rigol_visa.query.side_effect = lambda command: responses[command]
+    rigol_visa.query.side_effect = lambda command: responses.get(command, _NO_ERROR)
 
     assert rigol.get_modulation_type(1) == ModulationType.AM
     assert rigol.get_modulation_state(1) is False

--- a/tests/unstable/awg/rigol/test_rigol_to_tektronix.py
+++ b/tests/unstable/awg/rigol/test_rigol_to_tektronix.py
@@ -104,14 +104,14 @@ def _drive_waveform(rigol: RigolDG1022Z, waveform: Waveform, amplitude_vpp: floa
     rigol.set_waveform(AWG_CHANNEL, waveform)
     if not isinstance(waveform, StaticValue):
         rigol.set_amplitude(AWG_CHANNEL, amplitude_vpp, AmplitudeMeasurementUnit.VPP)
-    rigol.check_errors()
+    rigol._check_errors()
 
 
 def _enable_and_settle(
     rigol: RigolDG1022Z, scope: InstroScope, vertical_scale: float, horizontal_scale: float, trigger_level: float
 ) -> None:
     rigol.output_enable(AWG_CHANNEL, True)
-    rigol.check_errors()
+    rigol._check_errors()
     scope.set_vertical_scale(vertical_scale, channel=SCOPE_CHANNEL)
     scope.set_horizontal_scale(horizontal_scale)
     scope.set_trigger_level(trigger_level)
@@ -155,7 +155,7 @@ def reset_rigol_before_each_test(rigol: RigolDG1022Z) -> None:
     rigol._visa.write("*RST")
     time.sleep(0.5)
     rigol._visa.write("*CLS")
-    rigol.check_errors()
+    rigol._check_errors()
     # Direct BNC into the scope's high-Z input, with no external 50 ohm terminator: without this
     # the Rigol assumes a 50 ohm load and the scope reads ~2x the programmed Vpp (open-circuit
     # doubling from the AWG's internal 50 ohm source impedance).
@@ -208,7 +208,7 @@ def scope() -> Iterator[InstroScope]:
 
 def test_01_connects_to_both_instruments(rigol: RigolDG1022Z, scope: InstroScope) -> None:
     """Confirm both VISA sessions are open and responding, before checking what they identify as."""
-    rigol.check_errors()
+    rigol._check_errors()
     scope.get_horizontal_scale()
 
 
@@ -219,7 +219,7 @@ def test_02_identifies_both_instruments(rigol: RigolDG1022Z, scope: InstroScope)
 
     assert "DG1" in awg_idn.upper()
     assert "TEK" in scope_idn.upper()
-    rigol.check_errors()
+    rigol._check_errors()
 
 
 @pytest.mark.parametrize(
@@ -321,7 +321,7 @@ def test_08_all_modulation_types_signal_present(
     _drive_waveform(rigol, Square(frequency_hz=TEST_FREQUENCY_HZ))
     rigol.set_modulation(AWG_CHANNEL, mod_type, shape, 50.0)
     rigol.modulation_enable(AWG_CHANNEL, True)
-    rigol.check_errors()
+    rigol._check_errors()
     try:
         _enable_and_settle(rigol, scope, TEST_AMPLITUDE_VPP / 4.0, STANDARD_HORIZONTAL_S_PER_DIV, trigger_level=0.0)
         measured_vpp = _measure(scope, ScopeMeasurementType.VPP)

--- a/tests/unstable/awg/test_awg.py
+++ b/tests/unstable/awg/test_awg.py
@@ -83,7 +83,6 @@ def test_01_awg_driver_base_contract_enforces_instantiation_rules() -> None:
 @pytest.mark.parametrize(
     ("method_name", "args"),
     [
-        ("check_errors", ()),
         ("set_output_load", (1, 50.0)),
         ("get_output_load", (1,)),
         ("align_phase", ()),
@@ -177,14 +176,6 @@ def test_04_helper_tags_avoid_collision_with_positional_params(awg: InstroAWG) -
     with pytest.raises(RuntimeError, match="instrument error queue not empty"):
         awg.set_waveform(2, Sine(frequency_hz=1000.0))
     assert 2 not in awg._channel_waveforms
-
-
-def test_04b_check_errors_is_optional(mock_driver: MagicMock) -> None:
-    """A driver that doesn't implement check_errors must not break other calls."""
-    mock_driver.check_errors.side_effect = NotImplementedError("check_errors is not implemented for _NoErrorCheck")
-    awg = InstroAWG(name="test_awg", driver=mock_driver, num_channels=2)
-    awg.set_waveform(1, Sine(frequency_hz=1000.0))
-    awg.get_output_state(1)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unstable/awg/test_awg.py
+++ b/tests/unstable/awg/test_awg.py
@@ -32,9 +32,6 @@ class _MinimalAWGDriver(AWGDriverBase):
     def close(self) -> None:
         pass
 
-    def check_errors(self) -> None:
-        pass
-
     def set_waveform(self, channel: int, waveform: Waveform) -> None:
         pass
 
@@ -84,6 +81,7 @@ def test_01_awg_driver_base_contract_enforces_instantiation_rules() -> None:
 @pytest.mark.parametrize(
     ("method_name", "args"),
     [
+        ("check_errors", ()),
         ("set_output_load", (1, 50.0)),
         ("get_output_load", (1,)),
         ("align_phase", ()),
@@ -187,6 +185,14 @@ def test_04_check_errors_called_propagates_and_helper_tags_avoid_collision(
     with pytest.raises(RuntimeError, match="instrument error queue not empty"):
         awg.set_waveform(2, Sine(frequency_hz=1000.0))
     assert 2 not in awg._channel_waveforms
+
+
+def test_04b_check_errors_is_optional(mock_driver: MagicMock) -> None:
+    """A driver that doesn't implement check_errors must not break other calls."""
+    mock_driver.check_errors.side_effect = NotImplementedError("check_errors is not implemented for _NoErrorCheck")
+    awg = InstroAWG(name="test_awg", driver=mock_driver, num_channels=2)
+    awg.set_waveform(1, Sine(frequency_hz=1000.0))
+    awg.get_output_state(1)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unstable/awg/test_awg.py
+++ b/tests/unstable/awg/test_awg.py
@@ -1,9 +1,11 @@
 """Tests for AWGDriverBase contract and InstroAWG's generic wiring to a driver.
 
 Scoped to what's actually generic about the abstraction layer: the driver contract, lifecycle,
-the shared check_errors/tagging conventions, and channel-bounds enforcement across every method.
-Per-method roundtrip/packaging behavior (set_waveform, amplitude, offset, output, modulation, ...)
-is the responsibility of each vendor driver's own software test file, not re-derived here.
+the shared tagging conventions, and channel-bounds enforcement across every method. Per-method
+roundtrip/packaging behavior (set_waveform, amplitude, offset, output, modulation, ...) is the
+responsibility of each vendor driver's own software test file, not re-derived here. Error
+checking is a per-driver concern (it's a SCPI/VISA convention, not a universal instrument
+concept) and is tested against the concrete drivers that implement it, not here.
 """
 
 from unittest.mock import MagicMock
@@ -81,7 +83,6 @@ def test_01_awg_driver_base_contract_enforces_instantiation_rules() -> None:
 @pytest.mark.parametrize(
     ("method_name", "args"),
     [
-        ("check_errors", ()),
         ("set_output_load", (1, 50.0)),
         ("get_output_load", (1,)),
         ("align_phase", ()),
@@ -159,40 +160,22 @@ def test_03_lifecycle_open_close_start_background_daemon_and_invalid_configurati
 
 
 # ---------------------------------------------------------------------------
-# Error checking and tagging conventions
+# Tagging conventions
 # ---------------------------------------------------------------------------
 
 
-def test_04_check_errors_called_propagates_and_helper_tags_avoid_collision(
-    awg: InstroAWG, mock_driver: MagicMock
-) -> None:
-    """Scope precedent: a pending error surfaces at the next query instead of hanging a later blocking read."""
-    awg.set_waveform(1, Sine(frequency_hz=1000.0))
-    mock_driver.check_errors.assert_called_once()
-
-    mock_driver.check_errors.reset_mock()
-    awg.get_output_state(1)
-    awg.get_offset(1)
-    assert mock_driver.check_errors.call_count == 2
-
+def test_04_helper_tags_avoid_collision_with_positional_params(awg: InstroAWG) -> None:
     # Helper params are positional-only, so user tags named after them publish instead of colliding.
     cmd = awg.set_offset(1, 0.5, channel_suffix="rig7", value="x")
     assert cmd.tags["channel_suffix"] == "rig7"
     assert cmd.tags["value"] == "x"
 
-    # Scope-style ordering: check_errors runs before config is recorded, so a rejected set is never cached.
-    mock_driver.check_errors.side_effect = RuntimeError("instrument error queue not empty")
+    # A driver-raised error still propagates before config is recorded, so a rejected set is never cached.
+    driver = awg._driver
+    driver.set_waveform.side_effect = RuntimeError("instrument error queue not empty")
     with pytest.raises(RuntimeError, match="instrument error queue not empty"):
         awg.set_waveform(2, Sine(frequency_hz=1000.0))
     assert 2 not in awg._channel_waveforms
-
-
-def test_04b_check_errors_is_optional(mock_driver: MagicMock) -> None:
-    """A driver that doesn't implement check_errors must not break other calls."""
-    mock_driver.check_errors.side_effect = NotImplementedError("check_errors is not implemented for _NoErrorCheck")
-    awg = InstroAWG(name="test_awg", driver=mock_driver, num_channels=2)
-    awg.set_waveform(1, Sine(frequency_hz=1000.0))
-    awg.get_output_state(1)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Move check_errors() from the outer abstraction layer into the vendor-specific driver file. In this PR, we remove `check_errors()` from `awg.py`. We keep `_check_errors()` in `rigol_dg1022z.py`, but update each function to now call `_check_errors()`.

## Type of change

- [x] Bug fix (`fix`)
- [ ] New feature (`feat`)
- [ ] Breaking change (`feat!` / `fix!`)
- [ ] Refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] Chore / tooling (`chore`)

## Verification
<img width="1021" height="819" alt="Screenshot 2026-08-07 at 3 37 53 PM" src="https://github.com/user-attachments/assets/2b226a8d-8d58-43bf-aea5-844b3a4b372d" />

<img width="1033" height="414" alt="Screenshot 2026-08-07 at 3 38 06 PM" src="https://github.com/user-attachments/assets/93ea5326-5a8b-401a-81a1-e3a61b489daf" />

<img width="1016" height="600" alt="Screenshot 2026-08-07 at 3 38 18 PM" src="https://github.com/user-attachments/assets/b902bf59-d49e-4c30-a09b-cf781c440eea" />

## Tests

- [ ] Unit tests added or updated
- [ ] Existing tests cover this change
- [x] No tests — explain why: Existing tests were used to verify that functionality was not changed.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(driver): add support for Keysight E36300`)
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] Documentation updated if user-facing behavior changed
- [x] Code follows the style/conventions of the surrounding code

## Notes for reviewers