### PR TITLE
feat(awg): implement sweep functions and add tests for Rigol

### DIFF
--- a/docs/guides/instrumentation/awg.mdx
+++ b/docs/guides/instrumentation/awg.mdx
@@ -11,7 +11,7 @@ description: Using InstroAWG for SCPI-based arbitrary waveform generators
 `InstroAWG` ships in the `instro-unstable` package. Its API is not settled and may change without notice between releases. Install it with `pip install "instro[unstable]"`. See [Unstable modules](/instrumentation/installation#unstable-modules) for details.
 </Warning>
 
-`InstroAWG` is a hardware abstraction layer (HAL) that provides a unified interface for arbitrary waveform generators. The category class defines the vendor-independent API (`set_waveform`, `set_amplitude`, `set_offset`, `set_modulation`, …). A vendor-specific driver owns its connection details and translates those calls into vendor commands.
+`InstroAWG` is a hardware abstraction layer (HAL) that provides a unified interface for arbitrary waveform generators. The category class defines the vendor-independent API (`set_waveform`, `set_amplitude`, `set_offset`, `set_modulation`, `set_sweep`, …). A vendor-specific driver owns its connection details and translates those calls into vendor commands.
 
 ## Supported Vendors
 
@@ -158,6 +158,13 @@ Every measurement/command call produces a channel keyed under `{name}.{descripto
 | `set_burst_gate_polarity(channel=N)` | `ch{N}.burst_gate_polarity.cmd` | command |
 | `set_burst_ncycles(channel=N)` | `ch{N}.burst_ncycles.cmd` | command |
 | `set_burst_period(channel=N)` | `ch{N}.burst_period.cmd` | command |
+| `set_sweep(channel=N)` | `ch{N}.sweep.cmd` | command |
+| `sweep_enable(channel=N)` | `ch{N}.sweep_enabled.cmd` | command |
+| `set_sweep_start_freq(channel=N)` | `ch{N}.sweep_start_freq.cmd` | command |
+| `set_sweep_end_freq(channel=N)` | `ch{N}.sweep_end_freq.cmd` | command |
+| `set_sweep_time(channel=N)` | `ch{N}.sweep_time.cmd` | command |
+| `set_sweep_hold_time(channel=N)` | `ch{N}.sweep_hold_time.cmd` | command |
+| `set_sweep_return_time(channel=N)` | `ch{N}.sweep_return_time.cmd` | command |
 | `get_offset(channel=N)` | `ch{N}.offset` | telemetry |
 | `get_output_state(channel=N)` | `ch{N}.enabled` | telemetry |
 | `get_output_load(channel=N)` | `ch{N}.load` | telemetry |
@@ -166,9 +173,15 @@ Every measurement/command call produces a channel keyed under `{name}.{descripto
 | `get_burst_delay(channel=N)` | `ch{N}.burst_delay` | telemetry |
 | `get_burst_ncycles(channel=N)` | `ch{N}.burst_ncycles` | telemetry |
 | `get_burst_period(channel=N)` | `ch{N}.burst_period` | telemetry |
+| `get_sweep_state(channel=N)` | `ch{N}.sweep_enabled` | telemetry |
+| `get_sweep_start_freq(channel=N)` | `ch{N}.sweep_start_freq` | telemetry |
+| `get_sweep_end_freq(channel=N)` | `ch{N}.sweep_end_freq` | telemetry |
+| `get_sweep_time(channel=N)` | `ch{N}.sweep_time` | telemetry |
+| `get_sweep_hold_time(channel=N)` | `ch{N}.sweep_hold_time` | telemetry |
+| `get_sweep_return_time(channel=N)` | `ch{N}.sweep_return_time` | telemetry |
 
 <Note>
-`get_waveform()`, `get_amplitude()`, `convert_amplitude()`, `get_modulation_type()`, `get_burst_type()`, `get_burst_trigger()`, and `get_burst_gate_polarity()` return a plain Python value (`Waveform`, `tuple[float, AmplitudeMeasurementUnit]`, `float`, `ModulationType`, `BurstType`, `BurstTriggerSource`, `GatePolarity`) directly rather than a `Measurement`, and don't publish. Every other readback listed above publishes a `Measurement` on the descriptor shown.
+`get_waveform()`, `get_amplitude()`, `convert_amplitude()`, `get_modulation_type()`, `get_burst_type()`, `get_burst_trigger()`, `get_burst_gate_polarity()`, and `get_sweep_type()` return a plain Python value (`Waveform`, `tuple[float, AmplitudeMeasurementUnit]`, `float`, `ModulationType`, `BurstType`, `BurstTriggerSource`, `GatePolarity`, `SweepType`) directly rather than a `Measurement`, and don't publish. Every other readback listed above publishes a `Measurement` on the descriptor shown.
 </Note>
 
 ## Method Reference
@@ -209,6 +222,20 @@ Every measurement/command call produces a channel keyed under `{name}.{descripto
 | `get_burst_ncycles(channel)` | Read back the number of cycles per trigger for NCYCLE bursts on channel |
 | `set_burst_period(channel, period)` | Set the internal burst period in seconds on channel |
 | `get_burst_period(channel)` | Read back the internal burst period in seconds on channel |
+| `set_sweep(channel, sweep_type)` | Configure a channel's sweep type (`LINEAR`/`LOG`/`STEP`) |
+| `get_sweep_type(channel)` | Read back the sweep type currently configured on channel |
+| `sweep_enable(channel, enable)` | Enable or disable sweep mode on channel |
+| `get_sweep_state(channel)` | Read back whether sweep mode is enabled on channel |
+| `set_sweep_start_freq(channel, frequency_hz)` | Set the sweep start frequency in Hz on a channel |
+| `get_sweep_start_freq(channel)` | Read back the sweep start frequency in Hz on a channel |
+| `set_sweep_end_freq(channel, frequency_hz)` | Set the sweep end frequency in Hz on a channel |
+| `get_sweep_end_freq(channel)` | Read back the sweep end frequency in Hz on a channel |
+| `set_sweep_time(channel, sweep_time)` | Set the sweep time in seconds on a channel |
+| `get_sweep_time(channel)` | Read back the sweep time in seconds on a channel |
+| `set_sweep_hold_time(channel, hold_time)` | Set the sweep hold time in seconds on a channel |
+| `get_sweep_hold_time(channel)` | Read back the sweep hold time in seconds on a channel |
+| `set_sweep_return_time(channel, return_time)` | Set the sweep return time in seconds on a channel |
+| `get_sweep_return_time(channel)` | Read back the sweep return time in seconds on a channel |
 | `start()` | Begin background daemon |
 | `stop()` | End background daemon |
 
@@ -295,6 +322,13 @@ Optional overrides (raise `NotImplementedError` if not supported):
 - **`set_burst_gate_polarity(channel, gate_polarity)`** / **`get_burst_gate_polarity(channel)`**: Set or read back the gate polarity (`NORM`/`INV`) for GATED bursts.
 - **`set_burst_ncycles(channel, n_cycles)`** / **`get_burst_ncycles(channel)`**: Set or read back the number of cycles per trigger for NCYCLE bursts.
 - **`set_burst_period(channel, period)`** / **`get_burst_period(channel)`**: Set or read back the internal burst period in seconds.
+- **`set_sweep(channel, sweep_type)`** / **`get_sweep_type(channel)`**: Configure or read back a channel's sweep type (`LINEAR`/`LOG`/`STEP`).
+- **`sweep_enable(channel, enable)`** / **`get_sweep_state(channel)`**: Enable or disable sweep mode, or read back whether it's enabled.
+- **`set_sweep_start_freq(channel, frequency_hz)`** / **`get_sweep_start_freq(channel)`**: Set or read the sweep start frequency.
+- **`set_sweep_end_freq(channel, frequency_hz)`** / **`get_sweep_end_freq(channel)`**: Set or read the sweep end frequency.
+- **`set_sweep_time(channel, sweep_time)`** / **`get_sweep_time(channel)`**: Set or read the sweep time.
+- **`set_sweep_hold_time(channel, hold_time)`** / **`get_sweep_hold_time(channel)`**: Set or read the sweep hold time.
+- **`set_sweep_return_time(channel, return_time)`** / **`get_sweep_return_time(channel)`**: Set or read the sweep return time.
 
 ### Talking to the Instrument
 

--- a/docs/guides/instrumentation/awg.mdx
+++ b/docs/guides/instrumentation/awg.mdx
@@ -160,6 +160,7 @@ Every measurement/command call produces a channel keyed under `{name}.{descripto
 | `set_burst_period(channel=N)` | `ch{N}.burst_period.cmd` | command |
 | `set_sweep(channel=N)` | `ch{N}.sweep.cmd` | command |
 | `sweep_enable(channel=N)` | `ch{N}.sweep_enabled.cmd` | command |
+| `set_sweep_trigger(channel=N)` | `ch{N}.sweep_trigger.cmd` | command |
 | `set_sweep_start_freq(channel=N)` | `ch{N}.sweep_start_freq.cmd` | command |
 | `set_sweep_end_freq(channel=N)` | `ch{N}.sweep_end_freq.cmd` | command |
 | `set_sweep_time(channel=N)` | `ch{N}.sweep_time.cmd` | command |
@@ -182,7 +183,7 @@ Every measurement/command call produces a channel keyed under `{name}.{descripto
 | `get_sweep_return_time(channel=N)` | `ch{N}.sweep_return_time` | telemetry |
 
 <Note>
-`get_waveform()`, `get_amplitude()`, `convert_amplitude()`, `get_modulation_type()`, `get_burst_type()`, `get_burst_trigger()`, `get_burst_gate_polarity()`, and `get_sweep_type()` return a plain Python value (`Waveform`, `tuple[float, AmplitudeMeasurementUnit]`, `float`, `ModulationType`, `BurstType`, `BurstTriggerSource`, `GatePolarity`, `SweepType`) directly rather than a `Measurement`, and don't publish. Every other readback listed above publishes a `Measurement` on the descriptor shown.
+`get_waveform()`, `get_amplitude()`, `convert_amplitude()`, `get_modulation_type()`, `get_burst_type()`, `get_burst_trigger()`, `get_burst_gate_polarity()`, `get_sweep_type()`, and `get_sweep_trigger()` return a plain Python value (`Waveform`, `tuple[float, AmplitudeMeasurementUnit]`, `float`, `ModulationType`, `BurstType`, `BurstTriggerSource`, `GatePolarity`, `SweepType`, `SweepTriggerSource`) directly rather than a `Measurement`, and don't publish. Every other readback listed above publishes a `Measurement` on the descriptor shown.
 </Note>
 
 ## Method Reference
@@ -227,6 +228,8 @@ Every measurement/command call produces a channel keyed under `{name}.{descripto
 | `get_sweep_type(channel)` | Read back the sweep type currently configured on channel |
 | `sweep_enable(channel, enable)` | Enable or disable sweep mode on channel |
 | `get_sweep_state(channel)` | Read back whether sweep mode is enabled on channel |
+| `set_sweep_trigger(channel, source)` | Set the sweep trigger source (`INTERNAL`/`EXTERNAL`/`MANUAL`) on channel |
+| `get_sweep_trigger(channel)` | Read back the sweep trigger source on channel |
 | `set_sweep_start_freq(channel, frequency_hz)` | Set the sweep start frequency in Hz on a channel |
 | `get_sweep_start_freq(channel)` | Read back the sweep start frequency in Hz on a channel |
 | `set_sweep_end_freq(channel, frequency_hz)` | Set the sweep end frequency in Hz on a channel |
@@ -326,6 +329,7 @@ Optional overrides (raise `NotImplementedError` if not supported):
 - **`set_burst_period(channel, period)`** / **`get_burst_period(channel)`**: Set or read back the internal burst period in seconds.
 - **`set_sweep(channel, sweep_type)`** / **`get_sweep_type(channel)`**: Configure or read back a channel's sweep type (`LINEAR`/`LOG`/`STEP`).
 - **`sweep_enable(channel, enable)`** / **`get_sweep_state(channel)`**: Enable or disable sweep mode, or read back whether it's enabled.
+- **`set_sweep_trigger(channel, source)`** / **`get_sweep_trigger(channel)`**: Set or read back the sweep trigger source (`INTERNAL`/`EXTERNAL`/`MANUAL`).
 - **`set_sweep_start_freq(channel, frequency_hz)`** / **`get_sweep_start_freq(channel)`**: Set or read the sweep start frequency.
 - **`set_sweep_end_freq(channel, frequency_hz)`** / **`get_sweep_end_freq(channel)`**: Set or read the sweep end frequency.
 - **`set_sweep_time(channel, sweep_time)`** / **`get_sweep_time(channel)`**: Set or read the sweep time.

--- a/docs/guides/instrumentation/awg.mdx
+++ b/docs/guides/instrumentation/awg.mdx
@@ -165,6 +165,7 @@ Every measurement/command call produces a channel keyed under `{name}.{descripto
 | `set_sweep_time(channel=N)` | `ch{N}.sweep_time.cmd` | command |
 | `set_sweep_hold_time(channel=N)` | `ch{N}.sweep_hold_time.cmd` | command |
 | `set_sweep_return_time(channel=N)` | `ch{N}.sweep_return_time.cmd` | command |
+| `fire_sweep_trigger(channel=N)` | `ch{N}.sweep_trigger_forced.cmd` | command |
 | `get_offset(channel=N)` | `ch{N}.offset` | telemetry |
 | `get_output_state(channel=N)` | `ch{N}.enabled` | telemetry |
 | `get_output_load(channel=N)` | `ch{N}.load` | telemetry |
@@ -236,6 +237,7 @@ Every measurement/command call produces a channel keyed under `{name}.{descripto
 | `get_sweep_hold_time(channel)` | Read back the sweep hold time in seconds on a channel |
 | `set_sweep_return_time(channel, return_time)` | Set the sweep return time in seconds on a channel |
 | `get_sweep_return_time(channel)` | Read back the sweep return time in seconds on a channel |
+| `fire_sweep_trigger(channel)` | Manually trigger a sweep on a channel |
 | `start()` | Begin background daemon |
 | `stop()` | End background daemon |
 
@@ -329,6 +331,7 @@ Optional overrides (raise `NotImplementedError` if not supported):
 - **`set_sweep_time(channel, sweep_time)`** / **`get_sweep_time(channel)`**: Set or read the sweep time.
 - **`set_sweep_hold_time(channel, hold_time)`** / **`get_sweep_hold_time(channel)`**: Set or read the sweep hold time.
 - **`set_sweep_return_time(channel, return_time)`** / **`get_sweep_return_time(channel)`**: Set or read the sweep return time.
+- **`fire_sweep_trigger(channel)`**: Manually trigger a sweep on channel.
 
 ### Talking to the Instrument
 

--- a/packages/instro-unstable/instro/unstable/awg/__init__.py
+++ b/packages/instro-unstable/instro/unstable/awg/__init__.py
@@ -16,6 +16,7 @@ from instro.unstable.awg.types import (
     Sine,
     Square,
     StaticValue,
+    SweepType,
     Triangle,
     Waveform,
     convert_amplitude,
@@ -37,5 +38,6 @@ __all__ = [
     "BurstType",
     "BurstTriggerSource",
     "GatePolarity",
+    "SweepType",
     "convert_amplitude",
 ]

--- a/packages/instro-unstable/instro/unstable/awg/__init__.py
+++ b/packages/instro-unstable/instro/unstable/awg/__init__.py
@@ -16,6 +16,7 @@ from instro.unstable.awg.types import (
     Sine,
     Square,
     StaticValue,
+    SweepTriggerSource,
     SweepType,
     Triangle,
     Waveform,
@@ -39,5 +40,6 @@ __all__ = [
     "BurstTriggerSource",
     "GatePolarity",
     "SweepType",
+    "SweepTriggerSource",
     "convert_amplitude",
 ]

--- a/packages/instro-unstable/instro/unstable/awg/awg.py
+++ b/packages/instro-unstable/instro/unstable/awg/awg.py
@@ -220,6 +220,10 @@ class AWGDriverBase(abc.ABC):
         """Get the sweep return time (seconds) on channel."""
         raise NotImplementedError(f"get_sweep_return_time is not implemented for {type(self).__name__}")
 
+    def fire_sweep_trigger(self, channel: int) -> None:
+        """Manually trigger a sweep on channel."""
+        raise NotImplementedError(f"fire_sweep_trigger is not implemented for {type(self).__name__}")
+
 
 _PUBLISHED_NAMES: dict[type, str] = {
     Sine: "SINE",
@@ -701,3 +705,13 @@ class InstroAWG(Instrument):
         """Read back the sweep return time (seconds) on channel."""
         self._check_channel(channel)
         return self._execute_measurement(self._driver.get_sweep_return_time, channel, "sweep_return_time", **kwargs)
+
+    @publish_command
+    def fire_sweep_trigger(self, channel: int, **kwargs) -> Command:
+        """Trigger a sweep on a channel manually."""
+        self._check_channel(channel)
+        with self._resource_lock:
+            self._driver.fire_sweep_trigger(channel=channel)
+            timestamp = time.time_ns()
+        descriptor = f"ch{channel}.sweep_trigger_forced.cmd"
+        return self._package_command(descriptor, "TRIGGER", timestamp, **kwargs)

--- a/packages/instro-unstable/instro/unstable/awg/awg.py
+++ b/packages/instro-unstable/instro/unstable/awg/awg.py
@@ -24,6 +24,7 @@ from instro.unstable.awg.types import (
     Sine,
     Square,
     StaticValue,
+    SweepTriggerSource,
     SweepType,
     Triangle,
     Waveform,
@@ -179,6 +180,14 @@ class AWGDriverBase(abc.ABC):
     def get_sweep_state(self, channel: int) -> bool:
         """Return True if sweep mode is enabled on channel."""
         raise NotImplementedError(f"get_sweep_state is not implemented for {type(self).__name__}")
+
+    def set_sweep_trigger(self, channel: int, source: SweepTriggerSource) -> None:
+        """Set the sweep trigger source on channel."""
+        raise NotImplementedError(f"set_sweep_trigger is not implemented for {type(self).__name__}")
+
+    def get_sweep_trigger(self, channel: int) -> SweepTriggerSource:
+        """Get the sweep trigger source on channel."""
+        raise NotImplementedError(f"get_sweep_trigger is not implemented for {type(self).__name__}")
 
     def set_sweep_start_freq(self, channel: int, frequency_hz: float) -> None:
         """Set the sweep start frequency (Hz) on channel."""
@@ -651,6 +660,25 @@ class InstroAWG(Instrument):
         """Read back whether sweep mode is enabled on channel."""
         self._check_channel(channel)
         return self._execute_measurement(self._driver.get_sweep_state, channel, "sweep_enabled", **kwargs)
+
+    @publish_command
+    def set_sweep_trigger(self, channel: int, source: SweepTriggerSource, **kwargs) -> Command:
+        """Set the sweep trigger source on channel."""
+        if not isinstance(source, SweepTriggerSource):
+            raise TypeError(f"source must be a SweepTriggerSource, got {type(source).__name__}")
+        self._check_channel(channel)
+        with self._resource_lock:
+            self._driver.set_sweep_trigger(channel=channel, source=source)
+            timestamp = time.time_ns()
+        descriptor = f"ch{channel}.sweep_trigger.cmd"
+        return self._package_command(descriptor, source.value, timestamp, **kwargs)
+
+    def get_sweep_trigger(self, channel: int) -> SweepTriggerSource:
+        """Read back the sweep trigger source on channel."""
+        self._check_channel(channel)
+        with self._resource_lock:
+            source = self._driver.get_sweep_trigger(channel=channel)
+        return source
 
     def set_sweep_start_freq(self, channel: int, frequency_hz: float, **kwargs) -> Command:
         """Set the sweep start frequency (Hz) on channel."""

--- a/packages/instro-unstable/instro/unstable/awg/awg.py
+++ b/packages/instro-unstable/instro/unstable/awg/awg.py
@@ -24,6 +24,7 @@ from instro.unstable.awg.types import (
     Sine,
     Square,
     StaticValue,
+    SweepType,
     Triangle,
     Waveform,
     convert_amplitude,
@@ -162,6 +163,62 @@ class AWGDriverBase(abc.ABC):
     def get_burst_period(self, channel: int) -> float:
         """Get the internal burst period (seconds) on channel."""
         raise NotImplementedError(f"get_burst_period is not implemented for {type(self).__name__}")
+
+    def set_sweep(self, channel: int, sweep_type: SweepType) -> None:
+        """Configure the sweep type on channel."""
+        raise NotImplementedError(f"set_sweep is not implemented for {type(self).__name__}")
+
+    def get_sweep_type(self, channel: int) -> SweepType:
+        """Get the sweep type currently configured on channel."""
+        raise NotImplementedError(f"get_sweep_type is not implemented for {type(self).__name__}")
+
+    def sweep_enable(self, channel: int, enable: bool) -> None:
+        """Enable or disable sweep mode on channel."""
+        raise NotImplementedError(f"sweep_enable is not implemented for {type(self).__name__}")
+
+    def get_sweep_state(self, channel: int) -> bool:
+        """Return True if sweep mode is enabled on channel."""
+        raise NotImplementedError(f"get_sweep_state is not implemented for {type(self).__name__}")
+
+    def set_sweep_start_freq(self, channel: int, frequency_hz: float) -> None:
+        """Set the sweep start frequency (Hz) on channel."""
+        raise NotImplementedError(f"set_sweep_start_freq is not implemented for {type(self).__name__}")
+
+    def get_sweep_start_freq(self, channel: int) -> float:
+        """Get the sweep start frequency (Hz) on channel."""
+        raise NotImplementedError(f"get_sweep_start_freq is not implemented for {type(self).__name__}")
+
+    def set_sweep_end_freq(self, channel: int, frequency_hz: float) -> None:
+        """Set the sweep end frequency (Hz) on channel."""
+        raise NotImplementedError(f"set_sweep_end_freq is not implemented for {type(self).__name__}")
+
+    def get_sweep_end_freq(self, channel: int) -> float:
+        """Get the sweep end frequency (Hz) on channel."""
+        raise NotImplementedError(f"get_sweep_end_freq is not implemented for {type(self).__name__}")
+
+    def set_sweep_time(self, channel: int, sweep_time: float) -> None:
+        """Set the sweep time (seconds) on channel."""
+        raise NotImplementedError(f"set_sweep_time is not implemented for {type(self).__name__}")
+
+    def get_sweep_time(self, channel: int) -> float:
+        """Get the sweep time (seconds) on channel."""
+        raise NotImplementedError(f"get_sweep_time is not implemented for {type(self).__name__}")
+
+    def set_sweep_hold_time(self, channel: int, hold_time: float) -> None:
+        """Set the sweep hold time (seconds) on channel."""
+        raise NotImplementedError(f"set_sweep_hold_time is not implemented for {type(self).__name__}")
+
+    def get_sweep_hold_time(self, channel: int) -> float:
+        """Get the sweep hold time (seconds) on channel."""
+        raise NotImplementedError(f"get_sweep_hold_time is not implemented for {type(self).__name__}")
+
+    def set_sweep_return_time(self, channel: int, return_time: float) -> None:
+        """Set the sweep return time (seconds) on channel."""
+        raise NotImplementedError(f"set_sweep_return_time is not implemented for {type(self).__name__}")
+
+    def get_sweep_return_time(self, channel: int) -> float:
+        """Get the sweep return time (seconds) on channel."""
+        raise NotImplementedError(f"get_sweep_return_time is not implemented for {type(self).__name__}")
 
 
 _PUBLISHED_NAMES: dict[type, str] = {
@@ -561,3 +618,86 @@ class InstroAWG(Instrument):
         """Read back the internal burst period (seconds) on channel."""
         self._check_channel(channel)
         return self._execute_measurement(self._driver.get_burst_period, channel, "burst_period", **kwargs)
+
+    @publish_command
+    def set_sweep(self, channel: int, sweep_type: SweepType, **kwargs) -> Command:
+        """Configure the sweep type on channel."""
+        if not isinstance(sweep_type, SweepType):
+            raise TypeError(f"sweep_type must be a SweepType, got {type(sweep_type).__name__}")
+        self._check_channel(channel)
+        with self._resource_lock:
+            self._driver.set_sweep(channel=channel, sweep_type=sweep_type)
+            timestamp = time.time_ns()
+        descriptor = f"ch{channel}.sweep.cmd"
+        return self._package_command(descriptor, sweep_type.value, timestamp, **kwargs)
+
+    def get_sweep_type(self, channel: int) -> SweepType:
+        """Read back the sweep type currently configured on channel."""
+        self._check_channel(channel)
+        with self._resource_lock:
+            sweep_type = self._driver.get_sweep_type(channel=channel)
+        return sweep_type
+
+    def sweep_enable(self, channel: int, enable: bool, **kwargs) -> Command:
+        """Enable or disable sweep mode on channel."""
+        self._check_channel(channel)
+        return self._execute_command(self._driver.sweep_enable, channel, enable, "sweep_enabled", **kwargs)
+
+    def get_sweep_state(self, channel: int, **kwargs) -> Measurement | None:
+        """Read back whether sweep mode is enabled on channel."""
+        self._check_channel(channel)
+        return self._execute_measurement(self._driver.get_sweep_state, channel, "sweep_enabled", **kwargs)
+
+    def set_sweep_start_freq(self, channel: int, frequency_hz: float, **kwargs) -> Command:
+        """Set the sweep start frequency (Hz) on channel."""
+        self._check_channel(channel)
+        return self._execute_command(
+            self._driver.set_sweep_start_freq, channel, frequency_hz, "sweep_start_freq", **kwargs
+        )
+
+    def get_sweep_start_freq(self, channel: int, **kwargs) -> Measurement | None:
+        """Read back the sweep start frequency (Hz) on channel."""
+        self._check_channel(channel)
+        return self._execute_measurement(self._driver.get_sweep_start_freq, channel, "sweep_start_freq", **kwargs)
+
+    def set_sweep_end_freq(self, channel: int, frequency_hz: float, **kwargs) -> Command:
+        """Set the sweep end frequency (Hz) on channel."""
+        self._check_channel(channel)
+        return self._execute_command(self._driver.set_sweep_end_freq, channel, frequency_hz, "sweep_end_freq", **kwargs)
+
+    def get_sweep_end_freq(self, channel: int, **kwargs) -> Measurement | None:
+        """Read back the sweep end frequency (Hz) on channel."""
+        self._check_channel(channel)
+        return self._execute_measurement(self._driver.get_sweep_end_freq, channel, "sweep_end_freq", **kwargs)
+
+    def set_sweep_time(self, channel: int, sweep_time: float, **kwargs) -> Command:
+        """Set the sweep time (seconds) on channel."""
+        self._check_channel(channel)
+        return self._execute_command(self._driver.set_sweep_time, channel, sweep_time, "sweep_time", **kwargs)
+
+    def get_sweep_time(self, channel: int, **kwargs) -> Measurement | None:
+        """Read back the sweep time (seconds) on channel."""
+        self._check_channel(channel)
+        return self._execute_measurement(self._driver.get_sweep_time, channel, "sweep_time", **kwargs)
+
+    def set_sweep_hold_time(self, channel: int, hold_time: float, **kwargs) -> Command:
+        """Set the sweep hold time (seconds) on channel."""
+        self._check_channel(channel)
+        return self._execute_command(self._driver.set_sweep_hold_time, channel, hold_time, "sweep_hold_time", **kwargs)
+
+    def get_sweep_hold_time(self, channel: int, **kwargs) -> Measurement | None:
+        """Read back the sweep hold time (seconds) on channel."""
+        self._check_channel(channel)
+        return self._execute_measurement(self._driver.get_sweep_hold_time, channel, "sweep_hold_time", **kwargs)
+
+    def set_sweep_return_time(self, channel: int, return_time: float, **kwargs) -> Command:
+        """Set the sweep return time (seconds) on channel."""
+        self._check_channel(channel)
+        return self._execute_command(
+            self._driver.set_sweep_return_time, channel, return_time, "sweep_return_time", **kwargs
+        )
+
+    def get_sweep_return_time(self, channel: int, **kwargs) -> Measurement | None:
+        """Read back the sweep return time (seconds) on channel."""
+        self._check_channel(channel)
+        return self._execute_measurement(self._driver.get_sweep_return_time, channel, "sweep_return_time", **kwargs)

--- a/packages/instro-unstable/instro/unstable/awg/drivers/rigol_dg1022z.py
+++ b/packages/instro-unstable/instro/unstable/awg/drivers/rigol_dg1022z.py
@@ -16,6 +16,7 @@ from instro.unstable.awg.types import (
     Sine,
     Square,
     StaticValue,
+    SweepType,
     Triangle,
     Waveform,
 )
@@ -41,6 +42,13 @@ _BURST_MODES: dict[BurstType, str] = {
     BurstType.INFINITE: "INF",
 }
 _BURST_TYPES: dict[str, BurstType] = {mode: burst_type for burst_type, mode in _BURST_MODES.items()}
+
+# :SWE:SPAC? always echoes the instrument's own abbreviated mnemonic, never the full keyword written.
+_SWEEP_SPACING_READBACK: dict[str, SweepType] = {
+    "LIN": SweepType.LINEAR,
+    "LOG": SweepType.LOG,
+    "STE": SweepType.STEP,
+}
 
 
 class RigolDG1022Z(AWGDriverBase):
@@ -384,6 +392,100 @@ class RigolDG1022Z(AWGDriverBase):
         _check_channel(channel)
         with self._visa.lock():
             result = float(self._visa.query(f":SOUR{channel}:BURS:INT:PER?"))
+            self._check_errors()
+        return result
+
+    def set_sweep(self, channel: int, sweep_type: SweepType) -> None:
+        _check_channel(channel)
+        with self._visa.lock():
+            self._visa.write(f":SOUR{channel}:SWE:SPAC {sweep_type.value}")
+            self._check_errors()
+
+    def get_sweep_type(self, channel: int) -> SweepType:
+        _check_channel(channel)
+        with self._visa.lock():
+            resp = self._visa.query(f":SOUR{channel}:SWE:SPAC?").strip()
+            self._check_errors()
+        result = _SWEEP_SPACING_READBACK.get(resp)
+        if result is None:
+            raise ValueError(f"Rigol DG1022Z reported unsupported sweep type '{resp}'")
+        return result
+
+    def sweep_enable(self, channel: int, enable: bool) -> None:
+        _check_channel(channel)
+        with self._visa.lock():
+            self._visa.write(f":SOUR{channel}:SWE:STAT {'ON' if enable else 'OFF'}")
+            self._check_errors()
+
+    def get_sweep_state(self, channel: int) -> bool:
+        _check_channel(channel)
+        with self._visa.lock():
+            result = self._visa.query(f":SOUR{channel}:SWE:STAT?").strip() == "ON"
+            self._check_errors()
+        return result
+
+    def set_sweep_start_freq(self, channel: int, frequency_hz: float) -> None:
+        _check_channel(channel)
+        with self._visa.lock():
+            self._visa.write(f":SOUR{channel}:FREQ:STAR {frequency_hz}")
+            self._check_errors()
+
+    def get_sweep_start_freq(self, channel: int) -> float:
+        _check_channel(channel)
+        with self._visa.lock():
+            result = float(self._visa.query(f":SOUR{channel}:FREQ:STAR?"))
+            self._check_errors()
+        return result
+
+    def set_sweep_end_freq(self, channel: int, frequency_hz: float) -> None:
+        _check_channel(channel)
+        with self._visa.lock():
+            self._visa.write(f":SOUR{channel}:FREQ:STOP {frequency_hz}")
+            self._check_errors()
+
+    def get_sweep_end_freq(self, channel: int) -> float:
+        _check_channel(channel)
+        with self._visa.lock():
+            result = float(self._visa.query(f":SOUR{channel}:FREQ:STOP?"))
+            self._check_errors()
+        return result
+
+    def set_sweep_time(self, channel: int, sweep_time: float) -> None:
+        _check_channel(channel)
+        with self._visa.lock():
+            self._visa.write(f":SOUR{channel}:SWE:TIME {sweep_time}")
+            self._check_errors()
+
+    def get_sweep_time(self, channel: int) -> float:
+        _check_channel(channel)
+        with self._visa.lock():
+            result = float(self._visa.query(f":SOUR{channel}:SWE:TIME?"))
+            self._check_errors()
+        return result
+
+    def set_sweep_hold_time(self, channel: int, hold_time: float) -> None:
+        _check_channel(channel)
+        with self._visa.lock():
+            self._visa.write(f":SOUR{channel}:SWE:HTIM {hold_time}")
+            self._check_errors()
+
+    def get_sweep_hold_time(self, channel: int) -> float:
+        _check_channel(channel)
+        with self._visa.lock():
+            result = float(self._visa.query(f":SOUR{channel}:SWE:HTIM?"))
+            self._check_errors()
+        return result
+
+    def set_sweep_return_time(self, channel: int, return_time: float) -> None:
+        _check_channel(channel)
+        with self._visa.lock():
+            self._visa.write(f":SOUR{channel}:SWE:RTIM {return_time}")
+            self._check_errors()
+
+    def get_sweep_return_time(self, channel: int) -> float:
+        _check_channel(channel)
+        with self._visa.lock():
+            result = float(self._visa.query(f":SOUR{channel}:SWE:RTIM?"))
             self._check_errors()
         return result
 

--- a/packages/instro-unstable/instro/unstable/awg/drivers/rigol_dg1022z.py
+++ b/packages/instro-unstable/instro/unstable/awg/drivers/rigol_dg1022z.py
@@ -398,6 +398,8 @@ class RigolDG1022Z(AWGDriverBase):
 
     def set_sweep(self, channel: int, sweep_type: SweepType) -> None:
         _check_channel(channel)
+        if not isinstance(sweep_type, SweepType):
+            raise TypeError(f"sweep_type must be a SweepType, got {type(sweep_type).__name__}")
         with self._visa.lock():
             carrier = self.get_waveform(channel)
             if isinstance(carrier, StaticValue):

--- a/packages/instro-unstable/instro/unstable/awg/drivers/rigol_dg1022z.py
+++ b/packages/instro-unstable/instro/unstable/awg/drivers/rigol_dg1022z.py
@@ -398,6 +398,9 @@ class RigolDG1022Z(AWGDriverBase):
     def set_sweep(self, channel: int, sweep_type: SweepType) -> None:
         _check_channel(channel)
         with self._visa.lock():
+            carrier = self.get_waveform(channel)
+            if isinstance(carrier, StaticValue):
+                raise ValueError(f"the DG1022Z cannot sweep a StaticValue (DC) waveform on channel {channel}")
             self._visa.write(f":SOUR{channel}:SWE:SPAC {sweep_type.value}")
             self._check_errors()
 

--- a/packages/instro-unstable/instro/unstable/awg/drivers/rigol_dg1022z.py
+++ b/packages/instro-unstable/instro/unstable/awg/drivers/rigol_dg1022z.py
@@ -16,6 +16,7 @@ from instro.unstable.awg.types import (
     Sine,
     Square,
     StaticValue,
+    SweepTriggerSource,
     SweepType,
     Triangle,
     Waveform,
@@ -427,6 +428,21 @@ class RigolDG1022Z(AWGDriverBase):
             self._check_errors()
         return result
 
+    def set_sweep_trigger(self, channel: int, source: SweepTriggerSource) -> None:
+        _check_channel(channel)
+        if not isinstance(source, SweepTriggerSource):
+            raise TypeError(f"source must be a SweepTriggerSource, got {type(source).__name__}")
+        with self._visa.lock():
+            self._visa.write(f":SOUR{channel}:SWE:TRIG:SOUR {source.value}")
+            self._check_errors()
+
+    def get_sweep_trigger(self, channel: int) -> SweepTriggerSource:
+        _check_channel(channel)
+        with self._visa.lock():
+            result = SweepTriggerSource(self._visa.query(f":SOUR{channel}:SWE:TRIG:SOUR?").strip())
+            self._check_errors()
+        return result
+
     def set_sweep_start_freq(self, channel: int, frequency_hz: float) -> None:
         _check_channel(channel)
         with self._visa.lock():
@@ -491,6 +507,22 @@ class RigolDG1022Z(AWGDriverBase):
             result = float(self._visa.query(f":SOUR{channel}:SWE:RTIM?"))
             self._check_errors()
         return result
+
+    def fire_sweep_trigger(self, channel: int) -> None:
+        _check_channel(channel)
+        with self._visa.lock():
+            if not self.get_sweep_state(channel):
+                raise ValueError(
+                    f"Cannot fire a sweep trigger on channel {channel} unless sweep mode is already"
+                    " enabled, call sweep_enable(channel, True) first"
+                )
+            source = self.get_sweep_trigger(channel)
+            if source is not SweepTriggerSource.MANUAL:
+                raise ValueError(
+                    f"Cannot fire a sweep trigger on channel {channel} unless the trigger source is"
+                    f" already MANUAL, call set_sweep_trigger(channel, SweepTriggerSource.MANUAL) first. Got: {source.name}"
+                )
+            self._write_checked(f":SOUR{channel}:SWE:TRIG")
 
     def _write_frequency_and_phase(self, channel: int, frequency_hz: float, phase_deg: float) -> None:
         self._visa.write(f":SOUR{channel}:FREQ {frequency_hz}")

--- a/packages/instro-unstable/instro/unstable/awg/types.py
+++ b/packages/instro-unstable/instro/unstable/awg/types.py
@@ -39,6 +39,12 @@ class GatePolarity(Enum):
     INV = "INV"
 
 
+class SweepType(Enum):
+    LINEAR = "LINEAR"
+    LOG = "LOG"
+    STEP = "STEP"
+
+
 def _require_positive(name: str, value: float) -> None:
     if value <= 0:
         raise ValueError(f"{name} must be positive, got {value}")

--- a/packages/instro-unstable/instro/unstable/awg/types.py
+++ b/packages/instro-unstable/instro/unstable/awg/types.py
@@ -45,6 +45,12 @@ class SweepType(Enum):
     STEP = "STEP"
 
 
+class SweepTriggerSource(Enum):
+    INTERNAL = "INT"
+    EXTERNAL = "EXT"
+    MANUAL = "MAN"
+
+
 def _require_positive(name: str, value: float) -> None:
     if value <= 0:
         raise ValueError(f"{name} must be positive, got {value}")

--- a/tests/unstable/awg/rigol/test_rigol_dg1022z_hardware.py
+++ b/tests/unstable/awg/rigol/test_rigol_dg1022z_hardware.py
@@ -25,6 +25,7 @@ from instro.unstable.awg.types import (
     Sine,
     Square,
     StaticValue,
+    SweepTriggerSource,
     SweepType,
     Triangle,
     Waveform,
@@ -549,7 +550,59 @@ def test_24_sweep_enable_toggle(driver: RigolDG1022Z, channel: int) -> None:
     assert driver.get_sweep_state(channel) is False
 
 
-def test_25_sweep_frequency_bounds_roundtrip(driver: RigolDG1022Z) -> None:
+@pytest.mark.parametrize("source", list(SweepTriggerSource), ids=lambda source: source.value.lower())
+def test_25_sweep_trigger_roundtrip_matches_configured_source(driver: RigolDG1022Z, source: SweepTriggerSource) -> None:
+    driver.set_waveform(1, Sine(frequency_hz=TEST_FREQUENCY_HZ))
+    driver.set_sweep(1, SweepType.LINEAR)
+    driver._check_errors()
+
+    driver.set_sweep_trigger(1, source)
+    driver._check_errors()
+
+    assert driver.get_sweep_trigger(1) is source
+
+
+def test_26_get_sweep_trigger_rejects_invalid_channel(driver: RigolDG1022Z) -> None:
+    with pytest.raises(ValueError, match="channel must be 1 or 2"):
+        driver.get_sweep_trigger(INVALID_CHANNEL)
+
+    driver._check_errors()
+
+
+def test_27_fire_sweep_trigger_fires_when_source_already_manual(driver: RigolDG1022Z) -> None:
+    driver.set_waveform(1, Sine(frequency_hz=TEST_FREQUENCY_HZ))
+    driver.set_sweep(1, SweepType.LINEAR)
+    driver.set_sweep_trigger(1, SweepTriggerSource.MANUAL)
+    driver._check_errors()
+
+    try:
+        driver.output_enable(1, True)
+        driver.sweep_enable(1, True)
+        driver.fire_sweep_trigger(1)
+        driver._check_errors()
+    finally:
+        driver.sweep_enable(1, False)
+        driver.output_enable(1, False)
+
+
+def test_28_fire_sweep_trigger_rejects_non_manual_source(driver: RigolDG1022Z) -> None:
+    driver.set_waveform(1, Sine(frequency_hz=TEST_FREQUENCY_HZ))
+    driver.set_sweep(1, SweepType.LINEAR)
+    driver.set_sweep_trigger(1, SweepTriggerSource.EXTERNAL)
+    driver._check_errors()
+
+    try:
+        driver.sweep_enable(1, True)
+
+        with pytest.raises(ValueError, match="already MANUAL"):
+            driver.fire_sweep_trigger(1)
+
+        driver._check_errors()
+    finally:
+        driver.sweep_enable(1, False)
+
+
+def test_29_sweep_frequency_bounds_roundtrip(driver: RigolDG1022Z) -> None:
     driver.set_waveform(1, Sine(frequency_hz=TEST_FREQUENCY_HZ))
 
     driver.set_sweep_start_freq(1, TEST_SWEEP_START_HZ)
@@ -560,7 +613,7 @@ def test_25_sweep_frequency_bounds_roundtrip(driver: RigolDG1022Z) -> None:
     assert driver.get_sweep_end_freq(1) == pytest.approx(TEST_SWEEP_END_HZ, rel=FREQUENCY_TOLERANCE_REL)
 
 
-def test_26_sweep_timing_roundtrip(driver: RigolDG1022Z) -> None:
+def test_30_sweep_timing_roundtrip(driver: RigolDG1022Z) -> None:
     driver.set_waveform(1, Sine(frequency_hz=TEST_FREQUENCY_HZ))
 
     driver.set_sweep_time(1, TEST_SWEEP_TIME_S)

--- a/tests/unstable/awg/rigol/test_rigol_dg1022z_hardware.py
+++ b/tests/unstable/awg/rigol/test_rigol_dg1022z_hardware.py
@@ -25,6 +25,7 @@ from instro.unstable.awg.types import (
     Sine,
     Square,
     StaticValue,
+    SweepType,
     Triangle,
     Waveform,
 )
@@ -49,6 +50,13 @@ FREQUENCY_TOLERANCE_REL = 1e-4
 AMPLITUDE_TOLERANCE_REL = 0.01
 AMPLITUDE_DBM_TOLERANCE_ABS = 0.1
 PHASE_TOLERANCE_DEG = 0.1
+
+TEST_SWEEP_START_HZ = 100.0
+TEST_SWEEP_END_HZ = 900.0
+TEST_SWEEP_TIME_S = 1.0
+TEST_SWEEP_HOLD_TIME_S = 0.1
+TEST_SWEEP_RETURN_TIME_S = 0.1
+SWEEP_TIME_TOLERANCE_REL = 0.01
 
 _ARB_SAMPLES = (0.0, 0.5, 1.0, 0.5, 0.0, -0.5, -1.0, -0.5, 0.25)
 
@@ -510,3 +518,56 @@ def test_22_fire_burst_trigger_rejects_non_manual_source(driver: RigolDG1022Z) -
         driver.fire_burst_trigger(1)
 
     driver._check_errors()
+
+
+# ---------------------------------------------------------------------------
+# Sweep
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("sweep_type", list(SweepType), ids=lambda sweep_type: sweep_type.value.lower())
+def test_23_set_sweep_and_get_sweep_type_roundtrip(driver: RigolDG1022Z, sweep_type: SweepType) -> None:
+    """Also guards the abbreviated :SWE:SPAC? readback (LIN/LOG/STE) that get_sweep_type() must tolerate."""
+    driver.set_waveform(1, Sine(frequency_hz=TEST_FREQUENCY_HZ))
+
+    driver.set_sweep(1, sweep_type)
+    driver._check_errors()
+
+    assert driver.get_sweep_type(1) is sweep_type
+
+
+@pytest.mark.parametrize("channel", CHANNELS, ids=lambda channel: f"channel_{channel}")
+def test_24_sweep_enable_toggle(driver: RigolDG1022Z, channel: int) -> None:
+    driver.set_waveform(channel, Sine(frequency_hz=TEST_FREQUENCY_HZ))
+    try:
+        driver.sweep_enable(channel, True)
+        driver._check_errors()
+        assert driver.get_sweep_state(channel) is True
+    finally:
+        driver.sweep_enable(channel, False)
+
+    assert driver.get_sweep_state(channel) is False
+
+
+def test_25_sweep_frequency_bounds_roundtrip(driver: RigolDG1022Z) -> None:
+    driver.set_waveform(1, Sine(frequency_hz=TEST_FREQUENCY_HZ))
+
+    driver.set_sweep_start_freq(1, TEST_SWEEP_START_HZ)
+    driver.set_sweep_end_freq(1, TEST_SWEEP_END_HZ)
+    driver._check_errors()
+
+    assert driver.get_sweep_start_freq(1) == pytest.approx(TEST_SWEEP_START_HZ, rel=FREQUENCY_TOLERANCE_REL)
+    assert driver.get_sweep_end_freq(1) == pytest.approx(TEST_SWEEP_END_HZ, rel=FREQUENCY_TOLERANCE_REL)
+
+
+def test_26_sweep_timing_roundtrip(driver: RigolDG1022Z) -> None:
+    driver.set_waveform(1, Sine(frequency_hz=TEST_FREQUENCY_HZ))
+
+    driver.set_sweep_time(1, TEST_SWEEP_TIME_S)
+    driver.set_sweep_hold_time(1, TEST_SWEEP_HOLD_TIME_S)
+    driver.set_sweep_return_time(1, TEST_SWEEP_RETURN_TIME_S)
+    driver._check_errors()
+
+    assert driver.get_sweep_time(1) == pytest.approx(TEST_SWEEP_TIME_S, rel=SWEEP_TIME_TOLERANCE_REL)
+    assert driver.get_sweep_hold_time(1) == pytest.approx(TEST_SWEEP_HOLD_TIME_S, rel=SWEEP_TIME_TOLERANCE_REL)
+    assert driver.get_sweep_return_time(1) == pytest.approx(TEST_SWEEP_RETURN_TIME_S, rel=SWEEP_TIME_TOLERANCE_REL)

--- a/tests/unstable/awg/rigol/test_rigol_dg1022z_software.py
+++ b/tests/unstable/awg/rigol/test_rigol_dg1022z_software.py
@@ -19,6 +19,7 @@ from instro.unstable.awg.types import (
     Sine,
     Square,
     StaticValue,
+    SweepType,
     Triangle,
     Waveform,
 )
@@ -873,3 +874,95 @@ def test_44_fire_burst_trigger_rejects_when_burst_not_enabled(rigol: RigolDG1022
 
     assert _real_query_calls(rigol_visa) == [call(":SOUR1:BURS:STAT?")]
     rigol_visa.write.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Sweep
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("sweep_type", "expected_command"),
+    [
+        (SweepType.LINEAR, ":SOUR1:SWE:SPAC LINEAR"),
+        (SweepType.LOG, ":SOUR1:SWE:SPAC LOG"),
+        (SweepType.STEP, ":SOUR1:SWE:SPAC STEP"),
+    ],
+    ids=["linear", "log", "step"],
+)
+def test_45_set_sweep_writes_spacing_command(
+    rigol: RigolDG1022Z, rigol_visa: MagicMock, sweep_type: SweepType, expected_command: str
+) -> None:
+    rigol.set_sweep(1, sweep_type)
+
+    rigol_visa.write.assert_called_once_with(expected_command)
+
+
+@pytest.mark.parametrize(
+    ("response", "expected"),
+    [
+        ("LIN", SweepType.LINEAR),
+        ("LOG", SweepType.LOG),
+        ("STE", SweepType.STEP),
+    ],
+    ids=["linear", "log", "step"],
+)
+def test_46_get_sweep_type_parses_abbreviated_readback(
+    rigol: RigolDG1022Z, rigol_visa: MagicMock, response: str, expected: SweepType
+) -> None:
+    """The DG1000Z always echoes the abbreviated mnemonic (LIN/LOG/STE), never the full keyword written."""
+    _query_sequence(rigol_visa, [response])
+
+    assert rigol.get_sweep_type(2) is expected
+    assert _real_query_calls(rigol_visa) == [call(":SOUR2:SWE:SPAC?")]
+
+
+def test_47_get_sweep_type_raises_on_unexpected_instrument_response(rigol: RigolDG1022Z, rigol_visa: MagicMock) -> None:
+    _query_sequence(rigol_visa, ["XYZ"])
+
+    with pytest.raises(ValueError, match="unsupported sweep type 'XYZ'"):
+        rigol.get_sweep_type(1)
+
+
+def test_48_sweep_enable_and_get_sweep_state_roundtrip(rigol: RigolDG1022Z, rigol_visa: MagicMock) -> None:
+    rigol.sweep_enable(1, True)
+    rigol.sweep_enable(1, False)
+    assert rigol_visa.write.call_args_list == [call(":SOUR1:SWE:STAT ON"), call(":SOUR1:SWE:STAT OFF")]
+
+    _query_sequence(rigol_visa, ["ON\n"])
+    assert rigol.get_sweep_state(1) is True
+
+    _query_sequence(rigol_visa, ["OFF\n"])
+    assert rigol.get_sweep_state(1) is False
+
+
+def test_49_sweep_frequency_bounds_roundtrip(rigol: RigolDG1022Z, rigol_visa: MagicMock) -> None:
+    rigol.set_sweep_start_freq(1, 100.0)
+    rigol.set_sweep_end_freq(1, 900.0)
+    assert rigol_visa.write.call_args_list == [call(":SOUR1:FREQ:STAR 100.0"), call(":SOUR1:FREQ:STOP 900.0")]
+
+    _query_sequence(rigol_visa, ["1.000000E+02", "9.000000E+02"])
+    assert rigol.get_sweep_start_freq(1) == pytest.approx(100.0)
+    assert rigol.get_sweep_end_freq(1) == pytest.approx(900.0)
+    assert _real_query_calls(rigol_visa) == [call(":SOUR1:FREQ:STAR?"), call(":SOUR1:FREQ:STOP?")]
+
+
+def test_50_sweep_timing_roundtrip(rigol: RigolDG1022Z, rigol_visa: MagicMock) -> None:
+    rigol.set_sweep_time(2, 5.0)
+    rigol.set_sweep_hold_time(2, 1.0)
+    rigol.set_sweep_return_time(2, 0.5)
+    assert rigol_visa.write.call_args_list == [
+        call(":SOUR2:SWE:TIME 5.0"),
+        call(":SOUR2:SWE:HTIM 1.0"),
+        call(":SOUR2:SWE:RTIM 0.5"),
+    ]
+
+    _query_sequence(rigol_visa, ["5.000000E+00", "1.000000E+00", "5.000000E-01"])
+    assert rigol.get_sweep_time(2) == pytest.approx(5.0)
+    assert rigol.get_sweep_hold_time(2) == pytest.approx(1.0)
+    assert rigol.get_sweep_return_time(2) == pytest.approx(0.5)
+    assert _real_query_calls(rigol_visa) == [
+        call(":SOUR2:SWE:TIME?"),
+        call(":SOUR2:SWE:HTIM?"),
+        call(":SOUR2:SWE:RTIM?"),
+    ]

--- a/tests/unstable/awg/rigol/test_rigol_dg1022z_software.py
+++ b/tests/unstable/awg/rigol/test_rigol_dg1022z_software.py
@@ -920,6 +920,14 @@ def test_46_set_sweep_rejects_invalid_input(
     rigol_visa.write.assert_not_called()
 
 
+def test_47_set_sweep_rejects_invalid_type(rigol: RigolDG1022Z, rigol_visa: MagicMock) -> None:
+    with pytest.raises(TypeError, match="sweep_type must be a SweepType"):
+        rigol.set_sweep(1, "LINEAR")  # type: ignore[arg-type]
+
+    rigol_visa.write.assert_not_called()
+    rigol_visa.query.assert_not_called()
+
+
 @pytest.mark.parametrize(
     ("response", "expected"),
     [
@@ -929,7 +937,7 @@ def test_46_set_sweep_rejects_invalid_input(
     ],
     ids=["linear", "log", "step"],
 )
-def test_47_get_sweep_type_parses_abbreviated_readback(
+def test_48_get_sweep_type_parses_abbreviated_readback(
     rigol: RigolDG1022Z, rigol_visa: MagicMock, response: str, expected: SweepType
 ) -> None:
     """The DG1000Z always echoes the abbreviated mnemonic (LIN/LOG/STE), never the full keyword written."""
@@ -939,14 +947,14 @@ def test_47_get_sweep_type_parses_abbreviated_readback(
     assert _real_query_calls(rigol_visa) == [call(":SOUR2:SWE:SPAC?")]
 
 
-def test_48_get_sweep_type_raises_on_unexpected_instrument_response(rigol: RigolDG1022Z, rigol_visa: MagicMock) -> None:
+def test_49_get_sweep_type_raises_on_unexpected_instrument_response(rigol: RigolDG1022Z, rigol_visa: MagicMock) -> None:
     _query_sequence(rigol_visa, ["XYZ"])
 
     with pytest.raises(ValueError, match="unsupported sweep type 'XYZ'"):
         rigol.get_sweep_type(1)
 
 
-def test_49_sweep_enable_and_get_sweep_state_roundtrip(rigol: RigolDG1022Z, rigol_visa: MagicMock) -> None:
+def test_50_sweep_enable_and_get_sweep_state_roundtrip(rigol: RigolDG1022Z, rigol_visa: MagicMock) -> None:
     rigol.sweep_enable(1, True)
     rigol.sweep_enable(1, False)
     assert rigol_visa.write.call_args_list == [call(":SOUR1:SWE:STAT ON"), call(":SOUR1:SWE:STAT OFF")]
@@ -963,7 +971,7 @@ def test_49_sweep_enable_and_get_sweep_state_roundtrip(rigol: RigolDG1022Z, rigo
     [SweepTriggerSource.INTERNAL, SweepTriggerSource.EXTERNAL, SweepTriggerSource.MANUAL],
     ids=["internal", "external", "manual"],
 )
-def test_50_set_sweep_trigger_writes_source(
+def test_51_set_sweep_trigger_writes_source(
     rigol: RigolDG1022Z, rigol_visa: MagicMock, source: SweepTriggerSource
 ) -> None:
     rigol.set_sweep_trigger(1, source)
@@ -971,7 +979,7 @@ def test_50_set_sweep_trigger_writes_source(
     rigol_visa.write.assert_called_once_with(f":SOUR1:SWE:TRIG:SOUR {source.value}")
 
 
-def test_51_set_sweep_trigger_rejects_invalid_source_and_channel(rigol: RigolDG1022Z, rigol_visa: MagicMock) -> None:
+def test_52_set_sweep_trigger_rejects_invalid_source_and_channel(rigol: RigolDG1022Z, rigol_visa: MagicMock) -> None:
     with pytest.raises(TypeError, match="source must be a SweepTriggerSource"):
         rigol.set_sweep_trigger(1, "INT")  # type: ignore[arg-type]
 
@@ -986,7 +994,7 @@ def test_51_set_sweep_trigger_rejects_invalid_source_and_channel(rigol: RigolDG1
     [SweepTriggerSource.INTERNAL, SweepTriggerSource.EXTERNAL, SweepTriggerSource.MANUAL],
     ids=["internal", "external", "manual"],
 )
-def test_52_get_sweep_trigger_parses_every_source(
+def test_53_get_sweep_trigger_parses_every_source(
     rigol: RigolDG1022Z, rigol_visa: MagicMock, source: SweepTriggerSource
 ) -> None:
     _query_sequence(rigol_visa, [source.value])
@@ -995,14 +1003,14 @@ def test_52_get_sweep_trigger_parses_every_source(
     assert _real_query_calls(rigol_visa) == [call(":SOUR1:SWE:TRIG:SOUR?")]
 
 
-def test_53_get_sweep_trigger_rejects_invalid_channel(rigol: RigolDG1022Z, rigol_visa: MagicMock) -> None:
+def test_54_get_sweep_trigger_rejects_invalid_channel(rigol: RigolDG1022Z, rigol_visa: MagicMock) -> None:
     with pytest.raises(ValueError, match="channel must be 1 or 2"):
         rigol.get_sweep_trigger(3)
 
     rigol_visa.query.assert_not_called()
 
 
-def test_54_sweep_frequency_bounds_roundtrip(rigol: RigolDG1022Z, rigol_visa: MagicMock) -> None:
+def test_55_sweep_frequency_bounds_roundtrip(rigol: RigolDG1022Z, rigol_visa: MagicMock) -> None:
     rigol.set_sweep_start_freq(1, 100.0)
     rigol.set_sweep_end_freq(1, 900.0)
     assert rigol_visa.write.call_args_list == [call(":SOUR1:FREQ:STAR 100.0"), call(":SOUR1:FREQ:STOP 900.0")]
@@ -1013,7 +1021,7 @@ def test_54_sweep_frequency_bounds_roundtrip(rigol: RigolDG1022Z, rigol_visa: Ma
     assert _real_query_calls(rigol_visa) == [call(":SOUR1:FREQ:STAR?"), call(":SOUR1:FREQ:STOP?")]
 
 
-def test_55_sweep_timing_roundtrip(rigol: RigolDG1022Z, rigol_visa: MagicMock) -> None:
+def test_56_sweep_timing_roundtrip(rigol: RigolDG1022Z, rigol_visa: MagicMock) -> None:
     rigol.set_sweep_time(2, 5.0)
     rigol.set_sweep_hold_time(2, 1.0)
     rigol.set_sweep_return_time(2, 0.5)
@@ -1034,7 +1042,7 @@ def test_55_sweep_timing_roundtrip(rigol: RigolDG1022Z, rigol_visa: MagicMock) -
     ]
 
 
-def test_56_fire_sweep_trigger_fires_when_source_already_manual(rigol: RigolDG1022Z, rigol_visa: MagicMock) -> None:
+def test_57_fire_sweep_trigger_fires_when_source_already_manual(rigol: RigolDG1022Z, rigol_visa: MagicMock) -> None:
     _query_sequence(rigol_visa, ["ON", "MAN"])
 
     rigol.fire_sweep_trigger(1)
@@ -1043,7 +1051,7 @@ def test_56_fire_sweep_trigger_fires_when_source_already_manual(rigol: RigolDG10
     assert rigol_visa.write.call_args_list == [call(":SOUR1:SWE:TRIG")]
 
 
-def test_57_fire_sweep_trigger_rejects_non_manual_source_and_invalid_channel(
+def test_58_fire_sweep_trigger_rejects_non_manual_source_and_invalid_channel(
     rigol: RigolDG1022Z, rigol_visa: MagicMock
 ) -> None:
     _query_sequence(rigol_visa, ["ON", "EXT"])
@@ -1057,7 +1065,7 @@ def test_57_fire_sweep_trigger_rejects_non_manual_source_and_invalid_channel(
     rigol_visa.write.assert_not_called()
 
 
-def test_58_fire_sweep_trigger_rejects_when_sweep_not_enabled(rigol: RigolDG1022Z, rigol_visa: MagicMock) -> None:
+def test_59_fire_sweep_trigger_rejects_when_sweep_not_enabled(rigol: RigolDG1022Z, rigol_visa: MagicMock) -> None:
     _query_sequence(rigol_visa, ["OFF"])
 
     with pytest.raises(ValueError, match="sweep mode is already"):

--- a/tests/unstable/awg/rigol/test_rigol_dg1022z_software.py
+++ b/tests/unstable/awg/rigol/test_rigol_dg1022z_software.py
@@ -893,9 +893,30 @@ def test_44_fire_burst_trigger_rejects_when_burst_not_enabled(rigol: RigolDG1022
 def test_45_set_sweep_writes_spacing_command(
     rigol: RigolDG1022Z, rigol_visa: MagicMock, sweep_type: SweepType, expected_command: str
 ) -> None:
+    _query_sequence(rigol_visa, [_SINE_CARRIER_APPL_RESPONSE])
+
     rigol.set_sweep(1, sweep_type)
 
     rigol_visa.write.assert_called_once_with(expected_command)
+
+
+@pytest.mark.parametrize(
+    ("channel", "carrier_response", "match"),
+    [
+        (3, _SINE_CARRIER_APPL_RESPONSE, "channel must be 1 or 2"),
+        (1, _DC_CARRIER_APPL_RESPONSE, "cannot sweep a StaticValue"),
+    ],
+    ids=["invalid_channel", "staticvalue_carrier"],
+)
+def test_46_set_sweep_rejects_invalid_input(
+    rigol: RigolDG1022Z, rigol_visa: MagicMock, channel: int, carrier_response: str, match: str
+) -> None:
+    _query_sequence(rigol_visa, [carrier_response])
+
+    with pytest.raises(ValueError, match=match):
+        rigol.set_sweep(channel, SweepType.LINEAR)
+
+    rigol_visa.write.assert_not_called()
 
 
 @pytest.mark.parametrize(
@@ -907,7 +928,7 @@ def test_45_set_sweep_writes_spacing_command(
     ],
     ids=["linear", "log", "step"],
 )
-def test_46_get_sweep_type_parses_abbreviated_readback(
+def test_47_get_sweep_type_parses_abbreviated_readback(
     rigol: RigolDG1022Z, rigol_visa: MagicMock, response: str, expected: SweepType
 ) -> None:
     """The DG1000Z always echoes the abbreviated mnemonic (LIN/LOG/STE), never the full keyword written."""
@@ -917,14 +938,14 @@ def test_46_get_sweep_type_parses_abbreviated_readback(
     assert _real_query_calls(rigol_visa) == [call(":SOUR2:SWE:SPAC?")]
 
 
-def test_47_get_sweep_type_raises_on_unexpected_instrument_response(rigol: RigolDG1022Z, rigol_visa: MagicMock) -> None:
+def test_48_get_sweep_type_raises_on_unexpected_instrument_response(rigol: RigolDG1022Z, rigol_visa: MagicMock) -> None:
     _query_sequence(rigol_visa, ["XYZ"])
 
     with pytest.raises(ValueError, match="unsupported sweep type 'XYZ'"):
         rigol.get_sweep_type(1)
 
 
-def test_48_sweep_enable_and_get_sweep_state_roundtrip(rigol: RigolDG1022Z, rigol_visa: MagicMock) -> None:
+def test_49_sweep_enable_and_get_sweep_state_roundtrip(rigol: RigolDG1022Z, rigol_visa: MagicMock) -> None:
     rigol.sweep_enable(1, True)
     rigol.sweep_enable(1, False)
     assert rigol_visa.write.call_args_list == [call(":SOUR1:SWE:STAT ON"), call(":SOUR1:SWE:STAT OFF")]
@@ -936,7 +957,7 @@ def test_48_sweep_enable_and_get_sweep_state_roundtrip(rigol: RigolDG1022Z, rigo
     assert rigol.get_sweep_state(1) is False
 
 
-def test_49_sweep_frequency_bounds_roundtrip(rigol: RigolDG1022Z, rigol_visa: MagicMock) -> None:
+def test_50_sweep_frequency_bounds_roundtrip(rigol: RigolDG1022Z, rigol_visa: MagicMock) -> None:
     rigol.set_sweep_start_freq(1, 100.0)
     rigol.set_sweep_end_freq(1, 900.0)
     assert rigol_visa.write.call_args_list == [call(":SOUR1:FREQ:STAR 100.0"), call(":SOUR1:FREQ:STOP 900.0")]
@@ -947,7 +968,7 @@ def test_49_sweep_frequency_bounds_roundtrip(rigol: RigolDG1022Z, rigol_visa: Ma
     assert _real_query_calls(rigol_visa) == [call(":SOUR1:FREQ:STAR?"), call(":SOUR1:FREQ:STOP?")]
 
 
-def test_50_sweep_timing_roundtrip(rigol: RigolDG1022Z, rigol_visa: MagicMock) -> None:
+def test_51_sweep_timing_roundtrip(rigol: RigolDG1022Z, rigol_visa: MagicMock) -> None:
     rigol.set_sweep_time(2, 5.0)
     rigol.set_sweep_hold_time(2, 1.0)
     rigol.set_sweep_return_time(2, 0.5)

--- a/tests/unstable/awg/rigol/test_rigol_dg1022z_software.py
+++ b/tests/unstable/awg/rigol/test_rigol_dg1022z_software.py
@@ -19,6 +19,7 @@ from instro.unstable.awg.types import (
     Sine,
     Square,
     StaticValue,
+    SweepTriggerSource,
     SweepType,
     Triangle,
     Waveform,
@@ -957,7 +958,51 @@ def test_49_sweep_enable_and_get_sweep_state_roundtrip(rigol: RigolDG1022Z, rigo
     assert rigol.get_sweep_state(1) is False
 
 
-def test_50_sweep_frequency_bounds_roundtrip(rigol: RigolDG1022Z, rigol_visa: MagicMock) -> None:
+@pytest.mark.parametrize(
+    "source",
+    [SweepTriggerSource.INTERNAL, SweepTriggerSource.EXTERNAL, SweepTriggerSource.MANUAL],
+    ids=["internal", "external", "manual"],
+)
+def test_50_set_sweep_trigger_writes_source(
+    rigol: RigolDG1022Z, rigol_visa: MagicMock, source: SweepTriggerSource
+) -> None:
+    rigol.set_sweep_trigger(1, source)
+
+    rigol_visa.write.assert_called_once_with(f":SOUR1:SWE:TRIG:SOUR {source.value}")
+
+
+def test_51_set_sweep_trigger_rejects_invalid_source_and_channel(rigol: RigolDG1022Z, rigol_visa: MagicMock) -> None:
+    with pytest.raises(TypeError, match="source must be a SweepTriggerSource"):
+        rigol.set_sweep_trigger(1, "INT")  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="channel must be 1 or 2"):
+        rigol.set_sweep_trigger(3, SweepTriggerSource.INTERNAL)
+
+    rigol_visa.write.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "source",
+    [SweepTriggerSource.INTERNAL, SweepTriggerSource.EXTERNAL, SweepTriggerSource.MANUAL],
+    ids=["internal", "external", "manual"],
+)
+def test_52_get_sweep_trigger_parses_every_source(
+    rigol: RigolDG1022Z, rigol_visa: MagicMock, source: SweepTriggerSource
+) -> None:
+    _query_sequence(rigol_visa, [source.value])
+
+    assert rigol.get_sweep_trigger(1) is source
+    assert _real_query_calls(rigol_visa) == [call(":SOUR1:SWE:TRIG:SOUR?")]
+
+
+def test_53_get_sweep_trigger_rejects_invalid_channel(rigol: RigolDG1022Z, rigol_visa: MagicMock) -> None:
+    with pytest.raises(ValueError, match="channel must be 1 or 2"):
+        rigol.get_sweep_trigger(3)
+
+    rigol_visa.query.assert_not_called()
+
+
+def test_54_sweep_frequency_bounds_roundtrip(rigol: RigolDG1022Z, rigol_visa: MagicMock) -> None:
     rigol.set_sweep_start_freq(1, 100.0)
     rigol.set_sweep_end_freq(1, 900.0)
     assert rigol_visa.write.call_args_list == [call(":SOUR1:FREQ:STAR 100.0"), call(":SOUR1:FREQ:STOP 900.0")]
@@ -968,7 +1013,7 @@ def test_50_sweep_frequency_bounds_roundtrip(rigol: RigolDG1022Z, rigol_visa: Ma
     assert _real_query_calls(rigol_visa) == [call(":SOUR1:FREQ:STAR?"), call(":SOUR1:FREQ:STOP?")]
 
 
-def test_51_sweep_timing_roundtrip(rigol: RigolDG1022Z, rigol_visa: MagicMock) -> None:
+def test_55_sweep_timing_roundtrip(rigol: RigolDG1022Z, rigol_visa: MagicMock) -> None:
     rigol.set_sweep_time(2, 5.0)
     rigol.set_sweep_hold_time(2, 1.0)
     rigol.set_sweep_return_time(2, 0.5)
@@ -987,3 +1032,36 @@ def test_51_sweep_timing_roundtrip(rigol: RigolDG1022Z, rigol_visa: MagicMock) -
         call(":SOUR2:SWE:HTIM?"),
         call(":SOUR2:SWE:RTIM?"),
     ]
+
+
+def test_56_fire_sweep_trigger_fires_when_source_already_manual(rigol: RigolDG1022Z, rigol_visa: MagicMock) -> None:
+    _query_sequence(rigol_visa, ["ON", "MAN"])
+
+    rigol.fire_sweep_trigger(1)
+
+    assert _real_query_calls(rigol_visa) == [call(":SOUR1:SWE:STAT?"), call(":SOUR1:SWE:TRIG:SOUR?")]
+    assert rigol_visa.write.call_args_list == [call(":SOUR1:SWE:TRIG")]
+
+
+def test_57_fire_sweep_trigger_rejects_non_manual_source_and_invalid_channel(
+    rigol: RigolDG1022Z, rigol_visa: MagicMock
+) -> None:
+    _query_sequence(rigol_visa, ["ON", "EXT"])
+
+    with pytest.raises(ValueError, match="already MANUAL"):
+        rigol.fire_sweep_trigger(1)
+
+    with pytest.raises(ValueError, match="channel must be 1 or 2"):
+        rigol.fire_sweep_trigger(3)
+
+    rigol_visa.write.assert_not_called()
+
+
+def test_58_fire_sweep_trigger_rejects_when_sweep_not_enabled(rigol: RigolDG1022Z, rigol_visa: MagicMock) -> None:
+    _query_sequence(rigol_visa, ["OFF"])
+
+    with pytest.raises(ValueError, match="sweep mode is already"):
+        rigol.fire_sweep_trigger(1)
+
+    assert _real_query_calls(rigol_visa) == [call(":SOUR1:SWE:STAT?")]
+    rigol_visa.write.assert_not_called()

--- a/tests/unstable/awg/test_awg.py
+++ b/tests/unstable/awg/test_awg.py
@@ -20,6 +20,7 @@ from instro.unstable.awg.types import (
     GatePolarity,
     ModulationType,
     Sine,
+    SweepType,
     Waveform,
 )
 
@@ -108,6 +109,20 @@ def test_01_awg_driver_base_contract_enforces_instantiation_rules() -> None:
         ("get_burst_ncycles", (1,)),
         ("set_burst_period", (1, 0.001)),
         ("get_burst_period", (1,)),
+        ("set_sweep", (1, SweepType.LINEAR)),
+        ("get_sweep_type", (1,)),
+        ("sweep_enable", (1, True)),
+        ("get_sweep_state", (1,)),
+        ("set_sweep_start_freq", (1, 100.0)),
+        ("get_sweep_start_freq", (1,)),
+        ("set_sweep_end_freq", (1, 200.0)),
+        ("get_sweep_end_freq", (1,)),
+        ("set_sweep_time", (1, 0.5)),
+        ("get_sweep_time", (1,)),
+        ("set_sweep_hold_time", (1, 0.1)),
+        ("get_sweep_hold_time", (1,)),
+        ("set_sweep_return_time", (1, 0.1)),
+        ("get_sweep_return_time", (1,)),
     ],
 )
 def test_02_awg_driver_base_optional_methods_raise_not_implemented(
@@ -138,6 +153,8 @@ def mock_driver() -> MagicMock:
     driver.get_burst_state.return_value = False
     driver.get_burst_trigger.return_value = BurstTriggerSource.INTERNAL
     driver.get_burst_gate_polarity.return_value = GatePolarity.NORM
+    driver.get_sweep_type.return_value = SweepType.LINEAR
+    driver.get_sweep_state.return_value = False
     return driver
 
 
@@ -238,6 +255,20 @@ def test_04_helper_tags_avoid_collision_with_positional_params(awg: InstroAWG) -
         ("get_burst_ncycles", ()),
         ("set_burst_period", (0.001,)),
         ("get_burst_period", ()),
+        ("set_sweep", (SweepType.LINEAR,)),
+        ("get_sweep_type", ()),
+        ("sweep_enable", (True,)),
+        ("get_sweep_state", ()),
+        ("set_sweep_start_freq", (100.0,)),
+        ("get_sweep_start_freq", ()),
+        ("set_sweep_end_freq", (200.0,)),
+        ("get_sweep_end_freq", ()),
+        ("set_sweep_time", (0.5,)),
+        ("get_sweep_time", ()),
+        ("set_sweep_hold_time", (0.1,)),
+        ("get_sweep_hold_time", ()),
+        ("set_sweep_return_time", (0.1,)),
+        ("get_sweep_return_time", ()),
     ],
 )
 @pytest.mark.parametrize("channel", [0, 1, 2, 3])

--- a/tests/unstable/awg/test_awg.py
+++ b/tests/unstable/awg/test_awg.py
@@ -123,6 +123,7 @@ def test_01_awg_driver_base_contract_enforces_instantiation_rules() -> None:
         ("get_sweep_hold_time", (1,)),
         ("set_sweep_return_time", (1, 0.1)),
         ("get_sweep_return_time", (1,)),
+        ("fire_sweep_trigger", (1,)),
     ],
 )
 def test_02_awg_driver_base_optional_methods_raise_not_implemented(
@@ -269,6 +270,7 @@ def test_04_helper_tags_avoid_collision_with_positional_params(awg: InstroAWG) -
         ("get_sweep_hold_time", ()),
         ("set_sweep_return_time", (0.1,)),
         ("get_sweep_return_time", ()),
+        ("fire_sweep_trigger", ()),
     ],
 )
 @pytest.mark.parametrize("channel", [0, 1, 2, 3])

--- a/tests/unstable/awg/test_awg.py
+++ b/tests/unstable/awg/test_awg.py
@@ -20,6 +20,7 @@ from instro.unstable.awg.types import (
     GatePolarity,
     ModulationType,
     Sine,
+    SweepTriggerSource,
     SweepType,
     Waveform,
 )
@@ -113,6 +114,8 @@ def test_01_awg_driver_base_contract_enforces_instantiation_rules() -> None:
         ("get_sweep_type", (1,)),
         ("sweep_enable", (1, True)),
         ("get_sweep_state", (1,)),
+        ("set_sweep_trigger", (1, SweepTriggerSource.INTERNAL)),
+        ("get_sweep_trigger", (1,)),
         ("set_sweep_start_freq", (1, 100.0)),
         ("get_sweep_start_freq", (1,)),
         ("set_sweep_end_freq", (1, 200.0)),
@@ -156,6 +159,7 @@ def mock_driver() -> MagicMock:
     driver.get_burst_gate_polarity.return_value = GatePolarity.NORM
     driver.get_sweep_type.return_value = SweepType.LINEAR
     driver.get_sweep_state.return_value = False
+    driver.get_sweep_trigger.return_value = SweepTriggerSource.INTERNAL
     return driver
 
 
@@ -260,6 +264,8 @@ def test_04_helper_tags_avoid_collision_with_positional_params(awg: InstroAWG) -
         ("get_sweep_type", ()),
         ("sweep_enable", (True,)),
         ("get_sweep_state", ()),
+        ("set_sweep_trigger", (SweepTriggerSource.INTERNAL,)),
+        ("get_sweep_trigger", ()),
         ("set_sweep_start_freq", (100.0,)),
         ("get_sweep_start_freq", ()),
         ("set_sweep_end_freq", (200.0,)),


### PR DESCRIPTION
## Summary

This PR implements the sweep functions from https://github.com/nominal-io/instro/pull/388 in the rigol_dg1022z driver. 

## Type of change

- [ ] Bug fix (`fix`)
- [x] New feature (`feat`)
- [ ] Breaking change (`feat!` / `fix!`)
- [ ] Refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] Chore / tooling (`chore`)

## Verification
<img width="1435" height="840" alt="Screenshot 2026-08-12 at 3 00 00 PM" src="https://github.com/user-attachments/assets/59691851-853b-4ebc-b4c3-60810f15751d" />

<img width="1609" height="675" alt="Screenshot 2026-08-12 at 2 59 42 PM" src="https://github.com/user-attachments/assets/3fb92da7-4342-4d19-afb0-be88af6e2752" />


## Tests

- [x] Unit tests added or updated
- [ ] Existing tests cover this change
- [ ] No tests — explain why:

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(driver): add support for Keysight E36300`)
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] Documentation updated if user-facing behavior changed
- [x] Code follows the style/conventions of the surrounding code
