### PR TITLE
refactor(opcua): fix timestamp handling

### DIFF
--- a/crates/instro-opcua/src/client.rs
+++ b/crates/instro-opcua/src/client.rs
@@ -1013,6 +1013,7 @@ mod subscription_loop_tests {
     use anyhow::Context as _;
     use anyhow::Result;
     use anyhow::anyhow;
+    use futures_util::stream;
     use futures_util::Stream;
     use futures_util::StreamExt as _;
     use tokio::sync::mpsc;
@@ -1132,12 +1133,9 @@ mod subscription_loop_tests {
         }
     }
 
-    fn datapoint(server_timestamp: u64, value: f64) -> OpcUaDataPoint {
-        OpcUaDataPoint {
-            server_timestamp,
-            source_timestamp: None,
-            value: OpcUaValue::Double(value),
-        }
+    fn datapoint(ts: u64, value: f64) -> OpcUaDataPoint {
+        OpcUaDataPoint::new(OpcUaValue::Double(value))
+            .with_server_timestamp(ts)
     }
 
     /// Wraps an unbounded channel as a notification [`Stream`]; the stream ends when the sender
@@ -1145,7 +1143,7 @@ mod subscription_loop_tests {
     fn notification_stream(
         rx: mpsc::UnboundedReceiver<(OpcUaNodeId, OpcUaDataPoint)>,
     ) -> impl Stream<Item = (OpcUaNodeId, OpcUaDataPoint)> + Send + Unpin + 'static {
-        futures_util::stream::unfold(rx, |mut rx| async move {
+        stream::unfold(rx, |mut rx| async move {
             rx.recv().await.map(|item| (item, rx))
         })
         .boxed()
@@ -1239,13 +1237,16 @@ mod subscription_loop_tests {
             .collect::<Vec<_>>();
 
         assert_eq!(samples.len(), 3, "expected one polled sample per tick");
+
         for sample in &samples {
             assert_eq!(sample.node_id, x.node_id);
         }
+
         let timestamps = samples
             .iter()
-            .map(|s| s.data.server_timestamp)
+            .map(|s| s.data.server_timestamp.expect("server timestamp should be present"))
             .collect::<Vec<_>>();
+
         assert_eq!(
             timestamps,
             vec![1, 2, 3],
@@ -1258,6 +1259,7 @@ mod subscription_loop_tests {
             .map_err(|_| anyhow!("state poisoned"))?
             .requested
             .clone();
+
         assert_eq!(requested.len(), 3);
 
         Ok(())
@@ -1300,7 +1302,7 @@ mod subscription_loop_tests {
         assert_eq!(samples.len(), 1, "stale polled sample should be dropped");
         let sample = samples.first().context("missing notification sample")?;
         assert_eq!(sample.node_id, x.node_id);
-        assert_eq!(sample.data.server_timestamp, 100);
+        assert_eq!(sample.data.server_timestamp, Some(100));
         assert_eq!(sample.data.value, OpcUaValue::Double(1.0));
 
         let _ = state; // shared handle kept alive for the loop's duration
@@ -1345,10 +1347,10 @@ mod subscription_loop_tests {
         let polled = samples.first().context("missing polled sample")?;
         let notification = samples.get(1).context("missing notification sample")?;
         assert_eq!(
-            polled.data.server_timestamp, 100,
+            polled.data.server_timestamp, Some(100),
             "polled sample emitted first"
         );
-        assert_eq!(notification.data.server_timestamp, 200);
+        assert_eq!(notification.data.server_timestamp, Some(200));
 
         Ok(())
     }
@@ -1388,7 +1390,7 @@ mod subscription_loop_tests {
         );
         let sample = samples.first().context("missing drained sample")?;
         assert_eq!(sample.node_id, x.node_id);
-        assert_eq!(sample.data.server_timestamp, 7);
+        assert_eq!(sample.data.server_timestamp, Some(7));
 
         Ok(())
     }
@@ -1490,7 +1492,7 @@ mod subscription_loop_tests {
 
         assert_eq!(samples.len(), 1, "only the notification should be emitted");
         let sample = samples.first().context("missing notification sample")?;
-        assert_eq!(sample.data.server_timestamp, 7);
+        assert_eq!(sample.data.server_timestamp, Some(7));
 
         let requested = state
             .lock()
@@ -1564,7 +1566,7 @@ mod subscription_loop_tests {
             "static node should keep being polled (got {static_count})"
         );
         assert!(
-            active_timestamps.contains(&5) && active_timestamps.contains(&6),
+            active_timestamps.contains(&Some(5)) && active_timestamps.contains(&Some(6)),
             "both active-node notifications should be delivered, got {active_timestamps:?}",
         );
 
@@ -1618,7 +1620,7 @@ mod subscription_loop_tests {
             "only the buffered sample should be drained on exit"
         );
         let sample = samples.first().context("missing drained sample")?;
-        assert_eq!(sample.data.server_timestamp, 1);
+        assert_eq!(sample.data.server_timestamp, Some(1));
 
         // Tick 2 broke before reading, so exactly one read (from tick 1) was issued.
         let requested = state

--- a/crates/instro-opcua/src/client.rs
+++ b/crates/instro-opcua/src/client.rs
@@ -1135,7 +1135,7 @@ mod subscription_loop_tests {
 
     fn datapoint(ts: u64, value: f64) -> OpcUaDataPoint {
         OpcUaDataPoint::new(OpcUaValue::Double(value))
-            .with_server_timestamp(ts)
+            .with_server_timestamp(Some(ts))
     }
 
     /// Wraps an unbounded channel as a notification [`Stream`]; the stream ends when the sender

--- a/crates/instro-opcua/src/client.rs
+++ b/crates/instro-opcua/src/client.rs
@@ -322,6 +322,7 @@ impl OpcUaClient {
             .read_attribute(&ua_node_id, ua::AttributeId::DISPLAYNAME_T)
             .await
             .with_context(|| format!("reading display name for node {node_id}"))?;
+
         let display_name = display_name_value.scalar_value().with_context(|| {
             format!(
                 "display name attribute for node {node_id} was not readable: {:?}",
@@ -333,6 +334,7 @@ impl OpcUaClient {
             .read_attribute(&ua_node_id, ua::AttributeId::NODECLASS_T)
             .await
             .with_context(|| format!("reading node class for node {node_id}"))?;
+
         let node_class = node_class_value
             .scalar_value()
             .with_context(|| format!("node class attribute for node {node_id} was not readable"));
@@ -621,6 +623,7 @@ impl OpcUaClient {
                         let to_flush = reads
                             .into_iter()
                             .map(|sample| (sample.node_id.clone(), sample));
+
                         polled_nodes.extend(to_flush);
                     }
 
@@ -638,7 +641,7 @@ impl OpcUaClient {
 
                         // Older poll values preserve ordering; same-or-newer poll values are stale.
                         if let Some(polled_sample) = polled_nodes.remove(&node_id)
-                            && polled_sample.data.server_timestamp < data.server_timestamp
+                            && let Some(polled_sample) = polled_sample_filter(polled_sample, &data)
                         {
                             samples.push(polled_sample);
                         }
@@ -668,6 +671,24 @@ impl OpcUaClient {
         let samples_to_flush = polled_nodes.drain().map(|(_, sample)| sample).collect_vec();
 
         on_data(Box::new(samples_to_flush.into_iter()));
+    }
+}
+
+/// Takes removed polled sample and returns it if the subscription data is newer.
+/// Otherwise, the polled sample is forgotten and this function returns `None`.
+fn polled_sample_filter(polled: OpcUaSample, sub_data: &OpcUaDataPoint) -> Option<OpcUaSample> {
+    if let Some(poll_src_ts) = polled.data.source_timestamp
+        && let Some(sub_src_ts) = sub_data.source_timestamp
+        && poll_src_ts < sub_src_ts
+    {
+        Some(polled)
+    } else if let Some(poll_srv_ts) = polled.data.server_timestamp
+        && let Some(sub_srv_ts) = sub_data.server_timestamp
+        && poll_srv_ts < sub_srv_ts
+    {
+        Some(polled)
+    } else {
+        None
     }
 }
 
@@ -1013,9 +1034,9 @@ mod subscription_loop_tests {
     use anyhow::Context as _;
     use anyhow::Result;
     use anyhow::anyhow;
-    use futures_util::stream;
     use futures_util::Stream;
     use futures_util::StreamExt as _;
+    use futures_util::stream;
     use tokio::sync::mpsc;
     use tokio::time::timeout;
 
@@ -1134,8 +1155,7 @@ mod subscription_loop_tests {
     }
 
     fn datapoint(ts: u64, value: f64) -> OpcUaDataPoint {
-        OpcUaDataPoint::new(OpcUaValue::Double(value))
-            .with_server_timestamp(Some(ts))
+        OpcUaDataPoint::new(OpcUaValue::Double(value)).with_server_timestamp(Some(ts))
     }
 
     /// Wraps an unbounded channel as a notification [`Stream`]; the stream ends when the sender
@@ -1244,7 +1264,11 @@ mod subscription_loop_tests {
 
         let timestamps = samples
             .iter()
-            .map(|s| s.data.server_timestamp.expect("server timestamp should be present"))
+            .map(|s| {
+                s.data
+                    .server_timestamp
+                    .expect("server timestamp should be present")
+            })
             .collect::<Vec<_>>();
 
         assert_eq!(
@@ -1347,7 +1371,8 @@ mod subscription_loop_tests {
         let polled = samples.first().context("missing polled sample")?;
         let notification = samples.get(1).context("missing notification sample")?;
         assert_eq!(
-            polled.data.server_timestamp, Some(100),
+            polled.data.server_timestamp,
+            Some(100),
             "polled sample emitted first"
         );
         assert_eq!(notification.data.server_timestamp, Some(200));

--- a/crates/instro-opcua/src/types.rs
+++ b/crates/instro-opcua/src/types.rs
@@ -1062,9 +1062,29 @@ impl OpcUaSample {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct OpcUaDataPoint {
-    pub server_timestamp: u64,
+    pub server_timestamp: Option<u64>,
     pub source_timestamp: Option<u64>,
     pub value: OpcUaValue,
+}
+
+impl OpcUaDataPoint {
+    pub const fn new(value: OpcUaValue) -> Self {
+        Self {
+            value,
+            server_timestamp: None,
+            source_timestamp: None,
+        }
+    }
+
+    pub const fn with_server_timestamp(mut self, server_timestamp: u64) -> Self {
+        self.server_timestamp = Some(server_timestamp);
+        self
+    }
+
+    pub const fn with_source_timestamp(mut self, source_timestamp: u64) -> Self {
+        self.source_timestamp = Some(source_timestamp);
+        self
+    }
 }
 
 impl TryFrom<DataValue<ua::Variant>> for OpcUaDataPoint {
@@ -1073,9 +1093,7 @@ impl TryFrom<DataValue<ua::Variant>> for OpcUaDataPoint {
     fn try_from(value: DataValue<ua::Variant>) -> Result<Self> {
         let server_timestamp = value
             .server_timestamp()
-            .or_else(|| value.source_timestamp())
-            .map(|ts| ts.as_unix_timestamp_nanos() as u64)
-            .ok_or(anyhow!("no server or source timestamp found"))?;
+            .map(|ts| ts.as_unix_timestamp_nanos() as u64);
 
         let source_timestamp = value
             .source_timestamp()

--- a/crates/instro-opcua/src/types.rs
+++ b/crates/instro-opcua/src/types.rs
@@ -1076,13 +1076,13 @@ impl OpcUaDataPoint {
         }
     }
 
-    pub const fn with_server_timestamp(mut self, server_timestamp: u64) -> Self {
-        self.server_timestamp = Some(server_timestamp);
+    pub const fn with_server_timestamp(mut self, server_timestamp: Option<u64>) -> Self {
+        self.server_timestamp = server_timestamp;
         self
     }
 
-    pub const fn with_source_timestamp(mut self, source_timestamp: u64) -> Self {
-        self.source_timestamp = Some(source_timestamp);
+    pub const fn with_source_timestamp(mut self, source_timestamp: Option<u64>) -> Self {
+        self.source_timestamp = source_timestamp;
         self
     }
 }
@@ -1997,5 +1997,23 @@ mod tests {
             serde_json::to_value(OpcUaUserTokenType::Anonymous).expect("serialize"),
             serde_json::json!("anonymous"),
         );
+    }
+
+    #[test]
+    fn data_point_doesnt_coerce_null_server_timestamp() {
+        let data_point = OpcUaDataPoint::new(OpcUaValue::String("test".into()))
+            .with_source_timestamp(Some(100));
+
+        assert_eq!(data_point.server_timestamp, None);
+        assert_eq!(data_point.source_timestamp, Some(100));
+    }
+
+    #[test]
+    fn data_point_doesnt_coerce_null_source_timestamp() {
+        let data_point = OpcUaDataPoint::new(OpcUaValue::String("test".into()))
+            .with_server_timestamp(Some(100));
+
+        assert_eq!(data_point.source_timestamp, None);
+        assert_eq!(data_point.server_timestamp, Some(100));
     }
 }

--- a/crates/instro-opcua/src/types.rs
+++ b/crates/instro-opcua/src/types.rs
@@ -2001,8 +2001,8 @@ mod tests {
 
     #[test]
     fn data_point_doesnt_coerce_null_server_timestamp() {
-        let data_point = OpcUaDataPoint::new(OpcUaValue::String("test".into()))
-            .with_source_timestamp(Some(100));
+        let data_point =
+            OpcUaDataPoint::new(OpcUaValue::String("test".into())).with_source_timestamp(Some(100));
 
         assert_eq!(data_point.server_timestamp, None);
         assert_eq!(data_point.source_timestamp, Some(100));
@@ -2010,8 +2010,8 @@ mod tests {
 
     #[test]
     fn data_point_doesnt_coerce_null_source_timestamp() {
-        let data_point = OpcUaDataPoint::new(OpcUaValue::String("test".into()))
-            .with_server_timestamp(Some(100));
+        let data_point =
+            OpcUaDataPoint::new(OpcUaValue::String("test".into())).with_server_timestamp(Some(100));
 
         assert_eq!(data_point.source_timestamp, None);
         assert_eq!(data_point.server_timestamp, Some(100));

--- a/crates/instro-opcua/tests/client_harness.rs
+++ b/crates/instro-opcua/tests/client_harness.rs
@@ -102,9 +102,12 @@ fn monitored_item_config() -> OpcUaMonitoredItemConfig {
 
 fn assert_timestamps_present(samples: &[OpcUaSample]) {
     for sample in samples {
+        let timestamp = sample.data.server_timestamp
+            .or(sample.data.source_timestamp);
+
         assert!(
-            sample.data.server_timestamp > 0,
-            "server timestamp should be populated for {sample:?}",
+            matches!(timestamp, Some(timestamp) if timestamp > 0),
+            "timestamp should be populated for {sample:?}",
         );
     }
 }

--- a/crates/instro-opcua/tests/client_harness.rs
+++ b/crates/instro-opcua/tests/client_harness.rs
@@ -102,7 +102,9 @@ fn monitored_item_config() -> OpcUaMonitoredItemConfig {
 
 fn assert_timestamps_present(samples: &[OpcUaSample]) {
     for sample in samples {
-        let timestamp = sample.data.server_timestamp
+        let timestamp = sample
+            .data
+            .server_timestamp
             .or(sample.data.source_timestamp);
 
         assert!(

--- a/uv.lock
+++ b/uv.lock
@@ -594,7 +594,7 @@ wheels = [
 
 [[package]]
 name = "instro"
-version = "1.9.1"
+version = "1.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastavro", extra = ["snappy"] },
@@ -817,7 +817,7 @@ requires-dist = [{ name = "instro", editable = "." }]
 
 [[package]]
 name = "instro-unstable"
-version = "1.4.1"
+version = "1.5.0"
 source = { editable = "packages/instro-unstable" }
 dependencies = [
     { name = "gs-usb" },


### PR DESCRIPTION
## Summary

_Briefly describe what this PR does and why. If it fixes an existing issue, link it (e.g. `Fixes #123`)._
Fixes modelling of sample timestamps, where the source timestamp was assumed always available and was silently derived from the server timestamp if it wasn't available. It is now correctly optionally-present and there is no implicit coercion of timestamp sources.

## Type of change

- [ ] Bug fix (`fix`)
- [ ] New feature (`feat`)
- [ ] Breaking change (`feat!` / `fix!`)
- [x] Refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] Chore / tooling (`chore`)

## Verification

_How did you verify this change works? Provide evidence the reviewer can evaluate without reproducing your setup — e.g. test output, screenshots, logs, repro steps + result. If the change is hardware-specific and you don't have the device, say so._

## Tests

- [x] Unit tests added or updated
- [ ] Existing tests cover this change
- [ ] No tests — explain why:

Added regression tests that should signal if timestamp sources are confused or otherwise improperly interpreted.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(driver): add support for Keysight E36300`)
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] Documentation updated if user-facing behavior changed
- [x] Code follows the style/conventions of the surrounding code

## Notes for reviewers

_Optional — call out specific files, edge cases, or decisions you'd like eyes on._
