### PR TITLE
feat(unstable): add a shared CAN transport on TransportBase

### DIFF
--- a/packages/instro-unstable/instro/unstable/transports/__init__.py
+++ b/packages/instro-unstable/instro/unstable/transports/__init__.py
@@ -1,0 +1,5 @@
+"""In-development transport drivers; promoted to ``instro.lib.transports`` when their API settles."""
+
+from instro.unstable.transports.can import CanConfig, CanDriver, CanSubscription
+
+__all__ = ["CanConfig", "CanDriver", "CanSubscription"]

--- a/packages/instro-unstable/instro/unstable/transports/can.py
+++ b/packages/instro-unstable/instro/unstable/transports/can.py
@@ -1,0 +1,125 @@
+"""CAN transport driver. Wraps python-can; callers own frame encoding, this owns I/O, receive demux, and locking."""
+
+from __future__ import annotations
+
+import collections
+import dataclasses
+import logging
+from typing import Any, Callable
+
+import can
+
+from instro.lib.transports.transport_base import TransportBase
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SUBSCRIPTION_DEPTH = 512
+
+
+@dataclasses.dataclass
+class CanConfig:
+    """Connection parameters for a python-can bus.
+
+    ``interface`` is required because a CAN channel alone does not identify the
+    adapter type (``"gs_usb"``, ``"slcan"``, ``"socketcan"``, ...), unlike a
+    VISA resource string.
+    """
+
+    channel: str | int
+    interface: str
+    bitrate: int = 500_000
+    bus_kwargs: dict[str, Any] = dataclasses.field(default_factory=dict)
+
+
+class CanSubscription:
+    """A subscriber's view of the shared bus: drained frames matching its filter, oldest dropped when full."""
+
+    def __init__(self, transport: CanDriver, frame_filter: Callable[[can.Message], bool], depth: int) -> None:
+        self._transport = transport
+        self._filter = frame_filter
+        self._frames: collections.deque[can.Message] = collections.deque(maxlen=depth)
+
+    def drain(self) -> list[can.Message]:
+        """Pull pending bus frames through the demux and return this subscription's matches, oldest first."""
+        return self._transport._drain_for(self)
+
+
+class CanDriver(TransportBase):
+    """Transport for CAN-bus instruments. Composed by concrete drivers, not extended.
+
+    CAN is a broadcast bus, so this differs from request/response transports in two ways.
+    Several drivers on one physical adapter share this transport, each passing itself as the
+    holder to :meth:`open`/:meth:`close`; the bus closes when the last owner leaves. Receiving
+    goes through :meth:`subscribe`: any subscriber's drain routes pending frames to every
+    matching subscription, so one driver's read never consumes another driver's frames.
+    Send is fire-and-forget; there is no request/response helper.
+    """
+
+    def __init__(self, config: CanConfig) -> None:
+        super().__init__()
+        self._config = config
+        self._bus: can.BusABC | None = None
+        self._subscriptions: list[CanSubscription] = []
+
+    @property
+    def is_open(self) -> bool:
+        """Whether the underlying python-can bus is currently open."""
+        return self._bus is not None
+
+    def _open_session(self) -> None:
+        """Open the python-can bus. Idempotent. Called by open()."""
+        with self._lock:
+            if self._bus is not None:
+                return
+            cfg = self._config
+            logger.info("Opening CAN bus %s on interface %s at %d bit/s", cfg.channel, cfg.interface, cfg.bitrate)
+            self._bus = can.Bus(interface=cfg.interface, channel=cfg.channel, bitrate=cfg.bitrate, **cfg.bus_kwargs)
+
+    def _teardown_session(self) -> None:
+        """Shut down the python-can bus."""
+        if self._bus is None:
+            return
+        try:
+            self._bus.shutdown()
+        finally:
+            self._bus = None
+
+    def send(self, arbitration_id: int, data: bytes, is_extended_id: bool = True) -> None:
+        """Send one frame; the caller owns payload encoding."""
+        with self._lock:
+            bus = self._require_open_locked()
+            bus.send(can.Message(arbitration_id=arbitration_id, data=data, is_extended_id=is_extended_id))
+
+    def subscribe(
+        self,
+        frame_filter: Callable[[can.Message], bool],
+        depth: int = DEFAULT_SUBSCRIPTION_DEPTH,
+    ) -> CanSubscription:
+        """Register a receive filter and return the subscription whose drain() yields the matching frames."""
+        with self._lock:
+            subscription = CanSubscription(self, frame_filter, depth)
+            self._subscriptions.append(subscription)
+            return subscription
+
+    def unsubscribe(self, subscription: CanSubscription) -> None:
+        """Stop routing frames to ``subscription``; unknown subscriptions are ignored."""
+        with self._lock:
+            if subscription in self._subscriptions:
+                self._subscriptions.remove(subscription)
+
+    def _drain_for(self, subscription: CanSubscription) -> list[can.Message]:
+        """Route all pending bus frames to their subscribers, then hand over ``subscription``'s buffer."""
+        with self._lock:
+            bus = self._require_open_locked()
+            while (message := bus.recv(timeout=0.0)) is not None:
+                for candidate in self._subscriptions:
+                    if candidate._filter(message):
+                        candidate._frames.append(message)
+            frames = list(subscription._frames)
+            subscription._frames.clear()
+            return frames
+
+    def _require_open_locked(self) -> can.BusABC:
+        if self._bus is None:
+            raise RuntimeError(f"CanDriver is not open. Call open() first. Channel: {self._config.channel}")
+        return self._bus

--- a/packages/instro-unstable/instro/unstable/transports/can.py
+++ b/packages/instro-unstable/instro/unstable/transports/can.py
@@ -76,13 +76,15 @@ class CanDriver(TransportBase):
             self._bus = can.Bus(interface=cfg.interface, channel=cfg.channel, bitrate=cfg.bitrate, **cfg.bus_kwargs)
 
     def _teardown_session(self) -> None:
-        """Shut down the python-can bus."""
+        """Shut down the python-can bus and drop buffered frames, so a reopen never replays the previous session."""
         if self._bus is None:
             return
         try:
             self._bus.shutdown()
         finally:
             self._bus = None
+            for subscription in self._subscriptions:
+                subscription._frames.clear()
 
     def send(self, arbitration_id: int, data: bytes, is_extended_id: bool = True) -> None:
         """Send one frame; the caller owns payload encoding."""

--- a/packages/instro-unstable/instro/unstable/transports/can.py
+++ b/packages/instro-unstable/instro/unstable/transports/can.py
@@ -16,6 +16,14 @@ logger = logging.getLogger(__name__)
 DEFAULT_SUBSCRIPTION_DEPTH = 512
 
 
+def _prime_gs_usb_backend() -> None:
+    """Load the bundled libusb into pyusb's backend cache; hosts without a system libusb (notably Windows) find no backend otherwise."""
+    import libusb_package
+    import usb.backend.libusb1
+
+    usb.backend.libusb1.get_backend(find_library=libusb_package.find_library)
+
+
 @dataclasses.dataclass
 class CanConfig:
     """Connection parameters for a python-can bus.
@@ -73,7 +81,18 @@ class CanDriver(TransportBase):
                 return
             cfg = self._config
             logger.info("Opening CAN bus %s on interface %s at %d bit/s", cfg.channel, cfg.interface, cfg.bitrate)
-            self._bus = can.Bus(interface=cfg.interface, channel=cfg.channel, bitrate=cfg.bitrate, **cfg.bus_kwargs)
+            if cfg.interface == "gs_usb":
+                _prime_gs_usb_backend()
+            try:
+                self._bus = can.Bus(interface=cfg.interface, channel=cfg.channel, bitrate=cfg.bitrate, **cfg.bus_kwargs)
+            except can.exceptions.CanInitializationError as exc:
+                if cfg.interface != "gs_usb":
+                    raise
+                raise can.exceptions.CanInitializationError(
+                    f"Could not open gs_usb adapter (channel {cfg.channel}): check that the adapter is plugged in, "
+                    "runs candleLight/gs_usb firmware (stock vendor firmware often speaks neither gs_usb nor slcan), "
+                    f"and is not held by another process. Original error: {exc}"
+                ) from exc
 
     def _teardown_session(self) -> None:
         """Shut down the python-can bus and drop buffered frames, so a reopen never replays the previous session."""

--- a/packages/instro-unstable/pyproject.toml
+++ b/packages/instro-unstable/pyproject.toml
@@ -8,6 +8,8 @@ requires-python = ">=3.10,<3.15"
 dependencies = [
     "instro",
     "python-can>=4.3",
+    "gs-usb>=0.3",
+    "libusb-package>=1.0.26",
 ]
 
 [build-system]

--- a/packages/instro-unstable/pyproject.toml
+++ b/packages/instro-unstable/pyproject.toml
@@ -7,6 +7,7 @@ license-files = ["LICENSE"]
 requires-python = ">=3.10,<3.15"
 dependencies = [
     "instro",
+    "python-can>=4.3",
 ]
 
 [build-system]

--- a/packages/instro-unstable/pyproject.toml
+++ b/packages/instro-unstable/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
     "python-can>=4.3",
     "gs-usb>=0.3",
     "libusb-package>=1.0.26",
+    "pyserial>=3.5",
 ]
 
 [build-system]

--- a/tests/unstable/transports/test_can_driver.py
+++ b/tests/unstable/transports/test_can_driver.py
@@ -106,6 +106,19 @@ def test_full_subscription_drops_oldest_frames(transport: CanDriver, bus: MagicM
     assert [f.arbitration_id for f in subscription.drain()] == [2, 3]
 
 
+def test_reopen_does_not_replay_frames_from_the_previous_session(transport: CanDriver, bus: MagicMock) -> None:
+    transport.open()
+    keeper = transport.subscribe(lambda m: True)
+    router = transport.subscribe(lambda m: True)
+    bus.recv.side_effect = [_frame(0x901), None, None]
+    router.drain()  # routes the frame into keeper's buffer, where it sits across the close
+
+    transport.close()
+    transport.open()
+
+    assert keeper.drain() == []
+
+
 def test_unsubscribed_subscription_no_longer_receives(transport: CanDriver, bus: MagicMock) -> None:
     transport.open()
     dropped = transport.subscribe(lambda m: True)

--- a/tests/unstable/transports/test_can_driver.py
+++ b/tests/unstable/transports/test_can_driver.py
@@ -14,7 +14,13 @@ def _frame(arbitration_id: int, data: bytes = b"\x00", extended: bool = True) ->
 
 
 @pytest.fixture
-def bus_cls() -> Iterator[MagicMock]:
+def prime_backend() -> Iterator[MagicMock]:
+    with patch("instro.unstable.transports.can._prime_gs_usb_backend", autospec=True) as fn:
+        yield fn
+
+
+@pytest.fixture
+def bus_cls(prime_backend: MagicMock) -> Iterator[MagicMock]:
     with patch("instro.unstable.transports.can.can.Bus", autospec=True) as cls:
         yield cls
 
@@ -57,6 +63,24 @@ def test_shared_holders_open_once_and_teardown_on_last_close(
     bus.shutdown.assert_not_called()
     transport.close(second)
     bus.shutdown.assert_called_once_with()
+
+
+def test_gs_usb_open_primes_the_libusb_backend(bus: MagicMock, prime_backend: MagicMock) -> None:
+    CanDriver(CanConfig(channel=0, interface="gs_usb")).open()
+    prime_backend.assert_called_once_with()
+
+    prime_backend.reset_mock()
+    CanDriver(CanConfig(channel="COM4", interface="slcan")).open()
+    prime_backend.assert_not_called()
+
+
+def test_gs_usb_open_failure_raises_a_teaching_error(bus_cls: MagicMock) -> None:
+    bus_cls.side_effect = can.exceptions.CanInitializationError("Cannot find device 0. Devices found: 0")
+    transport = CanDriver(CanConfig(channel=0, interface="gs_usb"))
+
+    with pytest.raises(can.exceptions.CanInitializationError, match="candleLight") as excinfo:
+        transport.open()
+    assert isinstance(excinfo.value.__cause__, can.exceptions.CanInitializationError)
 
 
 def test_send_before_open_raises(transport: CanDriver, bus: MagicMock) -> None:

--- a/tests/unstable/transports/test_can_driver.py
+++ b/tests/unstable/transports/test_can_driver.py
@@ -1,0 +1,117 @@
+"""Unit tests for the CAN transport (issue #395), mocked python-can bus."""
+
+from collections.abc import Iterator
+from unittest.mock import MagicMock, patch
+
+import can
+import pytest
+
+from instro.unstable.transports import CanConfig, CanDriver
+
+
+def _frame(arbitration_id: int, data: bytes = b"\x00", extended: bool = True) -> can.Message:
+    return can.Message(arbitration_id=arbitration_id, data=data, is_extended_id=extended)
+
+
+@pytest.fixture
+def bus_cls() -> Iterator[MagicMock]:
+    with patch("instro.unstable.transports.can.can.Bus", autospec=True) as cls:
+        yield cls
+
+
+@pytest.fixture
+def bus(bus_cls: MagicMock) -> MagicMock:
+    instance = bus_cls.return_value
+    instance.recv.return_value = None
+    return instance
+
+
+@pytest.fixture
+def transport(bus: MagicMock) -> CanDriver:
+    return CanDriver(CanConfig(channel=0, interface="gs_usb"))
+
+
+def test_open_builds_bus_from_config_and_close_shuts_down(bus_cls: MagicMock, bus: MagicMock) -> None:
+    transport = CanDriver(CanConfig(channel="COM4", interface="slcan", bitrate=250_000, bus_kwargs={"index": 1}))
+    bus_cls.assert_not_called()
+
+    transport.open()
+    bus_cls.assert_called_once_with(interface="slcan", channel="COM4", bitrate=250_000, index=1)
+    assert transport.is_open
+
+    transport.close()
+    bus.shutdown.assert_called_once_with()
+    assert not transport.is_open
+
+
+def test_shared_holders_open_once_and_teardown_on_last_close(
+    transport: CanDriver, bus_cls: MagicMock, bus: MagicMock
+) -> None:
+    first, second = object(), object()
+
+    assert transport.open(first) is True
+    assert transport.open(second) is False
+    bus_cls.assert_called_once()
+
+    transport.close(first)
+    bus.shutdown.assert_not_called()
+    transport.close(second)
+    bus.shutdown.assert_called_once_with()
+
+
+def test_send_before_open_raises(transport: CanDriver, bus: MagicMock) -> None:
+    with pytest.raises(RuntimeError, match="not open"):
+        transport.send(0x123, b"\x01")
+    bus.send.assert_not_called()
+
+
+def test_send_builds_wire_frame(transport: CanDriver, bus: MagicMock) -> None:
+    transport.open()
+
+    transport.send(0x966, b"\x01\x02", is_extended_id=True)
+
+    frame = bus.send.call_args.args[0]
+    assert frame.arbitration_id == 0x966
+    assert bytes(frame.data) == b"\x01\x02"
+    assert frame.is_extended_id
+
+
+def test_drain_routes_frames_to_all_matching_subscriptions(transport: CanDriver, bus: MagicMock) -> None:
+    transport.open()
+    sub_a = transport.subscribe(lambda m: m.arbitration_id & 0xFF == 1)
+    sub_b = transport.subscribe(lambda m: m.arbitration_id & 0xFF == 2)
+    bus.recv.side_effect = [_frame(0x901), _frame(0x902), _frame(0x903), None, None]
+
+    frames_a = sub_a.drain()
+
+    assert [f.arbitration_id for f in frames_a] == [0x901]
+    # sub_b's frame was routed during sub_a's drain, not consumed; the bus has nothing further.
+    assert [f.arbitration_id for f in sub_b.drain()] == [0x902]
+
+
+def test_drain_hands_over_the_buffer(transport: CanDriver, bus: MagicMock) -> None:
+    transport.open()
+    subscription = transport.subscribe(lambda m: True)
+    bus.recv.side_effect = [_frame(0x901), None, None]
+
+    assert len(subscription.drain()) == 1
+    assert subscription.drain() == []
+
+
+def test_full_subscription_drops_oldest_frames(transport: CanDriver, bus: MagicMock) -> None:
+    transport.open()
+    subscription = transport.subscribe(lambda m: True, depth=2)
+    bus.recv.side_effect = [_frame(1), _frame(2), _frame(3), None]
+
+    assert [f.arbitration_id for f in subscription.drain()] == [2, 3]
+
+
+def test_unsubscribed_subscription_no_longer_receives(transport: CanDriver, bus: MagicMock) -> None:
+    transport.open()
+    dropped = transport.subscribe(lambda m: True)
+    kept = transport.subscribe(lambda m: True)
+    transport.unsubscribe(dropped)
+    bus.recv.side_effect = [_frame(0x901), None, None]
+
+    assert len(kept.drain()) == 1
+    assert dropped.drain() == []

--- a/uv.lock
+++ b/uv.lock
@@ -537,6 +537,18 @@ wheels = [
 ]
 
 [[package]]
+name = "gs-usb"
+version = "0.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyusb" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/37/d8/bb03645332d0de656b913cf4ac151aabc5c2c6e3c0c1fa30814fd4c45126/gs_usb-0.3.1.tar.gz", hash = "sha256:a8a76285fda29b45a5a633cfe232a08058f642441b3d030877dc28ef6e0b7807", size = 6605, upload-time = "2026-02-25T11:01:02.502Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/76/08/13b4e21ff15df9b7017e7e6265282df78098e50275bb99efc26b5d14ce29/gs_usb-0.3.1-py2.py3-none-any.whl", hash = "sha256:1c35d4404427db3f7955a687a1235b5829f94c61ece56eb0cf3f3b23e2d44883", size = 7333, upload-time = "2026-02-25T11:01:01.439Z" },
+]
+
+[[package]]
 name = "hightime"
 version = "0.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -808,13 +820,17 @@ name = "instro-unstable"
 version = "1.4.1"
 source = { editable = "packages/instro-unstable" }
 dependencies = [
+    { name = "gs-usb" },
     { name = "instro" },
+    { name = "libusb-package" },
     { name = "python-can" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "gs-usb", specifier = ">=0.3" },
     { name = "instro", editable = "." },
+    { name = "libusb-package", specifier = ">=1.0.26" },
     { name = "python-can", specifier = ">=4.3" },
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -582,7 +582,7 @@ wheels = [
 
 [[package]]
 name = "instro"
-version = "1.9.0"
+version = "1.9.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastavro", extra = ["snappy"] },
@@ -723,7 +723,7 @@ requires-dist = [{ name = "instro", editable = "." }]
 
 [[package]]
 name = "instro-daq-labjack"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "packages/instro-daq-labjack" }
 dependencies = [
     { name = "instro" },
@@ -805,14 +805,18 @@ requires-dist = [{ name = "instro", editable = "." }]
 
 [[package]]
 name = "instro-unstable"
-version = "1.4.0"
+version = "1.4.1"
 source = { editable = "packages/instro-unstable" }
 dependencies = [
     { name = "instro" },
+    { name = "python-can" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "instro", editable = "." }]
+requires-dist = [
+    { name = "instro", editable = "." },
+    { name = "python-can", specifier = ">=4.3" },
+]
 
 [[package]]
 name = "jinja2"
@@ -1840,6 +1844,20 @@ wheels = [
 ]
 
 [[package]]
+name = "python-can"
+version = "4.6.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "typing-extensions" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/f9/a9d99d36dd33be5badb747801c9255c3c526171a5542092eaacc73350fb8/python_can-4.6.1.tar.gz", hash = "sha256:290fea135d04b8504ebff33889cc6d301e2181a54099116609f940825ffe5005", size = 1206049, upload-time = "2025-08-12T07:44:58.314Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/34/e4ac153acdbcfba7f48bc73d6586a74c91cc919fcc2e29acbf81be329d1f/python_can-4.6.1-py3-none-any.whl", hash = "sha256:17f95255868a95108dcfcb90565a684dad32d5a3ebb35afd14f739e18c84ff6c", size = 276996, upload-time = "2025-08-12T07:44:56.55Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -2292,6 +2310,75 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/07/f6/d0e5b343768e8bcb4cda79f0f2f55051bf26177ecd5651f84c07567461cf/watchdog-6.0.0-py3-none-win32.whl", hash = "sha256:07df1fdd701c5d4c8e55ef6cf55b8f0120fe1aef7ef39a1c6fc6bc2e606d517a", size = 79065, upload-time = "2024-11-01T14:07:09.525Z" },
     { url = "https://files.pythonhosted.org/packages/db/d9/c495884c6e548fce18a8f40568ff120bc3a4b7b99813081c8ac0c936fa64/watchdog-6.0.0-py3-none-win_amd64.whl", hash = "sha256:cbafb470cf848d93b5d013e2ecb245d4aa1c8fd0504e863ccefa32445359d680", size = 79070, upload-time = "2024-11-01T14:07:10.686Z" },
     { url = "https://files.pythonhosted.org/packages/33/e8/e40370e6d74ddba47f002a32919d91310d6074130fe4e17dabcafc15cbf1/watchdog-6.0.0-py3-none-win_ia64.whl", hash = "sha256:a1914259fa9e1454315171103c6a30961236f508b9b623eae470268bbcc6a22f", size = 79067, upload-time = "2024-11-01T14:07:11.845Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "1.17.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/95/8f/aeb76c5b46e273670962298c23e7ddde79916cb74db802131d49a85e4b7d/wrapt-1.17.3.tar.gz", hash = "sha256:f66eb08feaa410fe4eebd17f2a2c8e2e46d3476e9f8c783daa8e09e0faa666d0", size = 55547, upload-time = "2025-08-12T05:53:21.714Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/23/bb82321b86411eb51e5a5db3fb8f8032fd30bd7c2d74bfe936136b2fa1d6/wrapt-1.17.3-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:88bbae4d40d5a46142e70d58bf664a89b6b4befaea7b2ecc14e03cedb8e06c04", size = 53482, upload-time = "2025-08-12T05:51:44.467Z" },
+    { url = "https://files.pythonhosted.org/packages/45/69/f3c47642b79485a30a59c63f6d739ed779fb4cc8323205d047d741d55220/wrapt-1.17.3-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:e6b13af258d6a9ad602d57d889f83b9d5543acd471eee12eb51f5b01f8eb1bc2", size = 38676, upload-time = "2025-08-12T05:51:32.636Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/71/e7e7f5670c1eafd9e990438e69d8fb46fa91a50785332e06b560c869454f/wrapt-1.17.3-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:fd341868a4b6714a5962c1af0bd44f7c404ef78720c7de4892901e540417111c", size = 38957, upload-time = "2025-08-12T05:51:54.655Z" },
+    { url = "https://files.pythonhosted.org/packages/de/17/9f8f86755c191d6779d7ddead1a53c7a8aa18bccb7cea8e7e72dfa6a8a09/wrapt-1.17.3-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:f9b2601381be482f70e5d1051a5965c25fb3625455a2bf520b5a077b22afb775", size = 81975, upload-time = "2025-08-12T05:52:30.109Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/15/dd576273491f9f43dd09fce517f6c2ce6eb4fe21681726068db0d0467096/wrapt-1.17.3-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:343e44b2a8e60e06a7e0d29c1671a0d9951f59174f3709962b5143f60a2a98bd", size = 83149, upload-time = "2025-08-12T05:52:09.316Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/c4/5eb4ce0d4814521fee7aa806264bf7a114e748ad05110441cd5b8a5c744b/wrapt-1.17.3-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:33486899acd2d7d3066156b03465b949da3fd41a5da6e394ec49d271baefcf05", size = 82209, upload-time = "2025-08-12T05:52:10.331Z" },
+    { url = "https://files.pythonhosted.org/packages/31/4b/819e9e0eb5c8dc86f60dfc42aa4e2c0d6c3db8732bce93cc752e604bb5f5/wrapt-1.17.3-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:e6f40a8aa5a92f150bdb3e1c44b7e98fb7113955b2e5394122fa5532fec4b418", size = 81551, upload-time = "2025-08-12T05:52:31.137Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/83/ed6baf89ba3a56694700139698cf703aac9f0f9eb03dab92f57551bd5385/wrapt-1.17.3-cp310-cp310-win32.whl", hash = "sha256:a36692b8491d30a8c75f1dfee65bef119d6f39ea84ee04d9f9311f83c5ad9390", size = 36464, upload-time = "2025-08-12T05:53:01.204Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/90/ee61d36862340ad7e9d15a02529df6b948676b9a5829fd5e16640156627d/wrapt-1.17.3-cp310-cp310-win_amd64.whl", hash = "sha256:afd964fd43b10c12213574db492cb8f73b2f0826c8df07a68288f8f19af2ebe6", size = 38748, upload-time = "2025-08-12T05:53:00.209Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/c3/cefe0bd330d389c9983ced15d326f45373f4073c9f4a8c2f99b50bfea329/wrapt-1.17.3-cp310-cp310-win_arm64.whl", hash = "sha256:af338aa93554be859173c39c85243970dc6a289fa907402289eeae7543e1ae18", size = 36810, upload-time = "2025-08-12T05:52:51.906Z" },
+    { url = "https://files.pythonhosted.org/packages/52/db/00e2a219213856074a213503fdac0511203dceefff26e1daa15250cc01a0/wrapt-1.17.3-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:273a736c4645e63ac582c60a56b0acb529ef07f78e08dc6bfadf6a46b19c0da7", size = 53482, upload-time = "2025-08-12T05:51:45.79Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/30/ca3c4a5eba478408572096fe9ce36e6e915994dd26a4e9e98b4f729c06d9/wrapt-1.17.3-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5531d911795e3f935a9c23eb1c8c03c211661a5060aab167065896bbf62a5f85", size = 38674, upload-time = "2025-08-12T05:51:34.629Z" },
+    { url = "https://files.pythonhosted.org/packages/31/25/3e8cc2c46b5329c5957cec959cb76a10718e1a513309c31399a4dad07eb3/wrapt-1.17.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:0610b46293c59a3adbae3dee552b648b984176f8562ee0dba099a56cfbe4df1f", size = 38959, upload-time = "2025-08-12T05:51:56.074Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/8f/a32a99fc03e4b37e31b57cb9cefc65050ea08147a8ce12f288616b05ef54/wrapt-1.17.3-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b32888aad8b6e68f83a8fdccbf3165f5469702a7544472bdf41f582970ed3311", size = 82376, upload-time = "2025-08-12T05:52:32.134Z" },
+    { url = "https://files.pythonhosted.org/packages/31/57/4930cb8d9d70d59c27ee1332a318c20291749b4fba31f113c2f8ac49a72e/wrapt-1.17.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cccf4f81371f257440c88faed6b74f1053eef90807b77e31ca057b2db74edb1", size = 83604, upload-time = "2025-08-12T05:52:11.663Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/f3/1afd48de81d63dd66e01b263a6fbb86e1b5053b419b9b33d13e1f6d0f7d0/wrapt-1.17.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d8a210b158a34164de8bb68b0e7780041a903d7b00c87e906fb69928bf7890d5", size = 82782, upload-time = "2025-08-12T05:52:12.626Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/d7/4ad5327612173b144998232f98a85bb24b60c352afb73bc48e3e0d2bdc4e/wrapt-1.17.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:79573c24a46ce11aab457b472efd8d125e5a51da2d1d24387666cd85f54c05b2", size = 82076, upload-time = "2025-08-12T05:52:33.168Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/59/e0adfc831674a65694f18ea6dc821f9fcb9ec82c2ce7e3d73a88ba2e8718/wrapt-1.17.3-cp311-cp311-win32.whl", hash = "sha256:c31eebe420a9a5d2887b13000b043ff6ca27c452a9a22fa71f35f118e8d4bf89", size = 36457, upload-time = "2025-08-12T05:53:03.936Z" },
+    { url = "https://files.pythonhosted.org/packages/83/88/16b7231ba49861b6f75fc309b11012ede4d6b0a9c90969d9e0db8d991aeb/wrapt-1.17.3-cp311-cp311-win_amd64.whl", hash = "sha256:0b1831115c97f0663cb77aa27d381237e73ad4f721391a9bfb2fe8bc25fa6e77", size = 38745, upload-time = "2025-08-12T05:53:02.885Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/1e/c4d4f3398ec073012c51d1c8d87f715f56765444e1a4b11e5180577b7e6e/wrapt-1.17.3-cp311-cp311-win_arm64.whl", hash = "sha256:5a7b3c1ee8265eb4c8f1b7d29943f195c00673f5ab60c192eba2d4a7eae5f46a", size = 36806, upload-time = "2025-08-12T05:52:53.368Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/41/cad1aba93e752f1f9268c77270da3c469883d56e2798e7df6240dcb2287b/wrapt-1.17.3-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:ab232e7fdb44cdfbf55fc3afa31bcdb0d8980b9b95c38b6405df2acb672af0e0", size = 53998, upload-time = "2025-08-12T05:51:47.138Z" },
+    { url = "https://files.pythonhosted.org/packages/60/f8/096a7cc13097a1869fe44efe68dace40d2a16ecb853141394047f0780b96/wrapt-1.17.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:9baa544e6acc91130e926e8c802a17f3b16fbea0fd441b5a60f5cf2cc5c3deba", size = 39020, upload-time = "2025-08-12T05:51:35.906Z" },
+    { url = "https://files.pythonhosted.org/packages/33/df/bdf864b8997aab4febb96a9ae5c124f700a5abd9b5e13d2a3214ec4be705/wrapt-1.17.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6b538e31eca1a7ea4605e44f81a48aa24c4632a277431a6ed3f328835901f4fd", size = 39098, upload-time = "2025-08-12T05:51:57.474Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/81/5d931d78d0eb732b95dc3ddaeeb71c8bb572fb01356e9133916cd729ecdd/wrapt-1.17.3-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:042ec3bb8f319c147b1301f2393bc19dba6e176b7da446853406d041c36c7828", size = 88036, upload-time = "2025-08-12T05:52:34.784Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/38/2e1785df03b3d72d34fc6252d91d9d12dc27a5c89caef3335a1bbb8908ca/wrapt-1.17.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3af60380ba0b7b5aeb329bc4e402acd25bd877e98b3727b0135cb5c2efdaefe9", size = 88156, upload-time = "2025-08-12T05:52:13.599Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/8b/48cdb60fe0603e34e05cffda0b2a4adab81fd43718e11111a4b0100fd7c1/wrapt-1.17.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0b02e424deef65c9f7326d8c19220a2c9040c51dc165cddb732f16198c168396", size = 87102, upload-time = "2025-08-12T05:52:14.56Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/51/d81abca783b58f40a154f1b2c56db1d2d9e0d04fa2d4224e357529f57a57/wrapt-1.17.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:74afa28374a3c3a11b3b5e5fca0ae03bef8450d6aa3ab3a1e2c30e3a75d023dc", size = 87732, upload-time = "2025-08-12T05:52:36.165Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/b1/43b286ca1392a006d5336412d41663eeef1ad57485f3e52c767376ba7e5a/wrapt-1.17.3-cp312-cp312-win32.whl", hash = "sha256:4da9f45279fff3543c371d5ababc57a0384f70be244de7759c85a7f989cb4ebe", size = 36705, upload-time = "2025-08-12T05:53:07.123Z" },
+    { url = "https://files.pythonhosted.org/packages/28/de/49493f962bd3c586ab4b88066e967aa2e0703d6ef2c43aa28cb83bf7b507/wrapt-1.17.3-cp312-cp312-win_amd64.whl", hash = "sha256:e71d5c6ebac14875668a1e90baf2ea0ef5b7ac7918355850c0908ae82bcb297c", size = 38877, upload-time = "2025-08-12T05:53:05.436Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/48/0f7102fe9cb1e8a5a77f80d4f0956d62d97034bbe88d33e94699f99d181d/wrapt-1.17.3-cp312-cp312-win_arm64.whl", hash = "sha256:604d076c55e2fdd4c1c03d06dc1a31b95130010517b5019db15365ec4a405fc6", size = 36885, upload-time = "2025-08-12T05:52:54.367Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/f6/759ece88472157acb55fc195e5b116e06730f1b651b5b314c66291729193/wrapt-1.17.3-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a47681378a0439215912ef542c45a783484d4dd82bac412b71e59cf9c0e1cea0", size = 54003, upload-time = "2025-08-12T05:51:48.627Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/a9/49940b9dc6d47027dc850c116d79b4155f15c08547d04db0f07121499347/wrapt-1.17.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:54a30837587c6ee3cd1a4d1c2ec5d24e77984d44e2f34547e2323ddb4e22eb77", size = 39025, upload-time = "2025-08-12T05:51:37.156Z" },
+    { url = "https://files.pythonhosted.org/packages/45/35/6a08de0f2c96dcdd7fe464d7420ddb9a7655a6561150e5fc4da9356aeaab/wrapt-1.17.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:16ecf15d6af39246fe33e507105d67e4b81d8f8d2c6598ff7e3ca1b8a37213f7", size = 39108, upload-time = "2025-08-12T05:51:58.425Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/37/6faf15cfa41bf1f3dba80cd3f5ccc6622dfccb660ab26ed79f0178c7497f/wrapt-1.17.3-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:6fd1ad24dc235e4ab88cda009e19bf347aabb975e44fd5c2fb22a3f6e4141277", size = 88072, upload-time = "2025-08-12T05:52:37.53Z" },
+    { url = "https://files.pythonhosted.org/packages/78/f2/efe19ada4a38e4e15b6dff39c3e3f3f73f5decf901f66e6f72fe79623a06/wrapt-1.17.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ed61b7c2d49cee3c027372df5809a59d60cf1b6c2f81ee980a091f3afed6a2d", size = 88214, upload-time = "2025-08-12T05:52:15.886Z" },
+    { url = "https://files.pythonhosted.org/packages/40/90/ca86701e9de1622b16e09689fc24b76f69b06bb0150990f6f4e8b0eeb576/wrapt-1.17.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:423ed5420ad5f5529db9ce89eac09c8a2f97da18eb1c870237e84c5a5c2d60aa", size = 87105, upload-time = "2025-08-12T05:52:17.914Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/e0/d10bd257c9a3e15cbf5523025252cc14d77468e8ed644aafb2d6f54cb95d/wrapt-1.17.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:e01375f275f010fcbf7f643b4279896d04e571889b8a5b3f848423d91bf07050", size = 87766, upload-time = "2025-08-12T05:52:39.243Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/cf/7d848740203c7b4b27eb55dbfede11aca974a51c3d894f6cc4b865f42f58/wrapt-1.17.3-cp313-cp313-win32.whl", hash = "sha256:53e5e39ff71b3fc484df8a522c933ea2b7cdd0d5d15ae82e5b23fde87d44cbd8", size = 36711, upload-time = "2025-08-12T05:53:10.074Z" },
+    { url = "https://files.pythonhosted.org/packages/57/54/35a84d0a4d23ea675994104e667ceff49227ce473ba6a59ba2c84f250b74/wrapt-1.17.3-cp313-cp313-win_amd64.whl", hash = "sha256:1f0b2f40cf341ee8cc1a97d51ff50dddb9fcc73241b9143ec74b30fc4f44f6cb", size = 38885, upload-time = "2025-08-12T05:53:08.695Z" },
+    { url = "https://files.pythonhosted.org/packages/01/77/66e54407c59d7b02a3c4e0af3783168fff8e5d61def52cda8728439d86bc/wrapt-1.17.3-cp313-cp313-win_arm64.whl", hash = "sha256:7425ac3c54430f5fc5e7b6f41d41e704db073309acfc09305816bc6a0b26bb16", size = 36896, upload-time = "2025-08-12T05:52:55.34Z" },
+    { url = "https://files.pythonhosted.org/packages/02/a2/cd864b2a14f20d14f4c496fab97802001560f9f41554eef6df201cd7f76c/wrapt-1.17.3-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:cf30f6e3c077c8e6a9a7809c94551203c8843e74ba0c960f4a98cd80d4665d39", size = 54132, upload-time = "2025-08-12T05:51:49.864Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/46/d011725b0c89e853dc44cceb738a307cde5d240d023d6d40a82d1b4e1182/wrapt-1.17.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e228514a06843cae89621384cfe3a80418f3c04aadf8a3b14e46a7be704e4235", size = 39091, upload-time = "2025-08-12T05:51:38.935Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/9e/3ad852d77c35aae7ddebdbc3b6d35ec8013af7d7dddad0ad911f3d891dae/wrapt-1.17.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:5ea5eb3c0c071862997d6f3e02af1d055f381b1d25b286b9d6644b79db77657c", size = 39172, upload-time = "2025-08-12T05:51:59.365Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f7/c983d2762bcce2326c317c26a6a1e7016f7eb039c27cdf5c4e30f4160f31/wrapt-1.17.3-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:281262213373b6d5e4bb4353bc36d1ba4084e6d6b5d242863721ef2bf2c2930b", size = 87163, upload-time = "2025-08-12T05:52:40.965Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/0f/f673f75d489c7f22d17fe0193e84b41540d962f75fce579cf6873167c29b/wrapt-1.17.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc4a8d2b25efb6681ecacad42fca8859f88092d8732b170de6a5dddd80a1c8fa", size = 87963, upload-time = "2025-08-12T05:52:20.326Z" },
+    { url = "https://files.pythonhosted.org/packages/df/61/515ad6caca68995da2fac7a6af97faab8f78ebe3bf4f761e1b77efbc47b5/wrapt-1.17.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:373342dd05b1d07d752cecbec0c41817231f29f3a89aa8b8843f7b95992ed0c7", size = 86945, upload-time = "2025-08-12T05:52:21.581Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/bd/4e70162ce398462a467bc09e768bee112f1412e563620adc353de9055d33/wrapt-1.17.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:d40770d7c0fd5cbed9d84b2c3f2e156431a12c9a37dc6284060fb4bec0b7ffd4", size = 86857, upload-time = "2025-08-12T05:52:43.043Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/b8/da8560695e9284810b8d3df8a19396a6e40e7518059584a1a394a2b35e0a/wrapt-1.17.3-cp314-cp314-win32.whl", hash = "sha256:fbd3c8319de8e1dc79d346929cd71d523622da527cca14e0c1d257e31c2b8b10", size = 37178, upload-time = "2025-08-12T05:53:12.605Z" },
+    { url = "https://files.pythonhosted.org/packages/db/c8/b71eeb192c440d67a5a0449aaee2310a1a1e8eca41676046f99ed2487e9f/wrapt-1.17.3-cp314-cp314-win_amd64.whl", hash = "sha256:e1a4120ae5705f673727d3253de3ed0e016f7cd78dc463db1b31e2463e1f3cf6", size = 39310, upload-time = "2025-08-12T05:53:11.106Z" },
+    { url = "https://files.pythonhosted.org/packages/45/20/2cda20fd4865fa40f86f6c46ed37a2a8356a7a2fde0773269311f2af56c7/wrapt-1.17.3-cp314-cp314-win_arm64.whl", hash = "sha256:507553480670cab08a800b9463bdb881b2edeed77dc677b0a5915e6106e91a58", size = 37266, upload-time = "2025-08-12T05:52:56.531Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ed/dd5cf21aec36c80443c6f900449260b80e2a65cf963668eaef3b9accce36/wrapt-1.17.3-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:ed7c635ae45cfbc1a7371f708727bf74690daedc49b4dba310590ca0bd28aa8a", size = 56544, upload-time = "2025-08-12T05:51:51.109Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/96/450c651cc753877ad100c7949ab4d2e2ecc4d97157e00fa8f45df682456a/wrapt-1.17.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:249f88ed15503f6492a71f01442abddd73856a0032ae860de6d75ca62eed8067", size = 40283, upload-time = "2025-08-12T05:51:39.912Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/86/2fcad95994d9b572db57632acb6f900695a648c3e063f2cd344b3f5c5a37/wrapt-1.17.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a03a38adec8066d5a37bea22f2ba6bbf39fcdefbe2d91419ab864c3fb515454", size = 40366, upload-time = "2025-08-12T05:52:00.693Z" },
+    { url = "https://files.pythonhosted.org/packages/64/0e/f4472f2fdde2d4617975144311f8800ef73677a159be7fe61fa50997d6c0/wrapt-1.17.3-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5d4478d72eb61c36e5b446e375bbc49ed002430d17cdec3cecb36993398e1a9e", size = 108571, upload-time = "2025-08-12T05:52:44.521Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/01/9b85a99996b0a97c8a17484684f206cbb6ba73c1ce6890ac668bcf3838fb/wrapt-1.17.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:223db574bb38637e8230eb14b185565023ab624474df94d2af18f1cdb625216f", size = 113094, upload-time = "2025-08-12T05:52:22.618Z" },
+    { url = "https://files.pythonhosted.org/packages/25/02/78926c1efddcc7b3aa0bc3d6b33a822f7d898059f7cd9ace8c8318e559ef/wrapt-1.17.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e405adefb53a435f01efa7ccdec012c016b5a1d3f35459990afc39b6be4d5056", size = 110659, upload-time = "2025-08-12T05:52:24.057Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/ee/c414501ad518ac3e6fe184753632fe5e5ecacdcf0effc23f31c1e4f7bfcf/wrapt-1.17.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:88547535b787a6c9ce4086917b6e1d291aa8ed914fdd3a838b3539dc95c12804", size = 106946, upload-time = "2025-08-12T05:52:45.976Z" },
+    { url = "https://files.pythonhosted.org/packages/be/44/a1bd64b723d13bb151d6cc91b986146a1952385e0392a78567e12149c7b4/wrapt-1.17.3-cp314-cp314t-win32.whl", hash = "sha256:41b1d2bc74c2cac6f9074df52b2efbef2b30bdfe5f40cb78f8ca22963bc62977", size = 38717, upload-time = "2025-08-12T05:53:15.214Z" },
+    { url = "https://files.pythonhosted.org/packages/79/d9/7cfd5a312760ac4dd8bf0184a6ee9e43c33e47f3dadc303032ce012b8fa3/wrapt-1.17.3-cp314-cp314t-win_amd64.whl", hash = "sha256:73d496de46cd2cdbdbcce4ae4bcdb4afb6a11234a1df9c085249d55166b95116", size = 41334, upload-time = "2025-08-12T05:53:14.178Z" },
+    { url = "https://files.pythonhosted.org/packages/46/78/10ad9781128ed2f99dbc474f43283b13fea8ba58723e98844367531c18e9/wrapt-1.17.3-cp314-cp314t-win_arm64.whl", hash = "sha256:f38e60678850c42461d4202739f9bf1e3a737c7ad283638251e79cc49effb6b6", size = 38471, upload-time = "2025-08-12T05:52:57.784Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f6/a933bd70f98e9cf3e08167fc5cd7aaaca49147e48411c0bd5ae701bb2194/wrapt-1.17.3-py3-none-any.whl", hash = "sha256:7171ae35d2c33d326ac19dd8facb1e82e5fd04ef8c6c0e394d7af55a55051c22", size = 23591, upload-time = "2025-08-12T05:53:20.674Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -823,6 +823,7 @@ dependencies = [
     { name = "gs-usb" },
     { name = "instro" },
     { name = "libusb-package" },
+    { name = "pyserial" },
     { name = "python-can" },
 ]
 
@@ -831,6 +832,7 @@ requires-dist = [
     { name = "gs-usb", specifier = ">=0.3" },
     { name = "instro", editable = "." },
     { name = "libusb-package", specifier = ">=1.0.26" },
+    { name = "pyserial", specifier = ">=3.5" },
     { name = "python-can", specifier = ">=4.3" },
 ]
 


### PR DESCRIPTION
Closes #395.

CAN adapters are single-claim (gs_usb), so two drivers cannot share one adapter today even though CAN is a bus, and a naive shared bus lets one driver's telemetry drain consume another driver's frames. Using a gs_usb adapter also required manual host setup (`gs-usb`/`libusb-package` pip installs outside the lock, a pyusb backend shim copy-pasted into every script, and `uv run --no-sync`).

Adds `CanDriver(TransportBase)` in instro-unstable (`instro/unstable/transports/can.py`): `CanConfig` with a required interface, locked fire-and-forget `send`, and `subscribe(predicate)` returning a bounded per-subscriber buffer — any subscriber's drain routes pending frames to every matching subscription under the lock (no reader thread). No request/response helper by design.

Pip-installable interfaces work out of the box: `gs-usb` + `libusb-package` (gs_usb) and `pyserial` (slcan/seeed/robotell/cantact) are declared dependencies, the transport primes pyusb's libusb backend itself on gs_usb opens (the same interface-specific open glue `VisaDriver` does for backend fallback and serial config), and a failed gs_usb open raises a teaching error (adapter unplugged / stock vendor firmware / held by another process). Vendor-SDK interfaces (Kvaser, PCAN, Vector, ...) still require their system installs; teaching errors for those get written when the hardware shows up.

Independent of #386; the `VESC6` refactor to compose this transport lands there once this merges. python-can stays an instro-unstable dependency only.