### PR TITLE
feat(awg): add burst to Keysight 33521B driver

### DIFF
--- a/packages/instro-unstable/instro/unstable/awg/drivers/keysight_33521b.py
+++ b/packages/instro-unstable/instro/unstable/awg/drivers/keysight_33521b.py
@@ -375,7 +375,7 @@ class Keysight33521B(AWGDriverBase):
             if source is not BurstTriggerSource.MANUAL:
                 raise ValueError(
                     f"Cannot fire a burst trigger on channel {channel} unless the trigger source is"
-                    f" already MANUAL, call set_burst_trigger(channel, BurstTriggerSource.MANUAL) first. Got: {source.name}"
+                    f" already MANUAL, call set_burst_trigger(channel, BurstTriggerSource.MANUAL) first. Current source: {source.name}"
                 )
             self._write_checked("*TRG")
 
@@ -383,7 +383,6 @@ class Keysight33521B(AWGDriverBase):
         _check_channel(channel)
         if delay_s < 0:
             raise ValueError(f"delay_s must be non-negative, got {delay_s}")
-        # the 33521B has no BURSt:TDELay; TRIGger:DELay is the shared burst/sweep/list trigger delay
         self._write_checked(f"TRIG:DEL {delay_s}")
 
     def get_burst_delay(self, channel: int) -> float:

--- a/packages/instro-unstable/instro/unstable/awg/drivers/keysight_33521b.py
+++ b/packages/instro-unstable/instro/unstable/awg/drivers/keysight_33521b.py
@@ -323,7 +323,12 @@ class Keysight33521B(AWGDriverBase):
             raise ValueError(f"the Keysight 33521B does not support {burst_type.name} burst mode")
         with self._visa.lock():
             carrier_name = self._visa.query("FUNC?").strip()
-            if carrier_name == "DC":
+            carrier_type = _FUNC_NAME_TO_CARRIER_TYPE.get(carrier_name)
+            if carrier_type is None:
+                self._check_errors()
+                raise ValueError(f"Keysight 33521B reported unsupported waveform '{carrier_name}'")
+            if carrier_type is StaticValue:
+                self._check_errors()
                 raise ValueError(f"the Keysight 33521B cannot burst a StaticValue (DC) waveform on channel {channel}")
             self._visa.write(f"BURS:MODE {_BURST_MODES[burst_type]}")
             self._check_errors()
@@ -401,9 +406,9 @@ class Keysight33521B(AWGDriverBase):
     def get_burst_gate_polarity(self, channel: int) -> GatePolarity:
         _check_channel(channel)
         with self._visa.lock():
-            result = GatePolarity(self._visa.query("BURS:GATE:POL?").strip())
+            raw = self._visa.query("BURS:GATE:POL?").strip()
             self._check_errors()
-        return result
+        return GatePolarity(raw)
 
     def set_burst_ncycles(self, channel: int, n_cycles: int) -> None:
         _check_channel(channel)

--- a/packages/instro-unstable/instro/unstable/awg/drivers/keysight_33521b.py
+++ b/packages/instro-unstable/instro/unstable/awg/drivers/keysight_33521b.py
@@ -9,6 +9,9 @@ from instro.unstable.awg.awg import AWGDriverBase
 from instro.unstable.awg.types import (
     AmplitudeMeasurementUnit,
     Arbitrary,
+    BurstTriggerSource,
+    BurstType,
+    GatePolarity,
     ModulationType,
     Pulse,
     Sawtooth,
@@ -57,6 +60,21 @@ _FUNC_NAME_TO_CARRIER_TYPE: dict[str, type] = {
     "PULS": Pulse,
     "DC": StaticValue,
     "ARB": Arbitrary,
+}
+
+_BURST_MODES: dict[BurstType, str] = {
+    BurstType.NCYCLE: "TRIG",
+    BurstType.GATED: "GAT",
+}
+_BURST_TYPES: dict[str, BurstType] = {mode: burst_type for burst_type, mode in _BURST_MODES.items()}
+
+_BURST_TRIGGER_SOURCES: dict[BurstTriggerSource, str] = {
+    BurstTriggerSource.INTERNAL: "IMM",
+    BurstTriggerSource.EXTERNAL: "EXT",
+    BurstTriggerSource.MANUAL: "BUS",
+}
+_BURST_TRIGGER_SOURCE_TYPES: dict[str, BurstTriggerSource] = {
+    token: source for source, token in _BURST_TRIGGER_SOURCES.items()
 }
 
 
@@ -297,9 +315,131 @@ class Keysight33521B(AWGDriverBase):
             self._check_errors()
         return result
 
+    def set_burst(self, channel: int, burst_type: BurstType) -> None:
+        _check_channel(channel)
+        if not isinstance(burst_type, BurstType):
+            raise TypeError(f"burst_type must be a BurstType, got {type(burst_type).__name__}")
+        if burst_type not in _BURST_MODES:
+            raise ValueError(f"the Keysight 33521B does not support {burst_type.name} burst mode")
+        with self._visa.lock():
+            carrier = self.get_waveform(channel)
+            if isinstance(carrier, StaticValue):
+                raise ValueError(f"the Keysight 33521B cannot burst a StaticValue (DC) waveform on channel {channel}")
+            self._visa.write(f"BURS:MODE {_BURST_MODES[burst_type]}")
+            self._check_errors()
+
+    def get_burst_type(self, channel: int) -> BurstType:
+        _check_channel(channel)
+        with self._visa.lock():
+            mode = self._visa.query("BURS:MODE?").strip()
+            self._check_errors()
+        if mode not in _BURST_TYPES:
+            raise ValueError(f"Keysight 33521B reported unsupported burst mode '{mode}'")
+        return _BURST_TYPES[mode]
+
+    def burst_enable(self, channel: int, enable: bool) -> None:
+        _check_channel(channel)
+        self._write_checked(f"BURS:STAT {'ON' if enable else 'OFF'}")
+
+    def get_burst_state(self, channel: int) -> bool:
+        _check_channel(channel)
+        with self._visa.lock():
+            result = self._visa.query("BURS:STAT?").strip() == "1"
+            self._check_errors()
+        return result
+
+    def set_burst_trigger(self, channel: int, source: BurstTriggerSource) -> None:
+        _check_channel(channel)
+        if not isinstance(source, BurstTriggerSource):
+            raise TypeError(f"source must be a BurstTriggerSource, got {type(source).__name__}")
+        self._write_checked(f"TRIG:SOUR {_BURST_TRIGGER_SOURCES[source]}")
+
+    def get_burst_trigger(self, channel: int) -> BurstTriggerSource:
+        _check_channel(channel)
+        with self._visa.lock():
+            token = self._visa.query("TRIG:SOUR?").strip()
+            self._check_errors()
+        if token not in _BURST_TRIGGER_SOURCE_TYPES:
+            raise ValueError(f"Keysight 33521B reported unsupported trigger source '{token}'")
+        return _BURST_TRIGGER_SOURCE_TYPES[token]
+
+    def fire_burst_trigger(self, channel: int) -> None:
+        _check_channel(channel)
+        with self._visa.lock():
+            if not self.get_burst_state(channel):
+                raise ValueError(
+                    f"Cannot fire a burst trigger on channel {channel} unless burst mode is already"
+                    " enabled, call burst_enable(channel, True) first"
+                )
+            source = self.get_burst_trigger(channel)
+            if source is not BurstTriggerSource.MANUAL:
+                raise ValueError(
+                    f"Cannot fire a burst trigger on channel {channel} unless the trigger source is"
+                    f" already MANUAL, call set_burst_trigger(channel, BurstTriggerSource.MANUAL) first. Got: {source.name}"
+                )
+            self._write_checked("*TRG")
+
+    def set_burst_delay(self, channel: int, delay_s: float) -> None:
+        _check_channel(channel)
+        if delay_s < 0:
+            raise ValueError(f"delay_s must be non-negative, got {delay_s}")
+        # the 33521B has no BURSt:TDELay; TRIGger:DELay is the shared burst/sweep/list trigger delay
+        self._write_checked(f"TRIG:DEL {delay_s}")
+
+    def get_burst_delay(self, channel: int) -> float:
+        _check_channel(channel)
+        with self._visa.lock():
+            result = float(self._visa.query("TRIG:DEL?"))
+            self._check_errors()
+        return result
+
+    def set_burst_gate_polarity(self, channel: int, gate_polarity: GatePolarity) -> None:
+        _check_channel(channel)
+        if not isinstance(gate_polarity, GatePolarity):
+            raise TypeError(f"gate_polarity must be a GatePolarity, got {type(gate_polarity).__name__}")
+        self._write_checked(f"BURS:GATE:POL {gate_polarity.value}")
+
+    def get_burst_gate_polarity(self, channel: int) -> GatePolarity:
+        _check_channel(channel)
+        with self._visa.lock():
+            result = GatePolarity(self._visa.query("BURS:GATE:POL?").strip())
+            self._check_errors()
+        return result
+
+    def set_burst_ncycles(self, channel: int, n_cycles: int) -> None:
+        _check_channel(channel)
+        if n_cycles <= 0:
+            raise ValueError(f"n_cycles must be >= 1, got {n_cycles}")
+        self._write_checked(f"BURS:NCYC {int(n_cycles)}")
+
+    def get_burst_ncycles(self, channel: int) -> int:
+        _check_channel(channel)
+        with self._visa.lock():
+            result = int(float(self._visa.query("BURS:NCYC?")))
+            self._check_errors()
+        return result
+
+    def set_burst_period(self, channel: int, period: float) -> None:
+        _check_channel(channel)
+        if period <= 0:
+            raise ValueError(f"period must be positive, got {period}")
+        self._write_checked(f"BURS:INT:PER {period}")
+
+    def get_burst_period(self, channel: int) -> float:
+        _check_channel(channel)
+        with self._visa.lock():
+            result = float(self._visa.query("BURS:INT:PER?"))
+            self._check_errors()
+        return result
+
     def _write_frequency_and_phase(self, frequency_hz: float, phase_deg: float) -> None:
         self._visa.write(f"FREQ {frequency_hz}")
         self._visa.write(f"PHAS {phase_deg % 360}")
+
+    def _write_checked(self, command: str) -> None:
+        with self._visa.lock():
+            self._visa.write(command)
+            self._check_errors()
 
     def _check_errors(self) -> None:
         """Query :SYSTem:ERRor? once and raise on a non-zero code. Does not drain the queue."""

--- a/packages/instro-unstable/instro/unstable/awg/drivers/keysight_33521b.py
+++ b/packages/instro-unstable/instro/unstable/awg/drivers/keysight_33521b.py
@@ -322,8 +322,8 @@ class Keysight33521B(AWGDriverBase):
         if burst_type not in _BURST_MODES:
             raise ValueError(f"the Keysight 33521B does not support {burst_type.name} burst mode")
         with self._visa.lock():
-            carrier = self.get_waveform(channel)
-            if isinstance(carrier, StaticValue):
+            carrier_name = self._visa.query("FUNC?").strip()
+            if carrier_name == "DC":
                 raise ValueError(f"the Keysight 33521B cannot burst a StaticValue (DC) waveform on channel {channel}")
             self._visa.write(f"BURS:MODE {_BURST_MODES[burst_type]}")
             self._check_errors()
@@ -409,7 +409,7 @@ class Keysight33521B(AWGDriverBase):
         _check_channel(channel)
         if n_cycles <= 0:
             raise ValueError(f"n_cycles must be >= 1, got {n_cycles}")
-        self._write_checked(f"BURS:NCYC {int(n_cycles)}")
+        self._write_checked(f"BURS:NCYC {n_cycles}")
 
     def get_burst_ncycles(self, channel: int) -> int:
         _check_channel(channel)

--- a/packages/instro-unstable/instro/unstable/awg/drivers/keysight_33521b.py
+++ b/packages/instro-unstable/instro/unstable/awg/drivers/keysight_33521b.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import sys
 
 from instro.lib.transports.visa import VisaConfig, VisaDriver
 from instro.unstable.awg.awg import AWGDriverBase
@@ -319,7 +320,8 @@ class Keysight33521B(AWGDriverBase):
         _check_channel(channel)
         if not isinstance(burst_type, BurstType):
             raise TypeError(f"burst_type must be a BurstType, got {type(burst_type).__name__}")
-        if burst_type not in _BURST_MODES:
+        scpi_mode = _BURST_MODES[BurstType.NCYCLE] if burst_type is BurstType.INFINITE else _BURST_MODES.get(burst_type)
+        if scpi_mode is None:
             raise ValueError(f"the Keysight 33521B does not support {burst_type.name} burst mode")
         with self._visa.lock():
             carrier_name = self._visa.query("FUNC?").strip()
@@ -330,7 +332,9 @@ class Keysight33521B(AWGDriverBase):
             if carrier_type is StaticValue:
                 self._check_errors()
                 raise ValueError(f"the Keysight 33521B cannot burst a StaticValue (DC) waveform on channel {channel}")
-            self._visa.write(f"BURS:MODE {_BURST_MODES[burst_type]}")
+            self._visa.write(f"BURS:MODE {scpi_mode}")
+            if burst_type is BurstType.INFINITE:
+                self._visa.write("BURS:NCYC INF")
             self._check_errors()
 
     def get_burst_type(self, channel: int) -> BurstType:
@@ -376,6 +380,11 @@ class Keysight33521B(AWGDriverBase):
                     f"Cannot fire a burst trigger on channel {channel} unless burst mode is already"
                     " enabled, call burst_enable(channel, True) first"
                 )
+            burst_type = self.get_burst_type(channel)
+            if burst_type is not BurstType.NCYCLE:
+                raise ValueError(
+                    f"fire_burst_trigger fires a single N-cycle burst; channel {channel} is in {burst_type.name} mode"
+                )
             source = self.get_burst_trigger(channel)
             if source is not BurstTriggerSource.MANUAL:
                 raise ValueError(
@@ -393,9 +402,9 @@ class Keysight33521B(AWGDriverBase):
     def get_burst_delay(self, channel: int) -> float:
         _check_channel(channel)
         with self._visa.lock():
-            result = float(self._visa.query("TRIG:DEL?"))
+            raw = self._visa.query("TRIG:DEL?")
             self._check_errors()
-        return result
+        return float(raw)
 
     def set_burst_gate_polarity(self, channel: int, gate_polarity: GatePolarity) -> None:
         _check_channel(channel)
@@ -419,9 +428,10 @@ class Keysight33521B(AWGDriverBase):
     def get_burst_ncycles(self, channel: int) -> int:
         _check_channel(channel)
         with self._visa.lock():
-            result = int(float(self._visa.query("BURS:NCYC?")))
+            raw = self._visa.query("BURS:NCYC?")
             self._check_errors()
-        return result
+        value = float(raw)
+        return sys.maxsize if value >= _HIGH_Z_SENTINEL else int(value)
 
     def set_burst_period(self, channel: int, period: float) -> None:
         _check_channel(channel)
@@ -432,9 +442,9 @@ class Keysight33521B(AWGDriverBase):
     def get_burst_period(self, channel: int) -> float:
         _check_channel(channel)
         with self._visa.lock():
-            result = float(self._visa.query("BURS:INT:PER?"))
+            raw = self._visa.query("BURS:INT:PER?")
             self._check_errors()
-        return result
+        return float(raw)
 
     def _write_frequency_and_phase(self, frequency_hz: float, phase_deg: float) -> None:
         self._visa.write(f"FREQ {frequency_hz}")

--- a/packages/instro-unstable/instro/unstable/awg/drivers/keysight_33521b.py
+++ b/packages/instro-unstable/instro/unstable/awg/drivers/keysight_33521b.py
@@ -320,30 +320,33 @@ class Keysight33521B(AWGDriverBase):
         _check_channel(channel)
         if not isinstance(burst_type, BurstType):
             raise TypeError(f"burst_type must be a BurstType, got {type(burst_type).__name__}")
-        scpi_mode = _BURST_MODES[BurstType.NCYCLE] if burst_type is BurstType.INFINITE else _BURST_MODES.get(burst_type)
-        if scpi_mode is None:
+        mode = _BURST_MODES[BurstType.NCYCLE] if burst_type is BurstType.INFINITE else _BURST_MODES.get(burst_type)
+        if mode is None:
             raise ValueError(f"the Keysight 33521B does not support {burst_type.name} burst mode")
         with self._visa.lock():
             carrier_name = self._visa.query("FUNC?").strip()
             carrier_type = _FUNC_NAME_TO_CARRIER_TYPE.get(carrier_name)
+            self._check_errors()
             if carrier_type is None:
-                self._check_errors()
                 raise ValueError(f"Keysight 33521B reported unsupported waveform '{carrier_name}'")
             if carrier_type is StaticValue:
-                self._check_errors()
                 raise ValueError(f"the Keysight 33521B cannot burst a StaticValue (DC) waveform on channel {channel}")
-            self._visa.write(f"BURS:MODE {scpi_mode}")
+            self._visa.write(f"BURS:MODE {mode}")
             if burst_type is BurstType.INFINITE:
                 self._visa.write("BURS:NCYC INF")
             self._check_errors()
 
     def get_burst_type(self, channel: int) -> BurstType:
+        """NCYCLE reads back as INFINITE when BURS:NCYC is the hardware's high-water sentinel for INF."""
         _check_channel(channel)
         with self._visa.lock():
             mode = self._visa.query("BURS:MODE?").strip()
+            ncycles_raw = self._visa.query("BURS:NCYC?") if mode == _BURST_MODES[BurstType.NCYCLE] else None
             self._check_errors()
         if mode not in _BURST_TYPES:
             raise ValueError(f"Keysight 33521B reported unsupported burst mode '{mode}'")
+        if ncycles_raw is not None and float(ncycles_raw) >= _HIGH_Z_SENTINEL:
+            return BurstType.INFINITE
         return _BURST_TYPES[mode]
 
     def burst_enable(self, channel: int, enable: bool) -> None:
@@ -381,7 +384,7 @@ class Keysight33521B(AWGDriverBase):
                     " enabled, call burst_enable(channel, True) first"
                 )
             burst_type = self.get_burst_type(channel)
-            if burst_type is not BurstType.NCYCLE:
+            if burst_type not in (BurstType.NCYCLE, BurstType.INFINITE):
                 raise ValueError(
                     f"fire_burst_trigger fires a single N-cycle burst; channel {channel} is in {burst_type.name} mode"
                 )

--- a/tests/unstable/awg/keysight/test_keysight_33521b_hardware.py
+++ b/tests/unstable/awg/keysight/test_keysight_33521b_hardware.py
@@ -561,11 +561,7 @@ def test_36_set_burst_ncycles_rejects_non_positive_value(driver: Keysight33521B)
 
 
 def test_37_set_burst_ncycles_silently_rounds_non_integer_value(driver: Keysight33521B) -> None:
-    """Hardware-confirmed: BURS:NCYC 10.5 is accepted with no SCPI error and silently rounds to 10.
-
-    The 33521B itself does not reject a fractional cycle count, so the driver cannot rely on
-    :SYST:ERR? to catch it; if this needs to be rejected, it has to be validated in software.
-    """
+    """Hardware-confirmed: BURS:NCYC 10.5 is accepted with no SCPI error and silently rounds to 10."""
     driver.set_waveform(CHANNEL, Square(frequency_hz=TEST_FREQUENCY_HZ))
     driver.set_burst(CHANNEL, BurstType.NCYCLE)
 
@@ -621,3 +617,17 @@ def test_41_set_burst_trigger_in_gated_mode(driver: Keysight33521B, source: Burs
     assert driver.get_burst_trigger(CHANNEL) is source
 
     driver._check_errors()
+
+
+def test_42_fire_burst_trigger_rejected_by_hardware_in_gated_mode(driver: Keysight33521B) -> None:
+    """Hardware-confirmed: GATED mode is level-triggered, so *TRG raises -211 "Trigger ignored"."""
+    driver.set_waveform(CHANNEL, Square(frequency_hz=TEST_FREQUENCY_HZ))
+    driver.set_burst(CHANNEL, BurstType.GATED)
+    driver.set_burst_trigger(CHANNEL, BurstTriggerSource.MANUAL)
+    driver.burst_enable(CHANNEL, True)
+    driver._check_errors()
+
+    with pytest.raises(RuntimeError, match=r'-211,"Trigger ignored"'):
+        driver.fire_burst_trigger(CHANNEL)
+
+    driver.burst_enable(CHANNEL, False)

--- a/tests/unstable/awg/keysight/test_keysight_33521b_hardware.py
+++ b/tests/unstable/awg/keysight/test_keysight_33521b_hardware.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from collections.abc import Iterator
 
 import pytest
@@ -438,21 +439,28 @@ def test_25_set_burst_ncycle_on_every_valid_carrier(driver: Keysight33521B, carr
     assert driver.get_burst_state(CHANNEL) is False
 
 
-def test_26_set_burst_rejects_staticvalue_carrier_and_infinite_mode(driver: Keysight33521B) -> None:
+def test_26_set_burst_rejects_staticvalue_carrier(driver: Keysight33521B) -> None:
     driver.set_waveform(CHANNEL, StaticValue(value=TEST_OFFSET_V))
 
     with pytest.raises(ValueError, match="cannot burst a StaticValue"):
         driver.set_burst(CHANNEL, BurstType.NCYCLE)
     driver._check_errors()
 
-    driver.set_waveform(CHANNEL, Sine(frequency_hz=TEST_FREQUENCY_HZ))
-    with pytest.raises(ValueError, match="does not support INFINITE burst mode"):
-        driver.set_burst(CHANNEL, BurstType.INFINITE)
+
+def test_27_set_burst_accepts_untracked_arbitrary_carrier(driver: Keysight33521B) -> None:
+    """Regression: pop the cache to simulate a driver instance that never downloaded this Arbitrary."""
+    driver.set_waveform(CHANNEL, Arbitrary(samples=_ARB_SAMPLES, sample_rate_hz=100_000.0))
     driver._check_errors()
+    driver._arb_waveforms.pop(CHANNEL)
+
+    driver.set_burst(CHANNEL, BurstType.NCYCLE)
+    driver._check_errors()
+
+    assert driver.get_burst_type(CHANNEL) is BurstType.NCYCLE
 
 
 @pytest.mark.parametrize("burst_type", [BurstType.NCYCLE, BurstType.GATED], ids=["ncycle", "gated"])
-def test_27_get_burst_type_matches_configured_type(driver: Keysight33521B, burst_type: BurstType) -> None:
+def test_28_get_burst_type_matches_configured_type(driver: Keysight33521B, burst_type: BurstType) -> None:
     driver.set_waveform(CHANNEL, Square(frequency_hz=TEST_FREQUENCY_HZ))
     driver.set_burst(CHANNEL, burst_type)
     driver._check_errors()
@@ -460,12 +468,44 @@ def test_27_get_burst_type_matches_configured_type(driver: Keysight33521B, burst
     assert driver.get_burst_type(CHANNEL) is burst_type
 
 
+def test_29_set_burst_infinite_maps_to_ncycle_with_max_ncycles(driver: Keysight33521B) -> None:
+    """The 33521B has no third BURSt:MODE value: INFINITE is programmed as BURS:MODE TRIG + BURS:NCYC INF."""
+    driver.set_waveform(CHANNEL, Square(frequency_hz=TEST_FREQUENCY_HZ))
+    driver.set_burst(CHANNEL, BurstType.INFINITE)
+    driver._check_errors()
+
+    assert driver.get_burst_type(CHANNEL) is BurstType.NCYCLE
+    assert driver.get_burst_ncycles(CHANNEL) == sys.maxsize
+
+
+def test_30_set_burst_infinite_rejects_staticvalue_carrier(driver: Keysight33521B) -> None:
+    driver.set_waveform(CHANNEL, StaticValue(value=TEST_OFFSET_V))
+
+    with pytest.raises(ValueError, match="cannot burst a StaticValue"):
+        driver.set_burst(CHANNEL, BurstType.INFINITE)
+    driver._check_errors()
+
+
+def test_31_switching_back_to_ncycle_after_infinite_clears_max_ncycles(driver: Keysight33521B) -> None:
+    """Confirms BURS:NCYC INF isn't sticky once a finite count is programmed on top of it."""
+    driver.set_waveform(CHANNEL, Square(frequency_hz=TEST_FREQUENCY_HZ))
+    driver.set_burst(CHANNEL, BurstType.INFINITE)
+    driver._check_errors()
+    assert driver.get_burst_ncycles(CHANNEL) == sys.maxsize
+
+    driver.set_burst(CHANNEL, BurstType.NCYCLE)
+    driver.set_burst_ncycles(CHANNEL, 10)
+    driver._check_errors()
+
+    assert driver.get_burst_ncycles(CHANNEL) == 10
+
+
 @pytest.mark.parametrize(
     "source",
     [BurstTriggerSource.INTERNAL, BurstTriggerSource.EXTERNAL, BurstTriggerSource.MANUAL],
     ids=["internal", "external", "manual"],
 )
-def test_28_burst_trigger_roundtrip_matches_configured_source(
+def test_32_burst_trigger_roundtrip_matches_configured_source(
     driver: Keysight33521B, source: BurstTriggerSource
 ) -> None:
     """Confirms the driver's IMM/EXT/BUS <-> INTERNAL/EXTERNAL/MANUAL mapping against real TRIGger:SOURce state."""
@@ -479,14 +519,33 @@ def test_28_burst_trigger_roundtrip_matches_configured_source(
     assert driver.get_burst_trigger(CHANNEL) is source
 
 
-def test_29_set_burst_trigger_rejects_invalid_channel(driver: Keysight33521B) -> None:
+def test_33_set_burst_trigger_rejects_invalid_channel(driver: Keysight33521B) -> None:
     with pytest.raises(ValueError, match="only supports 1 channel"):
         driver.set_burst_trigger(INVALID_CHANNEL, BurstTriggerSource.MANUAL)
 
     driver._check_errors()
 
 
-def test_30_fire_burst_trigger_fires_when_source_already_manual(driver: Keysight33521B) -> None:
+@pytest.mark.parametrize(
+    "source",
+    [BurstTriggerSource.INTERNAL, BurstTriggerSource.EXTERNAL, BurstTriggerSource.MANUAL],
+    ids=["internal", "external", "manual"],
+)
+def test_34_set_burst_trigger_in_gated_mode(driver: Keysight33521B, source: BurstTriggerSource) -> None:
+    """Untested gap: confirms whether GATED mode accepts a trigger source change, or rejects it like Rigol."""
+    driver.set_waveform(CHANNEL, Square(frequency_hz=TEST_FREQUENCY_HZ))
+    driver.set_burst(CHANNEL, BurstType.GATED)
+    driver._check_errors()
+
+    driver.set_burst_trigger(CHANNEL, source)
+    driver._check_errors()
+
+    assert driver.get_burst_trigger(CHANNEL) is source
+
+    driver._check_errors()
+
+
+def test_35_fire_burst_trigger_fires_when_source_already_manual(driver: Keysight33521B) -> None:
     """*TRG only fires once TRIGger:SOURce is BUS (mapped from BurstTriggerSource.MANUAL)."""
     driver.set_waveform(CHANNEL, Square(frequency_hz=TEST_FREQUENCY_HZ))
     driver.set_burst(CHANNEL, BurstType.NCYCLE)
@@ -502,7 +561,7 @@ def test_30_fire_burst_trigger_fires_when_source_already_manual(driver: Keysight
     driver.burst_enable(CHANNEL, False)
 
 
-def test_31_fire_burst_trigger_rejects_non_manual_source_and_when_not_enabled(driver: Keysight33521B) -> None:
+def test_36_fire_burst_trigger_rejects_non_manual_source_and_when_not_enabled(driver: Keysight33521B) -> None:
     driver.set_waveform(CHANNEL, Square(frequency_hz=TEST_FREQUENCY_HZ))
     driver.set_burst(CHANNEL, BurstType.NCYCLE)
     driver.set_burst_trigger(CHANNEL, BurstTriggerSource.EXTERNAL)
@@ -521,7 +580,40 @@ def test_31_fire_burst_trigger_rejects_non_manual_source_and_when_not_enabled(dr
     driver._check_errors()
 
 
-def test_32_burst_delay_roundtrip_uses_shared_trigger_delay_node(driver: Keysight33521B) -> None:
+def test_37_fire_burst_trigger_rejects_gated_mode_before_touching_hardware(driver: Keysight33521B) -> None:
+    """Software-side NCYCLE guard rejects GATED before *TRG is ever written, ahead of the -211 hardware would raise."""
+    driver.set_waveform(CHANNEL, Square(frequency_hz=TEST_FREQUENCY_HZ))
+    driver.set_burst(CHANNEL, BurstType.GATED)
+    driver.set_burst_trigger(CHANNEL, BurstTriggerSource.MANUAL)
+    driver.burst_enable(CHANNEL, True)
+    driver._check_errors()
+
+    with pytest.raises(ValueError, match="fires a single N-cycle burst"):
+        driver.fire_burst_trigger(CHANNEL)
+
+    # No SCPI error should be queued: the guard fired before *TRG was ever written.
+    driver._check_errors()
+
+    driver.burst_enable(CHANNEL, False)
+
+
+def test_38_fire_burst_trigger_fires_when_configured_via_infinite(driver: Keysight33521B) -> None:
+    """INFINITE reads back as NCYCLE (same wire mode), so the fire_burst_trigger guard does not reject it."""
+    driver.set_waveform(CHANNEL, Square(frequency_hz=TEST_FREQUENCY_HZ))
+    driver.set_burst(CHANNEL, BurstType.INFINITE)
+    driver.set_burst_trigger(CHANNEL, BurstTriggerSource.MANUAL)
+    driver._check_errors()
+
+    driver.output_enable(CHANNEL, True)
+    driver.burst_enable(CHANNEL, True)
+    driver.fire_burst_trigger(CHANNEL)
+    driver._check_errors()
+
+    driver.output_enable(CHANNEL, False)
+    driver.burst_enable(CHANNEL, False)
+
+
+def test_39_burst_delay_roundtrip_uses_shared_trigger_delay_node(driver: Keysight33521B) -> None:
     """The 33521B has no BURSt:TDELay; TRIGger:DELay is the shared burst/sweep/list trigger delay."""
     driver.set_burst_delay(CHANNEL, 0.001)
     driver._check_errors()
@@ -529,7 +621,7 @@ def test_32_burst_delay_roundtrip_uses_shared_trigger_delay_node(driver: Keysigh
     assert driver.get_burst_delay(CHANNEL) == pytest.approx(0.001, rel=0.01)
 
 
-def test_33_set_burst_delay_rejects_negative_value(driver: Keysight33521B) -> None:
+def test_40_set_burst_delay_rejects_negative_value(driver: Keysight33521B) -> None:
     with pytest.raises(ValueError, match="delay_s must be non-negative"):
         driver.set_burst_delay(CHANNEL, -0.1)
 
@@ -537,14 +629,14 @@ def test_33_set_burst_delay_rejects_negative_value(driver: Keysight33521B) -> No
 
 
 @pytest.mark.parametrize("gate_polarity", [GatePolarity.NORM, GatePolarity.INV], ids=["norm", "inv"])
-def test_34_burst_gate_polarity_roundtrip(driver: Keysight33521B, gate_polarity: GatePolarity) -> None:
+def test_41_burst_gate_polarity_roundtrip(driver: Keysight33521B, gate_polarity: GatePolarity) -> None:
     driver.set_burst_gate_polarity(CHANNEL, gate_polarity)
     driver._check_errors()
 
     assert driver.get_burst_gate_polarity(CHANNEL) is gate_polarity
 
 
-def test_35_burst_ncycles_roundtrip(driver: Keysight33521B) -> None:
+def test_42_burst_ncycles_roundtrip(driver: Keysight33521B) -> None:
     driver.set_waveform(CHANNEL, Square(frequency_hz=TEST_FREQUENCY_HZ))
     driver.set_burst(CHANNEL, BurstType.NCYCLE)
     driver.set_burst_ncycles(CHANNEL, 10)
@@ -553,14 +645,14 @@ def test_35_burst_ncycles_roundtrip(driver: Keysight33521B) -> None:
     assert driver.get_burst_ncycles(CHANNEL) == 10
 
 
-def test_36_set_burst_ncycles_rejects_non_positive_value(driver: Keysight33521B) -> None:
+def test_43_set_burst_ncycles_rejects_non_positive_value(driver: Keysight33521B) -> None:
     with pytest.raises(ValueError, match="n_cycles must be >= 1"):
         driver.set_burst_ncycles(CHANNEL, 0)
 
     driver._check_errors()
 
 
-def test_37_set_burst_ncycles_silently_rounds_non_integer_value(driver: Keysight33521B) -> None:
+def test_44_set_burst_ncycles_silently_rounds_non_integer_value(driver: Keysight33521B) -> None:
     """Hardware-confirmed: BURS:NCYC 10.5 is accepted with no SCPI error and silently rounds to 10."""
     driver.set_waveform(CHANNEL, Square(frequency_hz=TEST_FREQUENCY_HZ))
     driver.set_burst(CHANNEL, BurstType.NCYCLE)
@@ -572,7 +664,7 @@ def test_37_set_burst_ncycles_silently_rounds_non_integer_value(driver: Keysight
     assert driver.get_burst_ncycles(CHANNEL) == 10
 
 
-def test_38_burst_period_roundtrip(driver: Keysight33521B) -> None:
+def test_45_burst_period_roundtrip(driver: Keysight33521B) -> None:
     driver.set_waveform(CHANNEL, Square(frequency_hz=TEST_FREQUENCY_HZ))
     driver.set_burst(CHANNEL, BurstType.NCYCLE)
     driver.set_burst_period(CHANNEL, 0.05)
@@ -581,53 +673,8 @@ def test_38_burst_period_roundtrip(driver: Keysight33521B) -> None:
     assert driver.get_burst_period(CHANNEL) == pytest.approx(0.05, rel=0.01)
 
 
-def test_39_set_burst_period_rejects_non_positive_value(driver: Keysight33521B) -> None:
+def test_46_set_burst_period_rejects_non_positive_value(driver: Keysight33521B) -> None:
     with pytest.raises(ValueError, match="period must be positive"):
         driver.set_burst_period(CHANNEL, 0.0)
 
     driver._check_errors()
-
-
-def test_40_set_burst_accepts_untracked_arbitrary_carrier(driver: Keysight33521B) -> None:
-    """Regression: pop the cache to simulate a driver instance that never downloaded this Arbitrary."""
-    driver.set_waveform(CHANNEL, Arbitrary(samples=_ARB_SAMPLES, sample_rate_hz=100_000.0))
-    driver._check_errors()
-    driver._arb_waveforms.pop(CHANNEL)
-
-    driver.set_burst(CHANNEL, BurstType.NCYCLE)
-    driver._check_errors()
-
-    assert driver.get_burst_type(CHANNEL) is BurstType.NCYCLE
-
-
-@pytest.mark.parametrize(
-    "source",
-    [BurstTriggerSource.INTERNAL, BurstTriggerSource.EXTERNAL, BurstTriggerSource.MANUAL],
-    ids=["internal", "external", "manual"],
-)
-def test_41_set_burst_trigger_in_gated_mode(driver: Keysight33521B, source: BurstTriggerSource) -> None:
-    """Untested gap: confirms whether GATED mode accepts a trigger source change, or rejects it like Rigol."""
-    driver.set_waveform(CHANNEL, Square(frequency_hz=TEST_FREQUENCY_HZ))
-    driver.set_burst(CHANNEL, BurstType.GATED)
-    driver._check_errors()
-
-    driver.set_burst_trigger(CHANNEL, source)
-    driver._check_errors()
-
-    assert driver.get_burst_trigger(CHANNEL) is source
-
-    driver._check_errors()
-
-
-def test_42_fire_burst_trigger_rejected_by_hardware_in_gated_mode(driver: Keysight33521B) -> None:
-    """Hardware-confirmed: GATED mode is level-triggered, so *TRG raises -211 "Trigger ignored"."""
-    driver.set_waveform(CHANNEL, Square(frequency_hz=TEST_FREQUENCY_HZ))
-    driver.set_burst(CHANNEL, BurstType.GATED)
-    driver.set_burst_trigger(CHANNEL, BurstTriggerSource.MANUAL)
-    driver.burst_enable(CHANNEL, True)
-    driver._check_errors()
-
-    with pytest.raises(RuntimeError, match=r'-211,"Trigger ignored"'):
-        driver.fire_burst_trigger(CHANNEL)
-
-    driver.burst_enable(CHANNEL, False)

--- a/tests/unstable/awg/keysight/test_keysight_33521b_hardware.py
+++ b/tests/unstable/awg/keysight/test_keysight_33521b_hardware.py
@@ -560,7 +560,23 @@ def test_36_set_burst_ncycles_rejects_non_positive_value(driver: Keysight33521B)
     driver._check_errors()
 
 
-def test_37_burst_period_roundtrip(driver: Keysight33521B) -> None:
+def test_37_set_burst_ncycles_silently_rounds_non_integer_value(driver: Keysight33521B) -> None:
+    """Hardware-confirmed: BURS:NCYC 10.5 is accepted with no SCPI error and silently rounds to 10.
+
+    The 33521B itself does not reject a fractional cycle count, so the driver cannot rely on
+    :SYST:ERR? to catch it; if this needs to be rejected, it has to be validated in software.
+    """
+    driver.set_waveform(CHANNEL, Square(frequency_hz=TEST_FREQUENCY_HZ))
+    driver.set_burst(CHANNEL, BurstType.NCYCLE)
+
+    # driver.set_burst_ncycles(CHANNEL, 10.5)  # type: ignore[arg-type]
+    driver._visa.write("BURS:NCYC 10.5")
+    driver._check_errors()
+
+    assert driver.get_burst_ncycles(CHANNEL) == 10
+
+
+def test_38_burst_period_roundtrip(driver: Keysight33521B) -> None:
     driver.set_waveform(CHANNEL, Square(frequency_hz=TEST_FREQUENCY_HZ))
     driver.set_burst(CHANNEL, BurstType.NCYCLE)
     driver.set_burst_period(CHANNEL, 0.05)
@@ -569,23 +585,23 @@ def test_37_burst_period_roundtrip(driver: Keysight33521B) -> None:
     assert driver.get_burst_period(CHANNEL) == pytest.approx(0.05, rel=0.01)
 
 
-def test_38_set_burst_period_rejects_non_positive_value(driver: Keysight33521B) -> None:
+def test_39_set_burst_period_rejects_non_positive_value(driver: Keysight33521B) -> None:
     with pytest.raises(ValueError, match="period must be positive"):
         driver.set_burst_period(CHANNEL, 0.0)
 
     driver._check_errors()
 
 
-def test_39_set_burst_on_untracked_arbitrary_carrier_raises(driver: Keysight33521B) -> None:
-    """Known limitation, not fixed: pop the cache to simulate a driver instance that never downloaded it."""
+def test_40_set_burst_accepts_untracked_arbitrary_carrier(driver: Keysight33521B) -> None:
+    """Regression: pop the cache to simulate a driver instance that never downloaded this Arbitrary."""
     driver.set_waveform(CHANNEL, Arbitrary(samples=_ARB_SAMPLES, sample_rate_hz=100_000.0))
     driver._check_errors()
     driver._arb_waveforms.pop(CHANNEL)
 
-    with pytest.raises(RuntimeError, match="not programmed by this driver"):
-        driver.set_burst(CHANNEL, BurstType.NCYCLE)
-
+    driver.set_burst(CHANNEL, BurstType.NCYCLE)
     driver._check_errors()
+
+    assert driver.get_burst_type(CHANNEL) is BurstType.NCYCLE
 
 
 @pytest.mark.parametrize(
@@ -593,7 +609,7 @@ def test_39_set_burst_on_untracked_arbitrary_carrier_raises(driver: Keysight3352
     [BurstTriggerSource.INTERNAL, BurstTriggerSource.EXTERNAL, BurstTriggerSource.MANUAL],
     ids=["internal", "external", "manual"],
 )
-def test_40_set_burst_trigger_in_gated_mode(driver: Keysight33521B, source: BurstTriggerSource) -> None:
+def test_41_set_burst_trigger_in_gated_mode(driver: Keysight33521B, source: BurstTriggerSource) -> None:
     """Untested gap: confirms whether GATED mode accepts a trigger source change, or rejects it like Rigol."""
     driver.set_waveform(CHANNEL, Square(frequency_hz=TEST_FREQUENCY_HZ))
     driver.set_burst(CHANNEL, BurstType.GATED)

--- a/tests/unstable/awg/keysight/test_keysight_33521b_hardware.py
+++ b/tests/unstable/awg/keysight/test_keysight_33521b_hardware.py
@@ -11,6 +11,9 @@ from instro.unstable.awg.drivers import Keysight33521B
 from instro.unstable.awg.types import (
     AmplitudeMeasurementUnit,
     Arbitrary,
+    BurstTriggerSource,
+    BurstType,
+    GatePolarity,
     ModulationType,
     Pulse,
     Sawtooth,
@@ -399,4 +402,175 @@ def test_24_modulation_enable_persists_after_set_modulation(driver: Keysight3352
     assert driver.get_modulation_type(CHANNEL) == ModulationType.PSK
 
     driver.modulation_enable(CHANNEL, False)
+    driver._check_errors()
+
+
+# ---------------------------------------------------------------------------
+# Burst
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "carrier",
+    [
+        Sine(frequency_hz=TEST_FREQUENCY_HZ),
+        Square(frequency_hz=TEST_FREQUENCY_HZ),
+        Sawtooth(frequency_hz=TEST_FREQUENCY_HZ),
+        Triangle(frequency_hz=TEST_FREQUENCY_HZ),
+        Pulse(frequency_hz=TEST_FREQUENCY_HZ, width_s=0.0002),
+        Arbitrary(samples=_ARB_SAMPLES, sample_rate_hz=100_000.0),
+    ],
+    ids=["sine", "square", "sawtooth", "triangle", "pulse", "arbitrary"],
+)
+def test_25_set_burst_ncycle_on_every_valid_carrier(driver: Keysight33521B, carrier: Waveform) -> None:
+    driver.set_waveform(CHANNEL, carrier)
+    driver.set_burst(CHANNEL, BurstType.NCYCLE)
+    driver._check_errors()
+
+    assert driver.get_burst_type(CHANNEL) is BurstType.NCYCLE
+
+    driver.burst_enable(CHANNEL, True)
+    driver._check_errors()
+    assert driver.get_burst_state(CHANNEL) is True
+
+    driver.burst_enable(CHANNEL, False)
+    driver._check_errors()
+    assert driver.get_burst_state(CHANNEL) is False
+
+
+def test_26_set_burst_rejects_staticvalue_carrier_and_infinite_mode(driver: Keysight33521B) -> None:
+    driver.set_waveform(CHANNEL, StaticValue(value=TEST_OFFSET_V))
+
+    with pytest.raises(ValueError, match="cannot burst a StaticValue"):
+        driver.set_burst(CHANNEL, BurstType.NCYCLE)
+    driver._check_errors()
+
+    driver.set_waveform(CHANNEL, Sine(frequency_hz=TEST_FREQUENCY_HZ))
+    with pytest.raises(ValueError, match="does not support INFINITE burst mode"):
+        driver.set_burst(CHANNEL, BurstType.INFINITE)
+    driver._check_errors()
+
+
+@pytest.mark.parametrize("burst_type", [BurstType.NCYCLE, BurstType.GATED], ids=["ncycle", "gated"])
+def test_27_get_burst_type_matches_configured_type(driver: Keysight33521B, burst_type: BurstType) -> None:
+    driver.set_waveform(CHANNEL, Square(frequency_hz=TEST_FREQUENCY_HZ))
+    driver.set_burst(CHANNEL, burst_type)
+    driver._check_errors()
+
+    assert driver.get_burst_type(CHANNEL) is burst_type
+
+
+@pytest.mark.parametrize(
+    "source",
+    [BurstTriggerSource.INTERNAL, BurstTriggerSource.EXTERNAL, BurstTriggerSource.MANUAL],
+    ids=["internal", "external", "manual"],
+)
+def test_28_burst_trigger_roundtrip_matches_configured_source(
+    driver: Keysight33521B, source: BurstTriggerSource
+) -> None:
+    """Confirms the driver's IMM/EXT/BUS <-> INTERNAL/EXTERNAL/MANUAL mapping against real TRIGger:SOURce state."""
+    driver.set_waveform(CHANNEL, Square(frequency_hz=TEST_FREQUENCY_HZ))
+    driver.set_burst(CHANNEL, BurstType.NCYCLE)
+    driver._check_errors()
+
+    driver.set_burst_trigger(CHANNEL, source)
+    driver._check_errors()
+
+    assert driver.get_burst_trigger(CHANNEL) is source
+
+
+def test_29_set_burst_trigger_rejects_invalid_channel(driver: Keysight33521B) -> None:
+    with pytest.raises(ValueError, match="only supports 1 channel"):
+        driver.set_burst_trigger(INVALID_CHANNEL, BurstTriggerSource.MANUAL)
+
+    driver._check_errors()
+
+
+def test_30_fire_burst_trigger_fires_when_source_already_manual(driver: Keysight33521B) -> None:
+    """*TRG only fires once TRIGger:SOURce is BUS (mapped from BurstTriggerSource.MANUAL)."""
+    driver.set_waveform(CHANNEL, Square(frequency_hz=TEST_FREQUENCY_HZ))
+    driver.set_burst(CHANNEL, BurstType.NCYCLE)
+    driver.set_burst_trigger(CHANNEL, BurstTriggerSource.MANUAL)
+    driver._check_errors()
+
+    driver.output_enable(CHANNEL, True)
+    driver.burst_enable(CHANNEL, True)
+    driver.fire_burst_trigger(CHANNEL)
+    driver._check_errors()
+
+    driver.output_enable(CHANNEL, False)
+    driver.burst_enable(CHANNEL, False)
+
+
+def test_31_fire_burst_trigger_rejects_non_manual_source_and_when_not_enabled(driver: Keysight33521B) -> None:
+    driver.set_waveform(CHANNEL, Square(frequency_hz=TEST_FREQUENCY_HZ))
+    driver.set_burst(CHANNEL, BurstType.NCYCLE)
+    driver.set_burst_trigger(CHANNEL, BurstTriggerSource.EXTERNAL)
+    driver.burst_enable(CHANNEL, True)
+    driver._check_errors()
+
+    with pytest.raises(ValueError, match="already MANUAL"):
+        driver.fire_burst_trigger(CHANNEL)
+
+    driver.burst_enable(CHANNEL, False)
+    driver._check_errors()
+
+    with pytest.raises(ValueError, match="burst mode is already"):
+        driver.fire_burst_trigger(CHANNEL)
+
+    driver._check_errors()
+
+
+def test_32_burst_delay_roundtrip_uses_shared_trigger_delay_node(driver: Keysight33521B) -> None:
+    """The 33521B has no BURSt:TDELay; TRIGger:DELay is the shared burst/sweep/list trigger delay."""
+    driver.set_burst_delay(CHANNEL, 0.001)
+    driver._check_errors()
+
+    assert driver.get_burst_delay(CHANNEL) == pytest.approx(0.001, rel=0.01)
+
+
+def test_33_set_burst_delay_rejects_negative_value(driver: Keysight33521B) -> None:
+    with pytest.raises(ValueError, match="delay_s must be non-negative"):
+        driver.set_burst_delay(CHANNEL, -0.1)
+
+    driver._check_errors()
+
+
+@pytest.mark.parametrize("gate_polarity", [GatePolarity.NORM, GatePolarity.INV], ids=["norm", "inv"])
+def test_34_burst_gate_polarity_roundtrip(driver: Keysight33521B, gate_polarity: GatePolarity) -> None:
+    driver.set_burst_gate_polarity(CHANNEL, gate_polarity)
+    driver._check_errors()
+
+    assert driver.get_burst_gate_polarity(CHANNEL) is gate_polarity
+
+
+def test_35_burst_ncycles_roundtrip(driver: Keysight33521B) -> None:
+    driver.set_waveform(CHANNEL, Square(frequency_hz=TEST_FREQUENCY_HZ))
+    driver.set_burst(CHANNEL, BurstType.NCYCLE)
+    driver.set_burst_ncycles(CHANNEL, 10)
+    driver._check_errors()
+
+    assert driver.get_burst_ncycles(CHANNEL) == 10
+
+
+def test_36_set_burst_ncycles_rejects_non_positive_value(driver: Keysight33521B) -> None:
+    with pytest.raises(ValueError, match="n_cycles must be >= 1"):
+        driver.set_burst_ncycles(CHANNEL, 0)
+
+    driver._check_errors()
+
+
+def test_37_burst_period_roundtrip(driver: Keysight33521B) -> None:
+    driver.set_waveform(CHANNEL, Square(frequency_hz=TEST_FREQUENCY_HZ))
+    driver.set_burst(CHANNEL, BurstType.NCYCLE)
+    driver.set_burst_period(CHANNEL, 0.05)
+    driver._check_errors()
+
+    assert driver.get_burst_period(CHANNEL) == pytest.approx(0.05, rel=0.01)
+
+
+def test_38_set_burst_period_rejects_non_positive_value(driver: Keysight33521B) -> None:
+    with pytest.raises(ValueError, match="period must be positive"):
+        driver.set_burst_period(CHANNEL, 0.0)
+
     driver._check_errors()

--- a/tests/unstable/awg/keysight/test_keysight_33521b_hardware.py
+++ b/tests/unstable/awg/keysight/test_keysight_33521b_hardware.py
@@ -574,3 +574,34 @@ def test_38_set_burst_period_rejects_non_positive_value(driver: Keysight33521B) 
         driver.set_burst_period(CHANNEL, 0.0)
 
     driver._check_errors()
+
+
+def test_39_set_burst_on_untracked_arbitrary_carrier_raises(driver: Keysight33521B) -> None:
+    """Known limitation, not fixed: pop the cache to simulate a driver instance that never downloaded it."""
+    driver.set_waveform(CHANNEL, Arbitrary(samples=_ARB_SAMPLES, sample_rate_hz=100_000.0))
+    driver._check_errors()
+    driver._arb_waveforms.pop(CHANNEL)
+
+    with pytest.raises(RuntimeError, match="not programmed by this driver"):
+        driver.set_burst(CHANNEL, BurstType.NCYCLE)
+
+    driver._check_errors()
+
+
+@pytest.mark.parametrize(
+    "source",
+    [BurstTriggerSource.INTERNAL, BurstTriggerSource.EXTERNAL, BurstTriggerSource.MANUAL],
+    ids=["internal", "external", "manual"],
+)
+def test_40_set_burst_trigger_in_gated_mode(driver: Keysight33521B, source: BurstTriggerSource) -> None:
+    """Untested gap: confirms whether GATED mode accepts a trigger source change, or rejects it like Rigol."""
+    driver.set_waveform(CHANNEL, Square(frequency_hz=TEST_FREQUENCY_HZ))
+    driver.set_burst(CHANNEL, BurstType.GATED)
+    driver._check_errors()
+
+    driver.set_burst_trigger(CHANNEL, source)
+    driver._check_errors()
+
+    assert driver.get_burst_trigger(CHANNEL) is source
+
+    driver._check_errors()

--- a/tests/unstable/awg/keysight/test_keysight_33521b_hardware.py
+++ b/tests/unstable/awg/keysight/test_keysight_33521b_hardware.py
@@ -459,7 +459,9 @@ def test_27_set_burst_accepts_untracked_arbitrary_carrier(driver: Keysight33521B
     assert driver.get_burst_type(CHANNEL) is BurstType.NCYCLE
 
 
-@pytest.mark.parametrize("burst_type", [BurstType.NCYCLE, BurstType.GATED], ids=["ncycle", "gated"])
+@pytest.mark.parametrize(
+    "burst_type", [BurstType.NCYCLE, BurstType.GATED, BurstType.INFINITE], ids=["ncycle", "gated", "infinite"]
+)
 def test_28_get_burst_type_matches_configured_type(driver: Keysight33521B, burst_type: BurstType) -> None:
     driver.set_waveform(CHANNEL, Square(frequency_hz=TEST_FREQUENCY_HZ))
     driver.set_burst(CHANNEL, burst_type)
@@ -468,13 +470,13 @@ def test_28_get_burst_type_matches_configured_type(driver: Keysight33521B, burst
     assert driver.get_burst_type(CHANNEL) is burst_type
 
 
-def test_29_set_burst_infinite_maps_to_ncycle_with_max_ncycles(driver: Keysight33521B) -> None:
-    """The 33521B has no third BURSt:MODE value: INFINITE is programmed as BURS:MODE TRIG + BURS:NCYC INF."""
+def test_29_set_burst_infinite_reports_infinite_type_and_max_ncycles(driver: Keysight33521B) -> None:
+    """get_burst_type infers INFINITE from the BURS:NCYC sentinel; the 33521B has no third BURS:MODE value."""
     driver.set_waveform(CHANNEL, Square(frequency_hz=TEST_FREQUENCY_HZ))
     driver.set_burst(CHANNEL, BurstType.INFINITE)
     driver._check_errors()
 
-    assert driver.get_burst_type(CHANNEL) is BurstType.NCYCLE
+    assert driver.get_burst_type(CHANNEL) is BurstType.INFINITE
     assert driver.get_burst_ncycles(CHANNEL) == sys.maxsize
 
 
@@ -486,16 +488,22 @@ def test_30_set_burst_infinite_rejects_staticvalue_carrier(driver: Keysight33521
     driver._check_errors()
 
 
-def test_31_switching_back_to_ncycle_after_infinite_clears_max_ncycles(driver: Keysight33521B) -> None:
-    """Confirms BURS:NCYC INF isn't sticky once a finite count is programmed on top of it."""
+def test_31_set_burst_ncycle_leaves_a_prior_infinite_sentinel_until_ncycles_is_set(driver: Keysight33521B) -> None:
+    """set_burst(NCYCLE) only rewrites BURS:MODE; a leftover BURS:NCYC INF is the caller's to clear."""
     driver.set_waveform(CHANNEL, Square(frequency_hz=TEST_FREQUENCY_HZ))
     driver.set_burst(CHANNEL, BurstType.INFINITE)
     driver._check_errors()
     assert driver.get_burst_ncycles(CHANNEL) == sys.maxsize
 
     driver.set_burst(CHANNEL, BurstType.NCYCLE)
+    driver._check_errors()
+    assert driver.get_burst_type(CHANNEL) is BurstType.INFINITE
+
     driver.set_burst_ncycles(CHANNEL, 10)
     driver._check_errors()
+
+    assert driver.get_burst_type(CHANNEL) is BurstType.NCYCLE
+    assert driver.get_burst_ncycles(CHANNEL) == 10
 
     assert driver.get_burst_ncycles(CHANNEL) == 10
 
@@ -598,7 +606,7 @@ def test_37_fire_burst_trigger_rejects_gated_mode_before_touching_hardware(drive
 
 
 def test_38_fire_burst_trigger_fires_when_configured_via_infinite(driver: Keysight33521B) -> None:
-    """INFINITE reads back as NCYCLE (same wire mode), so the fire_burst_trigger guard does not reject it."""
+    """The NCYCLE guard also allows INFINITE, since firing is wire-identical to a plain NCYCLE burst."""
     driver.set_waveform(CHANNEL, Square(frequency_hz=TEST_FREQUENCY_HZ))
     driver.set_burst(CHANNEL, BurstType.INFINITE)
     driver.set_burst_trigger(CHANNEL, BurstTriggerSource.MANUAL)

--- a/tests/unstable/awg/keysight/test_keysight_33521b_software.py
+++ b/tests/unstable/awg/keysight/test_keysight_33521b_software.py
@@ -1006,3 +1006,13 @@ def test_66_set_burst_period_rejects_non_positive_value_and_invalid_channel(
         keysight.set_burst_period(2, 0.1)
 
     keysight_visa.write.assert_not_called()
+
+
+def test_67_set_burst_on_untracked_arbitrary_carrier_raises(keysight: Keysight33521B, keysight_visa: MagicMock) -> None:
+    """Known limitation, not fixed: an untracked Arbitrary carrier still raises via get_waveform()."""
+    _query_sequence(keysight_visa, ["ARB"])
+
+    with pytest.raises(RuntimeError, match="not programmed by this driver"):
+        keysight.set_burst(1, BurstType.NCYCLE)
+
+    keysight_visa.write.assert_not_called()

--- a/tests/unstable/awg/keysight/test_keysight_33521b_software.py
+++ b/tests/unstable/awg/keysight/test_keysight_33521b_software.py
@@ -776,6 +776,17 @@ def test_48_set_burst_infinite_uses_ncycle_mode_with_max_cycles(
     assert keysight_visa.write.call_args_list == [call("BURS:MODE TRIG"), call("BURS:NCYC INF")]
 
 
+def test_set_burst_ncycle_does_not_touch_a_prior_infinite_ncycles_sentinel(
+    keysight: Keysight33521B, keysight_visa: MagicMock
+) -> None:
+    """set_burst(NCYCLE) only writes BURS:MODE; BURS:NCYC is caller-owned via set_burst_ncycles, not auto-reset."""
+    _query_sequence(keysight_visa, ["SIN"])
+
+    keysight.set_burst(1, BurstType.NCYCLE)
+
+    assert keysight_visa.write.call_args_list == [call("BURS:MODE TRIG")]
+
+
 @pytest.mark.parametrize(
     ("channel", "burst_type", "carrier_responses", "match"),
     [
@@ -805,7 +816,7 @@ def test_49_set_burst_rejects_invalid_input(
 def test_50_get_burst_type_parses_every_mode_and_rejects_unknown(
     keysight: Keysight33521B, keysight_visa: MagicMock
 ) -> None:
-    _query_sequence(keysight_visa, ["TRIG"])
+    _query_sequence(keysight_visa, ["TRIG", "1.000000E+01"])
     assert keysight.get_burst_type(1) is BurstType.NCYCLE
 
     _query_sequence(keysight_visa, ["GAT"])
@@ -814,6 +825,16 @@ def test_50_get_burst_type_parses_every_mode_and_rejects_unknown(
     _query_sequence(keysight_visa, ["NOIS"])
     with pytest.raises(ValueError, match="unsupported burst mode 'NOIS'"):
         keysight.get_burst_type(1)
+
+
+def test_get_burst_type_reports_infinite_when_ncycles_is_the_high_water_sentinel(
+    keysight: Keysight33521B, keysight_visa: MagicMock
+) -> None:
+    """NCYCLE mode + a BURS:NCYC readback at the 9.9E37 sentinel reports as INFINITE, not NCYCLE."""
+    _query_sequence(keysight_visa, ["TRIG", "9.900000E+37"])
+
+    assert keysight.get_burst_type(1) is BurstType.INFINITE
+    assert _real_query_calls(keysight_visa) == [call("BURS:MODE?"), call("BURS:NCYC?")]
 
 
 def test_51_burst_enable_writes_burs_stat_and_get_burst_state_parses_it(
@@ -891,18 +912,34 @@ def test_56_fire_burst_trigger_fires_when_source_already_manual(
     keysight: Keysight33521B, keysight_visa: MagicMock
 ) -> None:
     """*TRG, not TRIGger:IMMediate, is the documented software-trigger command for this instrument."""
-    _query_sequence(keysight_visa, ["1", "TRIG", "BUS"])
+    _query_sequence(keysight_visa, ["1", "TRIG", "1.000000E+01", "BUS"])
 
     keysight.fire_burst_trigger(1)
 
-    assert _real_query_calls(keysight_visa) == [call("BURS:STAT?"), call("BURS:MODE?"), call("TRIG:SOUR?")]
+    assert _real_query_calls(keysight_visa) == [
+        call("BURS:STAT?"),
+        call("BURS:MODE?"),
+        call("BURS:NCYC?"),
+        call("TRIG:SOUR?"),
+    ]
+    assert keysight_visa.write.call_args_list == [call("*TRG")]
+
+
+def test_fire_burst_trigger_fires_when_configured_via_infinite(
+    keysight: Keysight33521B, keysight_visa: MagicMock
+) -> None:
+    """INFINITE is wire-identical to NCYCLE (same BURS:MODE token); the guard must allow both."""
+    _query_sequence(keysight_visa, ["1", "TRIG", "9.900000E+37", "BUS"])
+
+    keysight.fire_burst_trigger(1)
+
     assert keysight_visa.write.call_args_list == [call("*TRG")]
 
 
 def test_57_fire_burst_trigger_rejects_non_manual_source_and_invalid_channel(
     keysight: Keysight33521B, keysight_visa: MagicMock
 ) -> None:
-    _query_sequence(keysight_visa, ["1", "TRIG", "EXT"])
+    _query_sequence(keysight_visa, ["1", "TRIG", "1.000000E+01", "EXT"])
 
     with pytest.raises(ValueError, match="already MANUAL"):
         keysight.fire_burst_trigger(1)
@@ -934,7 +971,6 @@ def test_fire_burst_trigger_rejects_gated_mode_before_reading_trigger_source(
         keysight.fire_burst_trigger(1)
 
     assert _real_query_calls(keysight_visa) == [call("BURS:STAT?"), call("BURS:MODE?")]
-    keysight_visa.write.assert_not_called()
     keysight_visa.write.assert_not_called()
 
 

--- a/tests/unstable/awg/keysight/test_keysight_33521b_software.py
+++ b/tests/unstable/awg/keysight/test_keysight_33521b_software.py
@@ -757,7 +757,7 @@ def test_46_set_modulation_warns_when_reconfigure_fails_while_disabled(
 def test_47_set_burst_writes_mode_for_each_supported_type(
     keysight: Keysight33521B, keysight_visa: MagicMock, burst_type: BurstType, expected_mode: str
 ) -> None:
-    _query_sequence(keysight_visa, ["SIN", "1.000000E+03", "0.000000E+00"])
+    _query_sequence(keysight_visa, ["SIN"])
 
     keysight.set_burst(1, burst_type)
 
@@ -776,9 +776,9 @@ def test_48_set_burst_rejects_infinite_mode(keysight: Keysight33521B, keysight_v
 @pytest.mark.parametrize(
     ("channel", "burst_type", "carrier_responses", "match"),
     [
-        (2, BurstType.NCYCLE, ["SIN", "1.000000E+03", "0.000000E+00"], "only supports 1 channel"),
+        (2, BurstType.NCYCLE, [], "only supports 1 channel"),
         (1, "NCYCLE", [], "burst_type must be a BurstType"),
-        (1, BurstType.NCYCLE, ["DC", "1.500000E+00"], "cannot burst a StaticValue"),
+        (1, BurstType.NCYCLE, ["DC"], "cannot burst a StaticValue"),
     ],
     ids=["invalid_channel", "invalid_burst_type", "staticvalue_carrier"],
 )
@@ -1008,11 +1008,10 @@ def test_66_set_burst_period_rejects_non_positive_value_and_invalid_channel(
     keysight_visa.write.assert_not_called()
 
 
-def test_67_set_burst_on_untracked_arbitrary_carrier_raises(keysight: Keysight33521B, keysight_visa: MagicMock) -> None:
-    """Known limitation, not fixed: an untracked Arbitrary carrier still raises via get_waveform()."""
+def test_67_set_burst_accepts_untracked_arbitrary_carrier(keysight: Keysight33521B, keysight_visa: MagicMock) -> None:
+    """Regression: an Arbitrary carrier this driver instance never downloaded is still a valid burst carrier."""
     _query_sequence(keysight_visa, ["ARB"])
 
-    with pytest.raises(RuntimeError, match="not programmed by this driver"):
-        keysight.set_burst(1, BurstType.NCYCLE)
+    keysight.set_burst(1, BurstType.NCYCLE)
 
-    keysight_visa.write.assert_not_called()
+    assert keysight_visa.write.call_args_list == [call("BURS:MODE TRIG")]

--- a/tests/unstable/awg/keysight/test_keysight_33521b_software.py
+++ b/tests/unstable/awg/keysight/test_keysight_33521b_software.py
@@ -779,8 +779,9 @@ def test_48_set_burst_rejects_infinite_mode(keysight: Keysight33521B, keysight_v
         (2, BurstType.NCYCLE, [], "only supports 1 channel"),
         (1, "NCYCLE", [], "burst_type must be a BurstType"),
         (1, BurstType.NCYCLE, ["DC"], "cannot burst a StaticValue"),
+        (1, BurstType.NCYCLE, ["NOIS"], "unsupported waveform 'NOIS'"),
     ],
-    ids=["invalid_channel", "invalid_burst_type", "staticvalue_carrier"],
+    ids=["invalid_channel", "invalid_burst_type", "staticvalue_carrier", "unrecognized_carrier"],
 )
 def test_49_set_burst_rejects_invalid_input(
     keysight: Keysight33521B,

--- a/tests/unstable/awg/keysight/test_keysight_33521b_software.py
+++ b/tests/unstable/awg/keysight/test_keysight_33521b_software.py
@@ -11,6 +11,9 @@ from instro.unstable.awg.drivers import Keysight33521B
 from instro.unstable.awg.types import (
     AmplitudeMeasurementUnit,
     Arbitrary,
+    BurstTriggerSource,
+    BurstType,
+    GatePolarity,
     ModulationType,
     Pulse,
     Sawtooth,
@@ -739,3 +742,267 @@ def test_46_set_modulation_warns_when_reconfigure_fails_while_disabled(
 
     assert "modulation remains disabled" in caplog.text
     assert call("AM:STAT ON") not in keysight_visa.write.call_args_list
+
+
+# ---------------------------------------------------------------------------
+# Burst
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("burst_type", "expected_mode"),
+    [(BurstType.NCYCLE, "TRIG"), (BurstType.GATED, "GAT")],
+    ids=["ncycle", "gated"],
+)
+def test_47_set_burst_writes_mode_for_each_supported_type(
+    keysight: Keysight33521B, keysight_visa: MagicMock, burst_type: BurstType, expected_mode: str
+) -> None:
+    _query_sequence(keysight_visa, ["SIN", "1.000000E+03", "0.000000E+00"])
+
+    keysight.set_burst(1, burst_type)
+
+    assert keysight_visa.write.call_args_list == [call(f"BURS:MODE {expected_mode}")]
+
+
+def test_48_set_burst_rejects_infinite_mode(keysight: Keysight33521B, keysight_visa: MagicMock) -> None:
+    """The 33521B has no third BURSt:MODE value; infinite cycles is a BURSt:NCYCles parameter, not a mode."""
+    with pytest.raises(ValueError, match="does not support INFINITE burst mode"):
+        keysight.set_burst(1, BurstType.INFINITE)
+
+    keysight_visa.write.assert_not_called()
+    keysight_visa.query.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("channel", "burst_type", "carrier_responses", "match"),
+    [
+        (2, BurstType.NCYCLE, ["SIN", "1.000000E+03", "0.000000E+00"], "only supports 1 channel"),
+        (1, "NCYCLE", [], "burst_type must be a BurstType"),
+        (1, BurstType.NCYCLE, ["DC", "1.500000E+00"], "cannot burst a StaticValue"),
+    ],
+    ids=["invalid_channel", "invalid_burst_type", "staticvalue_carrier"],
+)
+def test_49_set_burst_rejects_invalid_input(
+    keysight: Keysight33521B,
+    keysight_visa: MagicMock,
+    channel: int,
+    burst_type: BurstType,
+    carrier_responses: list[str],
+    match: str,
+) -> None:
+    _query_sequence(keysight_visa, carrier_responses)
+
+    with pytest.raises((ValueError, TypeError), match=match):
+        keysight.set_burst(channel, burst_type)
+
+    keysight_visa.write.assert_not_called()
+
+
+def test_50_get_burst_type_parses_every_mode_and_rejects_unknown(
+    keysight: Keysight33521B, keysight_visa: MagicMock
+) -> None:
+    _query_sequence(keysight_visa, ["TRIG"])
+    assert keysight.get_burst_type(1) is BurstType.NCYCLE
+
+    _query_sequence(keysight_visa, ["GAT"])
+    assert keysight.get_burst_type(1) is BurstType.GATED
+
+    _query_sequence(keysight_visa, ["NOIS"])
+    with pytest.raises(ValueError, match="unsupported burst mode 'NOIS'"):
+        keysight.get_burst_type(1)
+
+
+def test_51_burst_enable_writes_burs_stat_and_get_burst_state_parses_it(
+    keysight: Keysight33521B, keysight_visa: MagicMock
+) -> None:
+    keysight.burst_enable(1, True)
+    keysight.burst_enable(1, False)
+    assert keysight_visa.write.call_args_list == [call("BURS:STAT ON"), call("BURS:STAT OFF")]
+
+    _query_sequence(keysight_visa, ["1"])
+    assert keysight.get_burst_state(1) is True
+
+    _query_sequence(keysight_visa, ["0"])
+    assert keysight.get_burst_state(1) is False
+
+
+@pytest.mark.parametrize(
+    ("source", "expected_token"),
+    [
+        (BurstTriggerSource.INTERNAL, "IMM"),
+        (BurstTriggerSource.EXTERNAL, "EXT"),
+        (BurstTriggerSource.MANUAL, "BUS"),
+    ],
+    ids=["internal", "external", "manual"],
+)
+def test_52_set_burst_trigger_writes_mapped_source_token(
+    keysight: Keysight33521B, keysight_visa: MagicMock, source: BurstTriggerSource, expected_token: str
+) -> None:
+    """The 33521B has no BURSt:TRIG:SOUR; it's the shared TRIGger:SOURce node with IMM/EXT/BUS tokens."""
+    keysight.set_burst_trigger(1, source)
+
+    keysight_visa.write.assert_called_once_with(f"TRIG:SOUR {expected_token}")
+
+
+def test_53_set_burst_trigger_rejects_invalid_source_and_channel(
+    keysight: Keysight33521B, keysight_visa: MagicMock
+) -> None:
+    with pytest.raises(TypeError, match="source must be a BurstTriggerSource"):
+        keysight.set_burst_trigger(1, "INT")  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="only supports 1 channel"):
+        keysight.set_burst_trigger(2, BurstTriggerSource.INTERNAL)
+
+    keysight_visa.write.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("token", "expected_source"),
+    [("IMM", BurstTriggerSource.INTERNAL), ("EXT", BurstTriggerSource.EXTERNAL), ("BUS", BurstTriggerSource.MANUAL)],
+    ids=["internal", "external", "manual"],
+)
+def test_54_get_burst_trigger_parses_every_mapped_source(
+    keysight: Keysight33521B, keysight_visa: MagicMock, token: str, expected_source: BurstTriggerSource
+) -> None:
+    _query_sequence(keysight_visa, [token])
+
+    assert keysight.get_burst_trigger(1) is expected_source
+    assert _real_query_calls(keysight_visa) == [call("TRIG:SOUR?")]
+
+
+def test_55_get_burst_trigger_rejects_unknown_source_and_invalid_channel(
+    keysight: Keysight33521B, keysight_visa: MagicMock
+) -> None:
+    """Regression guard: TIMer is a real TRIGger:SOURce value with no BurstTriggerSource counterpart."""
+    with pytest.raises(ValueError, match="only supports 1 channel"):
+        keysight.get_burst_trigger(2)
+    keysight_visa.query.assert_not_called()
+
+    _query_sequence(keysight_visa, ["TIM"])
+    with pytest.raises(ValueError, match="unsupported trigger source 'TIM'"):
+        keysight.get_burst_trigger(1)
+
+
+def test_56_fire_burst_trigger_fires_when_source_already_manual(
+    keysight: Keysight33521B, keysight_visa: MagicMock
+) -> None:
+    """*TRG, not TRIGger:IMMediate, is the documented software-trigger command for this instrument."""
+    _query_sequence(keysight_visa, ["1", "BUS"])
+
+    keysight.fire_burst_trigger(1)
+
+    assert _real_query_calls(keysight_visa) == [call("BURS:STAT?"), call("TRIG:SOUR?")]
+    assert keysight_visa.write.call_args_list == [call("*TRG")]
+
+
+def test_57_fire_burst_trigger_rejects_non_manual_source_and_invalid_channel(
+    keysight: Keysight33521B, keysight_visa: MagicMock
+) -> None:
+    _query_sequence(keysight_visa, ["1", "EXT"])
+
+    with pytest.raises(ValueError, match="already MANUAL"):
+        keysight.fire_burst_trigger(1)
+
+    with pytest.raises(ValueError, match="only supports 1 channel"):
+        keysight.fire_burst_trigger(2)
+
+    keysight_visa.write.assert_not_called()
+
+
+def test_58_fire_burst_trigger_rejects_when_burst_not_enabled(
+    keysight: Keysight33521B, keysight_visa: MagicMock
+) -> None:
+    _query_sequence(keysight_visa, ["0"])
+
+    with pytest.raises(ValueError, match="burst mode is already"):
+        keysight.fire_burst_trigger(1)
+
+    assert _real_query_calls(keysight_visa) == [call("BURS:STAT?")]
+    keysight_visa.write.assert_not_called()
+
+
+def test_59_burst_delay_roundtrip_uses_shared_trigger_delay_node(
+    keysight: Keysight33521B, keysight_visa: MagicMock
+) -> None:
+    """The 33521B has no BURSt:TDELay; TRIGger:DELay is the shared burst/sweep/list trigger delay."""
+    keysight.set_burst_delay(1, 0.5)
+    keysight_visa.write.assert_called_once_with("TRIG:DEL 0.5")
+
+    _query_sequence(keysight_visa, ["5.000000E-01"])
+    assert keysight.get_burst_delay(1) == pytest.approx(0.5)
+    assert _real_query_calls(keysight_visa) == [call("TRIG:DEL?")]
+
+
+def test_60_set_burst_delay_rejects_negative_value_and_invalid_channel(
+    keysight: Keysight33521B, keysight_visa: MagicMock
+) -> None:
+    with pytest.raises(ValueError, match="delay_s must be non-negative"):
+        keysight.set_burst_delay(1, -0.1)
+
+    with pytest.raises(ValueError, match="only supports 1 channel"):
+        keysight.set_burst_delay(2, 0.1)
+
+    keysight_visa.write.assert_not_called()
+
+
+@pytest.mark.parametrize("gate_polarity", [GatePolarity.NORM, GatePolarity.INV], ids=["norm", "inv"])
+def test_61_burst_gate_polarity_roundtrip(
+    keysight: Keysight33521B, keysight_visa: MagicMock, gate_polarity: GatePolarity
+) -> None:
+    keysight.set_burst_gate_polarity(1, gate_polarity)
+    keysight_visa.write.assert_called_once_with(f"BURS:GATE:POL {gate_polarity.value}")
+
+    _query_sequence(keysight_visa, [gate_polarity.value])
+    assert keysight.get_burst_gate_polarity(1) is gate_polarity
+
+
+def test_62_set_burst_gate_polarity_rejects_invalid_type_and_channel(
+    keysight: Keysight33521B, keysight_visa: MagicMock
+) -> None:
+    with pytest.raises(TypeError, match="gate_polarity must be a GatePolarity"):
+        keysight.set_burst_gate_polarity(1, "NORM")  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="only supports 1 channel"):
+        keysight.set_burst_gate_polarity(2, GatePolarity.NORM)
+
+    keysight_visa.write.assert_not_called()
+
+
+def test_63_burst_ncycles_roundtrip(keysight: Keysight33521B, keysight_visa: MagicMock) -> None:
+    keysight.set_burst_ncycles(1, 10)
+    keysight_visa.write.assert_called_once_with("BURS:NCYC 10")
+
+    _query_sequence(keysight_visa, ["1.000000E+01"])
+    assert keysight.get_burst_ncycles(1) == 10
+
+
+def test_64_set_burst_ncycles_rejects_non_positive_value_and_invalid_channel(
+    keysight: Keysight33521B, keysight_visa: MagicMock
+) -> None:
+    with pytest.raises(ValueError, match="n_cycles must be >= 1"):
+        keysight.set_burst_ncycles(1, 0)
+
+    with pytest.raises(ValueError, match="only supports 1 channel"):
+        keysight.set_burst_ncycles(2, 10)
+
+    keysight_visa.write.assert_not_called()
+
+
+def test_65_burst_period_roundtrip(keysight: Keysight33521B, keysight_visa: MagicMock) -> None:
+    keysight.set_burst_period(1, 0.25)
+    keysight_visa.write.assert_called_once_with("BURS:INT:PER 0.25")
+
+    _query_sequence(keysight_visa, ["2.500000E-01"])
+    assert keysight.get_burst_period(1) == pytest.approx(0.25)
+
+
+def test_66_set_burst_period_rejects_non_positive_value_and_invalid_channel(
+    keysight: Keysight33521B, keysight_visa: MagicMock
+) -> None:
+    with pytest.raises(ValueError, match="period must be positive"):
+        keysight.set_burst_period(1, 0.0)
+
+    with pytest.raises(ValueError, match="only supports 1 channel"):
+        keysight.set_burst_period(2, 0.1)
+
+    keysight_visa.write.assert_not_called()

--- a/tests/unstable/awg/keysight/test_keysight_33521b_software.py
+++ b/tests/unstable/awg/keysight/test_keysight_33521b_software.py
@@ -1,6 +1,7 @@
 """Software tests for the Keysight 33521B AWG driver."""
 
 import logging
+import sys
 from collections.abc import Iterator
 from unittest.mock import MagicMock, call, patch
 
@@ -764,13 +765,15 @@ def test_47_set_burst_writes_mode_for_each_supported_type(
     assert keysight_visa.write.call_args_list == [call(f"BURS:MODE {expected_mode}")]
 
 
-def test_48_set_burst_rejects_infinite_mode(keysight: Keysight33521B, keysight_visa: MagicMock) -> None:
-    """The 33521B has no third BURSt:MODE value; infinite cycles is a BURSt:NCYCles parameter, not a mode."""
-    with pytest.raises(ValueError, match="does not support INFINITE burst mode"):
-        keysight.set_burst(1, BurstType.INFINITE)
+def test_48_set_burst_infinite_uses_ncycle_mode_with_max_cycles(
+    keysight: Keysight33521B, keysight_visa: MagicMock
+) -> None:
+    """The 33521B has no third BURSt:MODE value; infinite cycles is an NCYCLE burst at BURSt:NCYCles INF."""
+    _query_sequence(keysight_visa, ["SIN"])
 
-    keysight_visa.write.assert_not_called()
-    keysight_visa.query.assert_not_called()
+    keysight.set_burst(1, BurstType.INFINITE)
+
+    assert keysight_visa.write.call_args_list == [call("BURS:MODE TRIG"), call("BURS:NCYC INF")]
 
 
 @pytest.mark.parametrize(
@@ -888,18 +891,18 @@ def test_56_fire_burst_trigger_fires_when_source_already_manual(
     keysight: Keysight33521B, keysight_visa: MagicMock
 ) -> None:
     """*TRG, not TRIGger:IMMediate, is the documented software-trigger command for this instrument."""
-    _query_sequence(keysight_visa, ["1", "BUS"])
+    _query_sequence(keysight_visa, ["1", "TRIG", "BUS"])
 
     keysight.fire_burst_trigger(1)
 
-    assert _real_query_calls(keysight_visa) == [call("BURS:STAT?"), call("TRIG:SOUR?")]
+    assert _real_query_calls(keysight_visa) == [call("BURS:STAT?"), call("BURS:MODE?"), call("TRIG:SOUR?")]
     assert keysight_visa.write.call_args_list == [call("*TRG")]
 
 
 def test_57_fire_burst_trigger_rejects_non_manual_source_and_invalid_channel(
     keysight: Keysight33521B, keysight_visa: MagicMock
 ) -> None:
-    _query_sequence(keysight_visa, ["1", "EXT"])
+    _query_sequence(keysight_visa, ["1", "TRIG", "EXT"])
 
     with pytest.raises(ValueError, match="already MANUAL"):
         keysight.fire_burst_trigger(1)
@@ -919,6 +922,19 @@ def test_58_fire_burst_trigger_rejects_when_burst_not_enabled(
         keysight.fire_burst_trigger(1)
 
     assert _real_query_calls(keysight_visa) == [call("BURS:STAT?")]
+
+
+def test_fire_burst_trigger_rejects_gated_mode_before_reading_trigger_source(
+    keysight: Keysight33521B, keysight_visa: MagicMock
+) -> None:
+    """The NCYCLE guard raises before TRIG:SOUR? is ever queried or *TRG is written."""
+    _query_sequence(keysight_visa, ["1", "GAT"])
+
+    with pytest.raises(ValueError, match="fires a single N-cycle burst"):
+        keysight.fire_burst_trigger(1)
+
+    assert _real_query_calls(keysight_visa) == [call("BURS:STAT?"), call("BURS:MODE?")]
+    keysight_visa.write.assert_not_called()
     keysight_visa.write.assert_not_called()
 
 
@@ -975,6 +991,14 @@ def test_63_burst_ncycles_roundtrip(keysight: Keysight33521B, keysight_visa: Mag
 
     _query_sequence(keysight_visa, ["1.000000E+01"])
     assert keysight.get_burst_ncycles(1) == 10
+
+
+def test_get_burst_ncycles_reports_infinity_sentinel_as_maxsize(
+    keysight: Keysight33521B, keysight_visa: MagicMock
+) -> None:
+    """An INFINITE burst reads BURSt:NCYCles back as the 9.9E+37 sentinel, same as OUTPut:LOAD."""
+    _query_sequence(keysight_visa, ["9.900000E+37"])
+    assert keysight.get_burst_ncycles(1) == sys.maxsize
 
 
 def test_64_set_burst_ncycles_rejects_non_positive_value_and_invalid_channel(


### PR DESCRIPTION
## Summary

This PR implements the burst base functions defined in `awg.py` inside the `keysight_33521b.py` driver. No documentation change was made since those were added in https://github.com/nominal-io/instro/pull/367. Software and hardware tests are included and were added to the existing hardware and software test suite for the Keysight 33521B. 

## Type of change

- [ ] Bug fix (`fix`)
- [x] New feature (`feat`)
- [ ] Breaking change (`feat!` / `fix!`)
- [ ] Refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] Chore / tooling (`chore`)

## Verification

<img width="1650" height="859" alt="Screenshot 2026-08-18 at 2 38 18 PM" src="https://github.com/user-attachments/assets/850f93ff-b139-4250-8c3a-86952fab2fd2" />

<img width="985" height="813" alt="Screenshot 2026-08-18 at 2 38 54 PM" src="https://github.com/user-attachments/assets/c0f6c117-5c8b-4ae9-ab7d-32755c0d8334" />


## Tests

- [x] Unit tests added or updated
- [ ] Existing tests cover this change
- [ ] No tests — explain why:

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(driver): add support for Keysight E36300`)
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] Documentation updated if user-facing behavior changed
- [x] Code follows the style/conventions of the surrounding code

## Notes for reviewers

The Keysight 33521B only has one channel. So, we make sure to validate that the user calls the correct channel parameter, but we don't use the channel value in the SCPI commands.