### PR TITLE
fix(discover): report 2 programmable channels for SiglentSPD3303

### DIFF
--- a/instro/lib/discover.py
+++ b/instro/lib/discover.py
@@ -56,7 +56,7 @@ _IDN_MAP: dict[tuple[str, str], tuple[str, str, int | None]] = {
     ("RIGOL TECHNOLOGIES", "DP821"): ("psu", "RigolDP800", 2),
     ("RIGOL TECHNOLOGIES", "DP831"): ("psu", "RigolDP800", 3),
     ("RIGOL TECHNOLOGIES", "DP832"): ("psu", "RigolDP800", 3),
-    ("SIGLENT TECHNOLOGIES", "SPD3303"): ("psu", "SiglentSPD3303", 3),
+    ("SIGLENT TECHNOLOGIES", "SPD3303"): ("psu", "SiglentSPD3303", 2),
     ("B&K PRECISION", "BK85"): ("eload", "BK85XXB", None),
     ("KEYSIGHT TECHNOLOGIES", "DSOX120"): ("scope", "Keysight1200X", 2),
     ("KEYSIGHT TECHNOLOGIES", "EDUX105"): ("scope", "Keysight1200X", 2),

--- a/instro/lib/discover.py
+++ b/instro/lib/discover.py
@@ -42,8 +42,10 @@ class VisaScanResult:
 
 
 # Key: (vendor, model) substrings matched case-insensitively against the *IDN? response.
-# Value: (category, driver_class_name, num_channels). num_channels is the instrument's real
-# channel count where known; left None where it isn't tracked (dmm, eload).
+# Value: (category, driver_class_name, num_channels). num_channels is the count of
+# SCPI-programmable channels where known, not necessarily the instrument's physical output
+# count (e.g. SiglentSPD3303's CH3 has no SCPI voltage/current access); left None where it
+# isn't tracked (dmm, eload).
 _IDN_MAP: dict[tuple[str, str], tuple[str, str, int | None]] = {
     ("AGILENT TECHNOLOGIES", "34401A"): ("dmm", "Agilent34401A", None),
     ("HEWLETT-PACKARD", "34401A"): ("dmm", "Agilent34401A", None),

--- a/tests/lib/test_discover.py
+++ b/tests/lib/test_discover.py
@@ -45,6 +45,22 @@ def test_scan_recognized_psu() -> None:
     assert info.num_channels == 1
 
 
+def test_scan_recognized_siglent_spd3303_reports_two_programmable_channels() -> None:
+    # Channel 3 is a front-panel-only switch with no SCPI programming interface
+    # (SiglentSPD3303._require_programmable_channel raises for it), so discovery
+    # must report 2, not the 3 physical output channels.
+    mock_rm = _rm_mock(("USB0::0xF4EC::0x1430::SPD3XJGQ806726::INSTR",))
+    with patch("instro.lib.discover.pyvisa.ResourceManager", return_value=mock_rm):
+        with patch("instro.lib.discover.VisaDriver") as mock_driver_cls:
+            mock_driver_cls.return_value.query.return_value = "SIGLENT TECHNOLOGIES,SPD3303X,12345,1.0"
+            result = scan_visa_resources()
+
+    assert len(result.instruments) == 1
+    info = result.instruments[0]
+    assert info.driver_class_name == "SiglentSPD3303"
+    assert info.num_channels == 2
+
+
 def test_scan_recognized_dmm() -> None:
     mock_rm = _rm_mock(("USB0::0x05E6::0x2400::INSTR",))
     with patch("instro.lib.discover.pyvisa.ResourceManager", return_value=mock_rm):


### PR DESCRIPTION
Closes #406.

`_IDN_MAP`'s entry for the Siglent SPD3303 reported `num_channels=3`, but channel 3 can never be a fully usable `InstroPSU` channel regardless of which SPD3303 sub-model (X, X-E, C, S, or D) is actually connected -- confirmed against the real Siglent manuals for each:

- No SCPI command exists to set or query CH3's voltage or current on any variant.
- No SCPI command exists to query CH3's output-enable state on any variant (`OUTPut?` isn't documented for it, and `SYSTem:STATus?`'s bit-field only defines CH1/CH2 bits).

(One correction to the driver's existing comment, surfaced while double-checking this: `OUTPut CH3,ON|OFF` -- the *write* direction of output enable -- actually *is* a documented command on SPD3303X/X-E/C, just not on the legacy S/D. That's a separate, real gap in the driver worth its own ticket, not something this PR touches -- the missing voltage/current control and missing output-status query hold across every variant either way, which is enough on its own to justify `num_channels=2` for discovery purposes.)

Changed to `2`, matching what's actually addressable over SCPI on every variant.

## Test plan
- [x] Added a regression test (`test_scan_recognized_siglent_spd3303_reports_two_programmable_channels`) asserting `scan_visa_resources()` reports 2 channels for a matched SPD3303 IDN response
- [x] `ruff format`/`ruff check`/`mypy` clean
- [x] Full test suite passes (1812 passed; pre-existing, unrelated `ModuleNotFoundError: can` in `tests/unstable/transports/test_can_driver.py` is an environment gap from a stale venv against a recent unrelated dependency addition, not something this PR touches)