### PR TITLE
feat(awg): add sweep functions to AWG base

### DIFF
--- a/docs/guides/instrumentation/awg.mdx
+++ b/docs/guides/instrumentation/awg.mdx
@@ -241,7 +241,7 @@ Every measurement/command call produces a channel keyed under `{name}.{descripto
 | `get_sweep_hold_time(channel)` | Read back the sweep hold time in seconds on a channel |
 | `set_sweep_return_time(channel, return_time)` | Set the sweep return time in seconds on a channel |
 | `get_sweep_return_time(channel)` | Read back the sweep return time in seconds on a channel |
-| `fire_sweep_trigger(channel)` | Manually trigger a sweep on a channel |
+| `fire_sweep_trigger(channel)` | Fire a sweep trigger on channel now; the trigger source must already be `MANUAL` |
 | `start()` | Begin background daemon |
 | `stop()` | End background daemon |
 
@@ -336,7 +336,7 @@ Optional overrides (raise `NotImplementedError` if not supported):
 - **`set_sweep_time(channel, sweep_time)`** / **`get_sweep_time(channel)`**: Set or read the sweep time.
 - **`set_sweep_hold_time(channel, hold_time)`** / **`get_sweep_hold_time(channel)`**: Set or read the sweep hold time.
 - **`set_sweep_return_time(channel, return_time)`** / **`get_sweep_return_time(channel)`**: Set or read the sweep return time.
-- **`fire_sweep_trigger(channel)`**: Manually trigger a sweep on channel.
+- **`fire_sweep_trigger(channel)`**: Fire a sweep trigger on channel immediately. Requires the trigger source already set to `MANUAL`; call `set_sweep_trigger()` first otherwise.
 
 ### Modulation
 

--- a/docs/guides/instrumentation/awg.mdx
+++ b/docs/guides/instrumentation/awg.mdx
@@ -161,6 +161,7 @@ Every measurement/command call produces a channel keyed under `{name}.{descripto
 | `set_burst_period(channel=N)` | `ch{N}.burst_period.cmd` | command |
 | `set_sweep(channel=N)` | `ch{N}.sweep.cmd` | command |
 | `sweep_enable(channel=N)` | `ch{N}.sweep_enabled.cmd` | command |
+| `set_sweep_trigger(channel=N)` | `ch{N}.sweep_trigger.cmd` | command |
 | `set_sweep_start_freq(channel=N)` | `ch{N}.sweep_start_freq.cmd` | command |
 | `set_sweep_end_freq(channel=N)` | `ch{N}.sweep_end_freq.cmd` | command |
 | `set_sweep_time(channel=N)` | `ch{N}.sweep_time.cmd` | command |
@@ -183,7 +184,7 @@ Every measurement/command call produces a channel keyed under `{name}.{descripto
 | `get_sweep_return_time(channel=N)` | `ch{N}.sweep_return_time` | telemetry |
 
 <Note>
-`get_waveform()`, `get_amplitude()`, `convert_amplitude()`, `get_modulation_type()`, `get_burst_type()`, `get_burst_trigger()`, `get_burst_gate_polarity()`, and `get_sweep_type()` return a plain Python value (`Waveform`, `tuple[float, AmplitudeMeasurementUnit]`, `float`, `ModulationType`, `BurstType`, `BurstTriggerSource`, `GatePolarity`, `SweepType`) directly rather than a `Measurement`, and don't publish. Every other readback listed above publishes a `Measurement` on the descriptor shown.
+`get_waveform()`, `get_amplitude()`, `convert_amplitude()`, `get_modulation_type()`, `get_burst_type()`, `get_burst_trigger()`, `get_burst_gate_polarity()`, `get_sweep_type()`, and `get_sweep_trigger()` return a plain Python value (`Waveform`, `tuple[float, AmplitudeMeasurementUnit]`, `float`, `ModulationType`, `BurstType`, `BurstTriggerSource`, `GatePolarity`, `SweepType`, `SweepTriggerSource`) directly rather than a `Measurement`, and don't publish. Every other readback listed above publishes a `Measurement` on the descriptor shown.
 </Note>
 
 ## Method Reference
@@ -228,6 +229,8 @@ Every measurement/command call produces a channel keyed under `{name}.{descripto
 | `get_sweep_type(channel)` | Read back the sweep type currently configured on channel |
 | `sweep_enable(channel, enable)` | Enable or disable sweep mode on channel |
 | `get_sweep_state(channel)` | Read back whether sweep mode is enabled on channel |
+| `set_sweep_trigger(channel, source)` | Set the sweep trigger source (`INTERNAL`/`EXTERNAL`/`MANUAL`) on channel |
+| `get_sweep_trigger(channel)` | Read back the sweep trigger source on channel |
 | `set_sweep_start_freq(channel, frequency_hz)` | Set the sweep start frequency in Hz on a channel |
 | `get_sweep_start_freq(channel)` | Read back the sweep start frequency in Hz on a channel |
 | `set_sweep_end_freq(channel, frequency_hz)` | Set the sweep end frequency in Hz on a channel |
@@ -327,6 +330,7 @@ Optional overrides (raise `NotImplementedError` if not supported):
 - **`set_burst_period(channel, period)`** / **`get_burst_period(channel)`**: Set or read back the internal burst period in seconds.
 - **`set_sweep(channel, sweep_type)`** / **`get_sweep_type(channel)`**: Configure or read back a channel's sweep type (`LINEAR`/`LOG`/`STEP`).
 - **`sweep_enable(channel, enable)`** / **`get_sweep_state(channel)`**: Enable or disable sweep mode, or read back whether it's enabled.
+- **`set_sweep_trigger(channel, source)`** / **`get_sweep_trigger(channel)`**: Set or read back the sweep trigger source (`INTERNAL`/`EXTERNAL`/`MANUAL`).
 - **`set_sweep_start_freq(channel, frequency_hz)`** / **`get_sweep_start_freq(channel)`**: Set or read the sweep start frequency.
 - **`set_sweep_end_freq(channel, frequency_hz)`** / **`get_sweep_end_freq(channel)`**: Set or read the sweep end frequency.
 - **`set_sweep_time(channel, sweep_time)`** / **`get_sweep_time(channel)`**: Set or read the sweep time.

--- a/docs/guides/instrumentation/awg.mdx
+++ b/docs/guides/instrumentation/awg.mdx
@@ -11,7 +11,7 @@ description: Using InstroAWG for SCPI-based arbitrary waveform generators
 `InstroAWG` ships in the `instro-unstable` package. Its API is not settled and may change without notice between releases. Install it with `pip install "instro[unstable]"`. See [Unstable modules](/instrumentation/installation#unstable-modules) for details.
 </Warning>
 
-`InstroAWG` is a hardware abstraction layer (HAL) that provides a unified interface for arbitrary waveform generators. The category class defines the vendor-independent API (`set_waveform`, `set_amplitude`, `set_offset`, `set_modulation`, …). A vendor-specific driver owns its connection details and translates those calls into vendor commands.
+`InstroAWG` is a hardware abstraction layer (HAL) that provides a unified interface for arbitrary waveform generators. The category class defines the vendor-independent API (`set_waveform`, `set_amplitude`, `set_offset`, `set_modulation`, `set_sweep`, …). A vendor-specific driver owns its connection details and translates those calls into vendor commands.
 
 ## Supported Vendors
 
@@ -159,6 +159,13 @@ Every measurement/command call produces a channel keyed under `{name}.{descripto
 | `set_burst_gate_polarity(channel=N)` | `ch{N}.burst_gate_polarity.cmd` | command |
 | `set_burst_ncycles(channel=N)` | `ch{N}.burst_ncycles.cmd` | command |
 | `set_burst_period(channel=N)` | `ch{N}.burst_period.cmd` | command |
+| `set_sweep(channel=N)` | `ch{N}.sweep.cmd` | command |
+| `sweep_enable(channel=N)` | `ch{N}.sweep_enabled.cmd` | command |
+| `set_sweep_start_freq(channel=N)` | `ch{N}.sweep_start_freq.cmd` | command |
+| `set_sweep_end_freq(channel=N)` | `ch{N}.sweep_end_freq.cmd` | command |
+| `set_sweep_time(channel=N)` | `ch{N}.sweep_time.cmd` | command |
+| `set_sweep_hold_time(channel=N)` | `ch{N}.sweep_hold_time.cmd` | command |
+| `set_sweep_return_time(channel=N)` | `ch{N}.sweep_return_time.cmd` | command |
 | `get_offset(channel=N)` | `ch{N}.offset` | telemetry |
 | `get_output_state(channel=N)` | `ch{N}.enabled` | telemetry |
 | `get_output_load(channel=N)` | `ch{N}.load` | telemetry |
@@ -167,9 +174,15 @@ Every measurement/command call produces a channel keyed under `{name}.{descripto
 | `get_burst_delay(channel=N)` | `ch{N}.burst_delay` | telemetry |
 | `get_burst_ncycles(channel=N)` | `ch{N}.burst_ncycles` | telemetry |
 | `get_burst_period(channel=N)` | `ch{N}.burst_period` | telemetry |
+| `get_sweep_state(channel=N)` | `ch{N}.sweep_enabled` | telemetry |
+| `get_sweep_start_freq(channel=N)` | `ch{N}.sweep_start_freq` | telemetry |
+| `get_sweep_end_freq(channel=N)` | `ch{N}.sweep_end_freq` | telemetry |
+| `get_sweep_time(channel=N)` | `ch{N}.sweep_time` | telemetry |
+| `get_sweep_hold_time(channel=N)` | `ch{N}.sweep_hold_time` | telemetry |
+| `get_sweep_return_time(channel=N)` | `ch{N}.sweep_return_time` | telemetry |
 
 <Note>
-`get_waveform()`, `get_amplitude()`, `convert_amplitude()`, `get_modulation_type()`, `get_burst_type()`, `get_burst_trigger()`, and `get_burst_gate_polarity()` return a plain Python value (`Waveform`, `tuple[float, AmplitudeMeasurementUnit]`, `float`, `ModulationType`, `BurstType`, `BurstTriggerSource`, `GatePolarity`) directly rather than a `Measurement`, and don't publish. Every other readback listed above publishes a `Measurement` on the descriptor shown.
+`get_waveform()`, `get_amplitude()`, `convert_amplitude()`, `get_modulation_type()`, `get_burst_type()`, `get_burst_trigger()`, `get_burst_gate_polarity()`, and `get_sweep_type()` return a plain Python value (`Waveform`, `tuple[float, AmplitudeMeasurementUnit]`, `float`, `ModulationType`, `BurstType`, `BurstTriggerSource`, `GatePolarity`, `SweepType`) directly rather than a `Measurement`, and don't publish. Every other readback listed above publishes a `Measurement` on the descriptor shown.
 </Note>
 
 ## Method Reference
@@ -210,6 +223,20 @@ Every measurement/command call produces a channel keyed under `{name}.{descripto
 | `get_burst_ncycles(channel)` | Read back the number of cycles per trigger for NCYCLE bursts on channel |
 | `set_burst_period(channel, period)` | Set the internal burst period in seconds on channel |
 | `get_burst_period(channel)` | Read back the internal burst period in seconds on channel |
+| `set_sweep(channel, sweep_type)` | Configure a channel's sweep type (`LINEAR`/`LOG`/`STEP`) |
+| `get_sweep_type(channel)` | Read back the sweep type currently configured on channel |
+| `sweep_enable(channel, enable)` | Enable or disable sweep mode on channel |
+| `get_sweep_state(channel)` | Read back whether sweep mode is enabled on channel |
+| `set_sweep_start_freq(channel, frequency_hz)` | Set the sweep start frequency in Hz on a channel |
+| `get_sweep_start_freq(channel)` | Read back the sweep start frequency in Hz on a channel |
+| `set_sweep_end_freq(channel, frequency_hz)` | Set the sweep end frequency in Hz on a channel |
+| `get_sweep_end_freq(channel)` | Read back the sweep end frequency in Hz on a channel |
+| `set_sweep_time(channel, sweep_time)` | Set the sweep time in seconds on a channel |
+| `get_sweep_time(channel)` | Read back the sweep time in seconds on a channel |
+| `set_sweep_hold_time(channel, hold_time)` | Set the sweep hold time in seconds on a channel |
+| `get_sweep_hold_time(channel)` | Read back the sweep hold time in seconds on a channel |
+| `set_sweep_return_time(channel, return_time)` | Set the sweep return time in seconds on a channel |
+| `get_sweep_return_time(channel)` | Read back the sweep return time in seconds on a channel |
 | `start()` | Begin background daemon |
 | `stop()` | End background daemon |
 
@@ -296,6 +323,13 @@ Optional overrides (raise `NotImplementedError` if not supported):
 - **`set_burst_gate_polarity(channel, gate_polarity)`** / **`get_burst_gate_polarity(channel)`**: Set or read back the gate polarity (`NORM`/`INV`) for GATED bursts.
 - **`set_burst_ncycles(channel, n_cycles)`** / **`get_burst_ncycles(channel)`**: Set or read back the number of cycles per trigger for NCYCLE bursts.
 - **`set_burst_period(channel, period)`** / **`get_burst_period(channel)`**: Set or read back the internal burst period in seconds.
+- **`set_sweep(channel, sweep_type)`** / **`get_sweep_type(channel)`**: Configure or read back a channel's sweep type (`LINEAR`/`LOG`/`STEP`).
+- **`sweep_enable(channel, enable)`** / **`get_sweep_state(channel)`**: Enable or disable sweep mode, or read back whether it's enabled.
+- **`set_sweep_start_freq(channel, frequency_hz)`** / **`get_sweep_start_freq(channel)`**: Set or read the sweep start frequency.
+- **`set_sweep_end_freq(channel, frequency_hz)`** / **`get_sweep_end_freq(channel)`**: Set or read the sweep end frequency.
+- **`set_sweep_time(channel, sweep_time)`** / **`get_sweep_time(channel)`**: Set or read the sweep time.
+- **`set_sweep_hold_time(channel, hold_time)`** / **`get_sweep_hold_time(channel)`**: Set or read the sweep hold time.
+- **`set_sweep_return_time(channel, return_time)`** / **`get_sweep_return_time(channel)`**: Set or read the sweep return time.
 
 ### Modulation
 

--- a/docs/guides/instrumentation/awg.mdx
+++ b/docs/guides/instrumentation/awg.mdx
@@ -166,6 +166,7 @@ Every measurement/command call produces a channel keyed under `{name}.{descripto
 | `set_sweep_time(channel=N)` | `ch{N}.sweep_time.cmd` | command |
 | `set_sweep_hold_time(channel=N)` | `ch{N}.sweep_hold_time.cmd` | command |
 | `set_sweep_return_time(channel=N)` | `ch{N}.sweep_return_time.cmd` | command |
+| `fire_sweep_trigger(channel=N)` | `ch{N}.sweep_trigger_forced.cmd` | command |
 | `get_offset(channel=N)` | `ch{N}.offset` | telemetry |
 | `get_output_state(channel=N)` | `ch{N}.enabled` | telemetry |
 | `get_output_load(channel=N)` | `ch{N}.load` | telemetry |
@@ -237,6 +238,7 @@ Every measurement/command call produces a channel keyed under `{name}.{descripto
 | `get_sweep_hold_time(channel)` | Read back the sweep hold time in seconds on a channel |
 | `set_sweep_return_time(channel, return_time)` | Set the sweep return time in seconds on a channel |
 | `get_sweep_return_time(channel)` | Read back the sweep return time in seconds on a channel |
+| `fire_sweep_trigger(channel)` | Manually trigger a sweep on a channel |
 | `start()` | Begin background daemon |
 | `stop()` | End background daemon |
 
@@ -330,6 +332,7 @@ Optional overrides (raise `NotImplementedError` if not supported):
 - **`set_sweep_time(channel, sweep_time)`** / **`get_sweep_time(channel)`**: Set or read the sweep time.
 - **`set_sweep_hold_time(channel, hold_time)`** / **`get_sweep_hold_time(channel)`**: Set or read the sweep hold time.
 - **`set_sweep_return_time(channel, return_time)`** / **`get_sweep_return_time(channel)`**: Set or read the sweep return time.
+- **`fire_sweep_trigger(channel)`**: Manually trigger a sweep on channel.
 
 ### Modulation
 

--- a/packages/instro-unstable/instro/unstable/awg/__init__.py
+++ b/packages/instro-unstable/instro/unstable/awg/__init__.py
@@ -16,6 +16,7 @@ from instro.unstable.awg.types import (
     Sine,
     Square,
     StaticValue,
+    SweepType,
     Triangle,
     Waveform,
     convert_amplitude,
@@ -37,5 +38,6 @@ __all__ = [
     "BurstType",
     "BurstTriggerSource",
     "GatePolarity",
+    "SweepType",
     "convert_amplitude",
 ]

--- a/packages/instro-unstable/instro/unstable/awg/__init__.py
+++ b/packages/instro-unstable/instro/unstable/awg/__init__.py
@@ -16,6 +16,7 @@ from instro.unstable.awg.types import (
     Sine,
     Square,
     StaticValue,
+    SweepTriggerSource,
     SweepType,
     Triangle,
     Waveform,
@@ -39,5 +40,6 @@ __all__ = [
     "BurstTriggerSource",
     "GatePolarity",
     "SweepType",
+    "SweepTriggerSource",
     "convert_amplitude",
 ]

--- a/packages/instro-unstable/instro/unstable/awg/awg.py
+++ b/packages/instro-unstable/instro/unstable/awg/awg.py
@@ -220,6 +220,10 @@ class AWGDriverBase(abc.ABC):
         """Get the sweep return time (seconds) on channel."""
         raise NotImplementedError(f"get_sweep_return_time is not implemented for {type(self).__name__}")
 
+    def fire_sweep_trigger(self, channel: int) -> None:
+        """Manually trigger a sweep on channel."""
+        raise NotImplementedError(f"fire_sweep_trigger is not implemented for {type(self).__name__}")
+
 
 _PUBLISHED_NAMES: dict[type, str] = {
     Sine: "SINE",
@@ -701,3 +705,13 @@ class InstroAWG(Instrument):
         """Read back the sweep return time (seconds) on channel."""
         self._check_channel(channel)
         return self._execute_measurement(self._driver.get_sweep_return_time, channel, "sweep_return_time", **kwargs)
+
+    @publish_command
+    def fire_sweep_trigger(self, channel: int, **kwargs) -> Command:
+        """Trigger a sweep on a channel manually."""
+        self._check_channel(channel)
+        with self._resource_lock:
+            self._driver.fire_sweep_trigger(channel=channel)
+            timestamp = time.time_ns()
+        descriptor = f"ch{channel}.sweep_trigger_forced.cmd"
+        return self._package_command(descriptor, "TRIGGER", timestamp, **kwargs)

--- a/packages/instro-unstable/instro/unstable/awg/awg.py
+++ b/packages/instro-unstable/instro/unstable/awg/awg.py
@@ -24,6 +24,7 @@ from instro.unstable.awg.types import (
     Sine,
     Square,
     StaticValue,
+    SweepTriggerSource,
     SweepType,
     Triangle,
     Waveform,
@@ -179,6 +180,14 @@ class AWGDriverBase(abc.ABC):
     def get_sweep_state(self, channel: int) -> bool:
         """Return True if sweep mode is enabled on channel."""
         raise NotImplementedError(f"get_sweep_state is not implemented for {type(self).__name__}")
+
+    def set_sweep_trigger(self, channel: int, source: SweepTriggerSource) -> None:
+        """Set the sweep trigger source on channel."""
+        raise NotImplementedError(f"set_sweep_trigger is not implemented for {type(self).__name__}")
+
+    def get_sweep_trigger(self, channel: int) -> SweepTriggerSource:
+        """Get the sweep trigger source on channel."""
+        raise NotImplementedError(f"get_sweep_trigger is not implemented for {type(self).__name__}")
 
     def set_sweep_start_freq(self, channel: int, frequency_hz: float) -> None:
         """Set the sweep start frequency (Hz) on channel."""
@@ -651,6 +660,25 @@ class InstroAWG(Instrument):
         """Read back whether sweep mode is enabled on channel."""
         self._check_channel(channel)
         return self._execute_measurement(self._driver.get_sweep_state, channel, "sweep_enabled", **kwargs)
+
+    @publish_command
+    def set_sweep_trigger(self, channel: int, source: SweepTriggerSource, **kwargs) -> Command:
+        """Set the sweep trigger source on channel."""
+        if not isinstance(source, SweepTriggerSource):
+            raise TypeError(f"source must be a SweepTriggerSource, got {type(source).__name__}")
+        self._check_channel(channel)
+        with self._resource_lock:
+            self._driver.set_sweep_trigger(channel=channel, source=source)
+            timestamp = time.time_ns()
+        descriptor = f"ch{channel}.sweep_trigger.cmd"
+        return self._package_command(descriptor, source.value, timestamp, **kwargs)
+
+    def get_sweep_trigger(self, channel: int) -> SweepTriggerSource:
+        """Read back the sweep trigger source on channel."""
+        self._check_channel(channel)
+        with self._resource_lock:
+            source = self._driver.get_sweep_trigger(channel=channel)
+        return source
 
     def set_sweep_start_freq(self, channel: int, frequency_hz: float, **kwargs) -> Command:
         """Set the sweep start frequency (Hz) on channel."""

--- a/packages/instro-unstable/instro/unstable/awg/awg.py
+++ b/packages/instro-unstable/instro/unstable/awg/awg.py
@@ -24,6 +24,7 @@ from instro.unstable.awg.types import (
     Sine,
     Square,
     StaticValue,
+    SweepType,
     Triangle,
     Waveform,
     convert_amplitude,
@@ -162,6 +163,62 @@ class AWGDriverBase(abc.ABC):
     def get_burst_period(self, channel: int) -> float:
         """Get the internal burst period (seconds) on channel."""
         raise NotImplementedError(f"get_burst_period is not implemented for {type(self).__name__}")
+
+    def set_sweep(self, channel: int, sweep_type: SweepType) -> None:
+        """Configure the sweep type on channel."""
+        raise NotImplementedError(f"set_sweep is not implemented for {type(self).__name__}")
+
+    def get_sweep_type(self, channel: int) -> SweepType:
+        """Get the sweep type currently configured on channel."""
+        raise NotImplementedError(f"get_sweep_type is not implemented for {type(self).__name__}")
+
+    def sweep_enable(self, channel: int, enable: bool) -> None:
+        """Enable or disable sweep mode on channel."""
+        raise NotImplementedError(f"sweep_enable is not implemented for {type(self).__name__}")
+
+    def get_sweep_state(self, channel: int) -> bool:
+        """Return True if sweep mode is enabled on channel."""
+        raise NotImplementedError(f"get_sweep_state is not implemented for {type(self).__name__}")
+
+    def set_sweep_start_freq(self, channel: int, frequency_hz: float) -> None:
+        """Set the sweep start frequency (Hz) on channel."""
+        raise NotImplementedError(f"set_sweep_start_freq is not implemented for {type(self).__name__}")
+
+    def get_sweep_start_freq(self, channel: int) -> float:
+        """Get the sweep start frequency (Hz) on channel."""
+        raise NotImplementedError(f"get_sweep_start_freq is not implemented for {type(self).__name__}")
+
+    def set_sweep_end_freq(self, channel: int, frequency_hz: float) -> None:
+        """Set the sweep end frequency (Hz) on channel."""
+        raise NotImplementedError(f"set_sweep_end_freq is not implemented for {type(self).__name__}")
+
+    def get_sweep_end_freq(self, channel: int) -> float:
+        """Get the sweep end frequency (Hz) on channel."""
+        raise NotImplementedError(f"get_sweep_end_freq is not implemented for {type(self).__name__}")
+
+    def set_sweep_time(self, channel: int, sweep_time: float) -> None:
+        """Set the sweep time (seconds) on channel."""
+        raise NotImplementedError(f"set_sweep_time is not implemented for {type(self).__name__}")
+
+    def get_sweep_time(self, channel: int) -> float:
+        """Get the sweep time (seconds) on channel."""
+        raise NotImplementedError(f"get_sweep_time is not implemented for {type(self).__name__}")
+
+    def set_sweep_hold_time(self, channel: int, hold_time: float) -> None:
+        """Set the sweep hold time (seconds) on channel."""
+        raise NotImplementedError(f"set_sweep_hold_time is not implemented for {type(self).__name__}")
+
+    def get_sweep_hold_time(self, channel: int) -> float:
+        """Get the sweep hold time (seconds) on channel."""
+        raise NotImplementedError(f"get_sweep_hold_time is not implemented for {type(self).__name__}")
+
+    def set_sweep_return_time(self, channel: int, return_time: float) -> None:
+        """Set the sweep return time (seconds) on channel."""
+        raise NotImplementedError(f"set_sweep_return_time is not implemented for {type(self).__name__}")
+
+    def get_sweep_return_time(self, channel: int) -> float:
+        """Get the sweep return time (seconds) on channel."""
+        raise NotImplementedError(f"get_sweep_return_time is not implemented for {type(self).__name__}")
 
 
 _PUBLISHED_NAMES: dict[type, str] = {
@@ -561,3 +618,86 @@ class InstroAWG(Instrument):
         """Read back the internal burst period (seconds) on channel."""
         self._check_channel(channel)
         return self._execute_measurement(self._driver.get_burst_period, channel, "burst_period", **kwargs)
+
+    @publish_command
+    def set_sweep(self, channel: int, sweep_type: SweepType, **kwargs) -> Command:
+        """Configure the sweep type on channel."""
+        if not isinstance(sweep_type, SweepType):
+            raise TypeError(f"sweep_type must be a SweepType, got {type(sweep_type).__name__}")
+        self._check_channel(channel)
+        with self._resource_lock:
+            self._driver.set_sweep(channel=channel, sweep_type=sweep_type)
+            timestamp = time.time_ns()
+        descriptor = f"ch{channel}.sweep.cmd"
+        return self._package_command(descriptor, sweep_type.value, timestamp, **kwargs)
+
+    def get_sweep_type(self, channel: int) -> SweepType:
+        """Read back the sweep type currently configured on channel."""
+        self._check_channel(channel)
+        with self._resource_lock:
+            sweep_type = self._driver.get_sweep_type(channel=channel)
+        return sweep_type
+
+    def sweep_enable(self, channel: int, enable: bool, **kwargs) -> Command:
+        """Enable or disable sweep mode on channel."""
+        self._check_channel(channel)
+        return self._execute_command(self._driver.sweep_enable, channel, enable, "sweep_enabled", **kwargs)
+
+    def get_sweep_state(self, channel: int, **kwargs) -> Measurement | None:
+        """Read back whether sweep mode is enabled on channel."""
+        self._check_channel(channel)
+        return self._execute_measurement(self._driver.get_sweep_state, channel, "sweep_enabled", **kwargs)
+
+    def set_sweep_start_freq(self, channel: int, frequency_hz: float, **kwargs) -> Command:
+        """Set the sweep start frequency (Hz) on channel."""
+        self._check_channel(channel)
+        return self._execute_command(
+            self._driver.set_sweep_start_freq, channel, frequency_hz, "sweep_start_freq", **kwargs
+        )
+
+    def get_sweep_start_freq(self, channel: int, **kwargs) -> Measurement | None:
+        """Read back the sweep start frequency (Hz) on channel."""
+        self._check_channel(channel)
+        return self._execute_measurement(self._driver.get_sweep_start_freq, channel, "sweep_start_freq", **kwargs)
+
+    def set_sweep_end_freq(self, channel: int, frequency_hz: float, **kwargs) -> Command:
+        """Set the sweep end frequency (Hz) on channel."""
+        self._check_channel(channel)
+        return self._execute_command(self._driver.set_sweep_end_freq, channel, frequency_hz, "sweep_end_freq", **kwargs)
+
+    def get_sweep_end_freq(self, channel: int, **kwargs) -> Measurement | None:
+        """Read back the sweep end frequency (Hz) on channel."""
+        self._check_channel(channel)
+        return self._execute_measurement(self._driver.get_sweep_end_freq, channel, "sweep_end_freq", **kwargs)
+
+    def set_sweep_time(self, channel: int, sweep_time: float, **kwargs) -> Command:
+        """Set the sweep time (seconds) on channel."""
+        self._check_channel(channel)
+        return self._execute_command(self._driver.set_sweep_time, channel, sweep_time, "sweep_time", **kwargs)
+
+    def get_sweep_time(self, channel: int, **kwargs) -> Measurement | None:
+        """Read back the sweep time (seconds) on channel."""
+        self._check_channel(channel)
+        return self._execute_measurement(self._driver.get_sweep_time, channel, "sweep_time", **kwargs)
+
+    def set_sweep_hold_time(self, channel: int, hold_time: float, **kwargs) -> Command:
+        """Set the sweep hold time (seconds) on channel."""
+        self._check_channel(channel)
+        return self._execute_command(self._driver.set_sweep_hold_time, channel, hold_time, "sweep_hold_time", **kwargs)
+
+    def get_sweep_hold_time(self, channel: int, **kwargs) -> Measurement | None:
+        """Read back the sweep hold time (seconds) on channel."""
+        self._check_channel(channel)
+        return self._execute_measurement(self._driver.get_sweep_hold_time, channel, "sweep_hold_time", **kwargs)
+
+    def set_sweep_return_time(self, channel: int, return_time: float, **kwargs) -> Command:
+        """Set the sweep return time (seconds) on channel."""
+        self._check_channel(channel)
+        return self._execute_command(
+            self._driver.set_sweep_return_time, channel, return_time, "sweep_return_time", **kwargs
+        )
+
+    def get_sweep_return_time(self, channel: int, **kwargs) -> Measurement | None:
+        """Read back the sweep return time (seconds) on channel."""
+        self._check_channel(channel)
+        return self._execute_measurement(self._driver.get_sweep_return_time, channel, "sweep_return_time", **kwargs)

--- a/packages/instro-unstable/instro/unstable/awg/awg.py
+++ b/packages/instro-unstable/instro/unstable/awg/awg.py
@@ -230,7 +230,7 @@ class AWGDriverBase(abc.ABC):
         raise NotImplementedError(f"get_sweep_return_time is not implemented for {type(self).__name__}")
 
     def fire_sweep_trigger(self, channel: int) -> None:
-        """Manually trigger a sweep on channel."""
+        """Fire a sweep trigger on channel now; the trigger source must already be MANUAL."""
         raise NotImplementedError(f"fire_sweep_trigger is not implemented for {type(self).__name__}")
 
 
@@ -736,10 +736,10 @@ class InstroAWG(Instrument):
 
     @publish_command
     def fire_sweep_trigger(self, channel: int, **kwargs) -> Command:
-        """Trigger a sweep on a channel manually."""
+        """Fire a sweep trigger on channel now; the trigger source must already be MANUAL."""
         self._check_channel(channel)
         with self._resource_lock:
             self._driver.fire_sweep_trigger(channel=channel)
             timestamp = time.time_ns()
         descriptor = f"ch{channel}.sweep_trigger_forced.cmd"
-        return self._package_command(descriptor, "TRIGGER", timestamp, **kwargs)
+        return self._package_command(descriptor, SweepTriggerSource.MANUAL.value, timestamp, **kwargs)

--- a/packages/instro-unstable/instro/unstable/awg/types.py
+++ b/packages/instro-unstable/instro/unstable/awg/types.py
@@ -39,6 +39,12 @@ class GatePolarity(Enum):
     INV = "INV"
 
 
+class SweepType(Enum):
+    LINEAR = "LINEAR"
+    LOG = "LOG"
+    STEP = "STEP"
+
+
 def _require_positive(name: str, value: float) -> None:
     if value <= 0:
         raise ValueError(f"{name} must be positive, got {value}")

--- a/packages/instro-unstable/instro/unstable/awg/types.py
+++ b/packages/instro-unstable/instro/unstable/awg/types.py
@@ -45,6 +45,12 @@ class SweepType(Enum):
     STEP = "STEP"
 
 
+class SweepTriggerSource(Enum):
+    INTERNAL = "INT"
+    EXTERNAL = "EXT"
+    MANUAL = "MAN"
+
+
 def _require_positive(name: str, value: float) -> None:
     if value <= 0:
         raise ValueError(f"{name} must be positive, got {value}")

--- a/tests/unstable/awg/test_awg.py
+++ b/tests/unstable/awg/test_awg.py
@@ -20,6 +20,7 @@ from instro.unstable.awg.types import (
     GatePolarity,
     ModulationType,
     Sine,
+    SweepType,
     Waveform,
 )
 
@@ -108,6 +109,20 @@ def test_01_awg_driver_base_contract_enforces_instantiation_rules() -> None:
         ("get_burst_ncycles", (1,)),
         ("set_burst_period", (1, 0.001)),
         ("get_burst_period", (1,)),
+        ("set_sweep", (1, SweepType.LINEAR)),
+        ("get_sweep_type", (1,)),
+        ("sweep_enable", (1, True)),
+        ("get_sweep_state", (1,)),
+        ("set_sweep_start_freq", (1, 100.0)),
+        ("get_sweep_start_freq", (1,)),
+        ("set_sweep_end_freq", (1, 200.0)),
+        ("get_sweep_end_freq", (1,)),
+        ("set_sweep_time", (1, 0.5)),
+        ("get_sweep_time", (1,)),
+        ("set_sweep_hold_time", (1, 0.1)),
+        ("get_sweep_hold_time", (1,)),
+        ("set_sweep_return_time", (1, 0.1)),
+        ("get_sweep_return_time", (1,)),
     ],
 )
 def test_02_awg_driver_base_optional_methods_raise_not_implemented(
@@ -138,6 +153,8 @@ def mock_driver() -> MagicMock:
     driver.get_burst_state.return_value = False
     driver.get_burst_trigger.return_value = BurstTriggerSource.INTERNAL
     driver.get_burst_gate_polarity.return_value = GatePolarity.NORM
+    driver.get_sweep_type.return_value = SweepType.LINEAR
+    driver.get_sweep_state.return_value = False
     return driver
 
 
@@ -238,6 +255,20 @@ def test_04_helper_tags_avoid_collision_with_positional_params(awg: InstroAWG) -
         ("get_burst_ncycles", ()),
         ("set_burst_period", (0.001,)),
         ("get_burst_period", ()),
+        ("set_sweep", (SweepType.LINEAR,)),
+        ("get_sweep_type", ()),
+        ("sweep_enable", (True,)),
+        ("get_sweep_state", ()),
+        ("set_sweep_start_freq", (100.0,)),
+        ("get_sweep_start_freq", ()),
+        ("set_sweep_end_freq", (200.0,)),
+        ("get_sweep_end_freq", ()),
+        ("set_sweep_time", (0.5,)),
+        ("get_sweep_time", ()),
+        ("set_sweep_hold_time", (0.1,)),
+        ("get_sweep_hold_time", ()),
+        ("set_sweep_return_time", (0.1,)),
+        ("get_sweep_return_time", ()),
     ],
 )
 @pytest.mark.parametrize("channel", [0, 1, 2, 3])

--- a/tests/unstable/awg/test_awg.py
+++ b/tests/unstable/awg/test_awg.py
@@ -123,6 +123,7 @@ def test_01_awg_driver_base_contract_enforces_instantiation_rules() -> None:
         ("get_sweep_hold_time", (1,)),
         ("set_sweep_return_time", (1, 0.1)),
         ("get_sweep_return_time", (1,)),
+        ("fire_sweep_trigger", (1,)),
     ],
 )
 def test_02_awg_driver_base_optional_methods_raise_not_implemented(
@@ -269,6 +270,7 @@ def test_04_helper_tags_avoid_collision_with_positional_params(awg: InstroAWG) -
         ("get_sweep_hold_time", ()),
         ("set_sweep_return_time", (0.1,)),
         ("get_sweep_return_time", ()),
+        ("fire_sweep_trigger", ()),
     ],
 )
 @pytest.mark.parametrize("channel", [0, 1, 2, 3])

--- a/tests/unstable/awg/test_awg.py
+++ b/tests/unstable/awg/test_awg.py
@@ -20,6 +20,7 @@ from instro.unstable.awg.types import (
     GatePolarity,
     ModulationType,
     Sine,
+    SweepTriggerSource,
     SweepType,
     Waveform,
 )
@@ -113,6 +114,8 @@ def test_01_awg_driver_base_contract_enforces_instantiation_rules() -> None:
         ("get_sweep_type", (1,)),
         ("sweep_enable", (1, True)),
         ("get_sweep_state", (1,)),
+        ("set_sweep_trigger", (1, SweepTriggerSource.INTERNAL)),
+        ("get_sweep_trigger", (1,)),
         ("set_sweep_start_freq", (1, 100.0)),
         ("get_sweep_start_freq", (1,)),
         ("set_sweep_end_freq", (1, 200.0)),
@@ -156,6 +159,7 @@ def mock_driver() -> MagicMock:
     driver.get_burst_gate_polarity.return_value = GatePolarity.NORM
     driver.get_sweep_type.return_value = SweepType.LINEAR
     driver.get_sweep_state.return_value = False
+    driver.get_sweep_trigger.return_value = SweepTriggerSource.INTERNAL
     return driver
 
 
@@ -260,6 +264,8 @@ def test_04_helper_tags_avoid_collision_with_positional_params(awg: InstroAWG) -
         ("get_sweep_type", ()),
         ("sweep_enable", (True,)),
         ("get_sweep_state", ()),
+        ("set_sweep_trigger", (SweepTriggerSource.INTERNAL,)),
+        ("get_sweep_trigger", ()),
         ("set_sweep_start_freq", (100.0,)),
         ("get_sweep_start_freq", ()),
         ("set_sweep_end_freq", (200.0,)),


### PR DESCRIPTION
## Summary

This PR adds sweep functionality to the AWGDriverBase and InstroAWG. We use the same `set`/`get` structure to allow the user to customize their sweep type, timing, and frequency. This PR does not include actual implementation in a specific driver. Rather, this PR is solely scoped to the base functionality.

## Type of change

- [ ] Bug fix (`fix`)
- [x] New feature (`feat`)
- [ ] Breaking change (`feat!` / `fix!`)
- [ ] Refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] Chore / tooling (`chore`)

## Verification

<img width="1524" height="185" alt="Screenshot 2026-08-12 at 11 18 09 AM" src="https://github.com/user-attachments/assets/9e7dbfcf-6944-4c1c-b7af-02ff781aefa5" />


## Tests

- [x] Unit tests added or updated
- [ ] Existing tests cover this change
- [ ] No tests — explain why: Existing tests were used to verify that this change is non-breaking.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(driver): add support for Keysight E36300`)
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] Documentation updated if user-facing behavior changed
- [x] Code follows the style/conventions of the surrounding code

## Notes for reviewers

