### PR TITLE
feat(awg): add sweep to Keysight 33521B driver

### DIFF
--- a/docs/guides/instrumentation/awg.mdx
+++ b/docs/guides/instrumentation/awg.mdx
@@ -165,7 +165,8 @@ Every measurement/command call produces a channel keyed under `{name}.{descripto
 | `set_sweep_start_freq(channel=N)` | `ch{N}.sweep_start_freq.cmd` | command |
 | `set_sweep_end_freq(channel=N)` | `ch{N}.sweep_end_freq.cmd` | command |
 | `set_sweep_time(channel=N)` | `ch{N}.sweep_time.cmd` | command |
-| `set_sweep_hold_time(channel=N)` | `ch{N}.sweep_hold_time.cmd` | command |
+| `set_sweep_start_hold_time(channel=N)` | `ch{N}.sweep_start_hold_time.cmd` | command |
+| `set_sweep_stop_hold_time(channel=N)` | `ch{N}.sweep_stop_hold_time.cmd` | command |
 | `set_sweep_return_time(channel=N)` | `ch{N}.sweep_return_time.cmd` | command |
 | `fire_sweep_trigger(channel=N)` | `ch{N}.sweep_trigger_forced.cmd` | command |
 | `get_offset(channel=N)` | `ch{N}.offset` | telemetry |
@@ -180,7 +181,8 @@ Every measurement/command call produces a channel keyed under `{name}.{descripto
 | `get_sweep_start_freq(channel=N)` | `ch{N}.sweep_start_freq` | telemetry |
 | `get_sweep_end_freq(channel=N)` | `ch{N}.sweep_end_freq` | telemetry |
 | `get_sweep_time(channel=N)` | `ch{N}.sweep_time` | telemetry |
-| `get_sweep_hold_time(channel=N)` | `ch{N}.sweep_hold_time` | telemetry |
+| `get_sweep_start_hold_time(channel=N)` | `ch{N}.sweep_start_hold_time` | telemetry |
+| `get_sweep_stop_hold_time(channel=N)` | `ch{N}.sweep_stop_hold_time` | telemetry |
 | `get_sweep_return_time(channel=N)` | `ch{N}.sweep_return_time` | telemetry |
 
 <Note>
@@ -237,8 +239,10 @@ Every measurement/command call produces a channel keyed under `{name}.{descripto
 | `get_sweep_end_freq(channel)` | Read back the sweep end frequency in Hz on a channel |
 | `set_sweep_time(channel, sweep_time)` | Set the sweep time in seconds on a channel |
 | `get_sweep_time(channel)` | Read back the sweep time in seconds on a channel |
-| `set_sweep_hold_time(channel, hold_time)` | Set the sweep hold time in seconds on a channel |
-| `get_sweep_hold_time(channel)` | Read back the sweep hold time in seconds on a channel |
+| `set_sweep_start_hold_time(channel, hold_time)` | Set the sweep start hold time in seconds on a channel |
+| `get_sweep_start_hold_time(channel)` | Read back the sweep start hold time in seconds on a channel |
+| `set_sweep_stop_hold_time(channel, hold_time)` | Set the sweep stop hold time in seconds on a channel |
+| `get_sweep_stop_hold_time(channel)` | Read back the sweep stop hold time in seconds on a channel |
 | `set_sweep_return_time(channel, return_time)` | Set the sweep return time in seconds on a channel |
 | `get_sweep_return_time(channel)` | Read back the sweep return time in seconds on a channel |
 | `fire_sweep_trigger(channel)` | Fire a sweep trigger on channel now; the trigger source must already be `MANUAL` |
@@ -334,7 +338,8 @@ Optional overrides (raise `NotImplementedError` if not supported):
 - **`set_sweep_start_freq(channel, frequency_hz)`** / **`get_sweep_start_freq(channel)`**: Set or read the sweep start frequency.
 - **`set_sweep_end_freq(channel, frequency_hz)`** / **`get_sweep_end_freq(channel)`**: Set or read the sweep end frequency.
 - **`set_sweep_time(channel, sweep_time)`** / **`get_sweep_time(channel)`**: Set or read the sweep time.
-- **`set_sweep_hold_time(channel, hold_time)`** / **`get_sweep_hold_time(channel)`**: Set or read the sweep hold time.
+- **`set_sweep_start_hold_time(channel, hold_time)`** / **`get_sweep_start_hold_time(channel)`**: Set or read the sweep start hold time.
+- **`set_sweep_stop_hold_time(channel, hold_time)`** / **`get_sweep_stop_hold_time(channel)`**: Set or read the sweep stop hold time.
 - **`set_sweep_return_time(channel, return_time)`** / **`get_sweep_return_time(channel)`**: Set or read the sweep return time.
 - **`fire_sweep_trigger(channel)`**: Fire a sweep trigger on channel immediately. Requires the trigger source already set to `MANUAL`; call `set_sweep_trigger()` first otherwise.
 

--- a/packages/instro-unstable/instro/unstable/awg/drivers/keysight_33521b.py
+++ b/packages/instro-unstable/instro/unstable/awg/drivers/keysight_33521b.py
@@ -535,13 +535,14 @@ class Keysight33521B(AWGDriverBase):
             self._check_errors()
         return result
 
-    def set_sweep_hold_time(self, channel: int, hold_time: float) -> None:
+    def set_sweep_stop_hold_time(self, channel: int, hold_time: float) -> None:
+        """The 33521B has no SWEep:HTIMe:STARt; HTIMe only holds at the stop frequency."""
         _check_channel(channel)
         if hold_time < 0:
             raise ValueError(f"hold_time must be non-negative, got {hold_time}")
         self._write_checked(f"SWE:HTIM {hold_time}")
 
-    def get_sweep_hold_time(self, channel: int) -> float:
+    def get_sweep_stop_hold_time(self, channel: int) -> float:
         _check_channel(channel)
         with self._visa.lock():
             result = float(self._visa.query("SWE:HTIM?"))

--- a/packages/instro-unstable/instro/unstable/awg/drivers/keysight_33521b.py
+++ b/packages/instro-unstable/instro/unstable/awg/drivers/keysight_33521b.py
@@ -19,6 +19,8 @@ from instro.unstable.awg.types import (
     Sine,
     Square,
     StaticValue,
+    SweepTriggerSource,
+    SweepType,
     Triangle,
     Waveform,
 )
@@ -76,6 +78,21 @@ _BURST_TRIGGER_SOURCES: dict[BurstTriggerSource, str] = {
 }
 _BURST_TRIGGER_SOURCE_TYPES: dict[str, BurstTriggerSource] = {
     token: source for source, token in _BURST_TRIGGER_SOURCES.items()
+}
+
+_SWEEP_SPACING: dict[SweepType, str] = {
+    SweepType.LINEAR: "LIN",
+    SweepType.LOG: "LOG",
+}
+_SWEEP_SPACING_TYPES: dict[str, SweepType] = {spacing: sweep_type for sweep_type, spacing in _SWEEP_SPACING.items()}
+
+_SWEEP_TRIGGER_SOURCES: dict[SweepTriggerSource, str] = {
+    SweepTriggerSource.INTERNAL: "IMM",
+    SweepTriggerSource.EXTERNAL: "EXT",
+    SweepTriggerSource.MANUAL: "BUS",
+}
+_SWEEP_TRIGGER_SOURCE_TYPES: dict[str, SweepTriggerSource] = {
+    token: source for source, token in _SWEEP_TRIGGER_SOURCES.items()
 }
 
 
@@ -199,9 +216,7 @@ class Keysight33521B(AWGDriverBase):
 
     def set_offset(self, channel: int, offset: float) -> None:
         _check_channel(channel)
-        with self._visa.lock():
-            self._visa.write(f"VOLT:OFFS {offset}")
-            self._check_errors()
+        self._write_checked(f"VOLT:OFFS {offset}")
 
     def get_offset(self, channel: int) -> float:
         _check_channel(channel)
@@ -212,9 +227,7 @@ class Keysight33521B(AWGDriverBase):
 
     def output_enable(self, channel: int, enable: bool) -> None:
         _check_channel(channel)
-        with self._visa.lock():
-            self._visa.write("OUTP ON" if enable else "OUTP OFF")
-            self._check_errors()
+        self._write_checked("OUTP ON" if enable else "OUTP OFF")
 
     def get_output_state(self, channel: int) -> bool:
         _check_channel(channel)
@@ -225,12 +238,7 @@ class Keysight33521B(AWGDriverBase):
 
     def set_output_load(self, channel: int, load: float | None) -> None:
         _check_channel(channel)
-        with self._visa.lock():
-            if load is None:
-                self._visa.write("OUTP:LOAD INF")
-            else:
-                self._visa.write(f"OUTP:LOAD {load}")
-            self._check_errors()
+        self._write_checked("OUTP:LOAD INF" if load is None else f"OUTP:LOAD {load}")
 
     def get_output_load(self, channel: int) -> float | None:
         _check_channel(channel)
@@ -448,6 +456,131 @@ class Keysight33521B(AWGDriverBase):
             raw = self._visa.query("BURS:INT:PER?")
             self._check_errors()
         return float(raw)
+
+    def set_sweep(self, channel: int, sweep_type: SweepType) -> None:
+        _check_channel(channel)
+        if not isinstance(sweep_type, SweepType):
+            raise TypeError(f"sweep_type must be a SweepType, got {type(sweep_type).__name__}")
+        if sweep_type not in _SWEEP_SPACING:
+            raise ValueError(f"the Keysight 33521B does not support {sweep_type.name} sweep spacing")
+        with self._visa.lock():
+            carrier_name = self._visa.query("FUNC?").strip()
+            if carrier_name == "DC":
+                raise ValueError(f"the Keysight 33521B cannot sweep a StaticValue (DC) waveform on channel {channel}")
+            self._visa.write(f"SWE:SPAC {_SWEEP_SPACING[sweep_type]}")
+            self._check_errors()
+
+    def get_sweep_type(self, channel: int) -> SweepType:
+        _check_channel(channel)
+        with self._visa.lock():
+            token = self._visa.query("SWE:SPAC?").strip()
+            self._check_errors()
+        if token not in _SWEEP_SPACING_TYPES:
+            raise ValueError(f"Keysight 33521B reported unsupported sweep type '{token}'")
+        return _SWEEP_SPACING_TYPES[token]
+
+    def sweep_enable(self, channel: int, enable: bool) -> None:
+        _check_channel(channel)
+        self._write_checked(f"SWE:STAT {'ON' if enable else 'OFF'}")
+
+    def get_sweep_state(self, channel: int) -> bool:
+        _check_channel(channel)
+        with self._visa.lock():
+            result = self._visa.query("SWE:STAT?").strip() == "1"
+            self._check_errors()
+        return result
+
+    def set_sweep_trigger(self, channel: int, source: SweepTriggerSource) -> None:
+        _check_channel(channel)
+        if not isinstance(source, SweepTriggerSource):
+            raise TypeError(f"source must be a SweepTriggerSource, got {type(source).__name__}")
+        self._write_checked(f"TRIG:SOUR {_SWEEP_TRIGGER_SOURCES[source]}")
+
+    def get_sweep_trigger(self, channel: int) -> SweepTriggerSource:
+        _check_channel(channel)
+        with self._visa.lock():
+            token = self._visa.query("TRIG:SOUR?").strip()
+            self._check_errors()
+        if token not in _SWEEP_TRIGGER_SOURCE_TYPES:
+            raise ValueError(f"Keysight 33521B reported unsupported trigger source '{token}'")
+        return _SWEEP_TRIGGER_SOURCE_TYPES[token]
+
+    def set_sweep_start_freq(self, channel: int, frequency_hz: float) -> None:
+        _check_channel(channel)
+        self._write_checked(f"FREQ:STAR {frequency_hz}")
+
+    def get_sweep_start_freq(self, channel: int) -> float:
+        _check_channel(channel)
+        with self._visa.lock():
+            result = float(self._visa.query("FREQ:STAR?"))
+            self._check_errors()
+        return result
+
+    def set_sweep_end_freq(self, channel: int, frequency_hz: float) -> None:
+        _check_channel(channel)
+        self._write_checked(f"FREQ:STOP {frequency_hz}")
+
+    def get_sweep_end_freq(self, channel: int) -> float:
+        _check_channel(channel)
+        with self._visa.lock():
+            result = float(self._visa.query("FREQ:STOP?"))
+            self._check_errors()
+        return result
+
+    def set_sweep_time(self, channel: int, sweep_time: float) -> None:
+        _check_channel(channel)
+        if sweep_time <= 0:
+            raise ValueError(f"sweep_time must be positive, got {sweep_time}")
+        self._write_checked(f"SWE:TIME {sweep_time}")
+
+    def get_sweep_time(self, channel: int) -> float:
+        _check_channel(channel)
+        with self._visa.lock():
+            result = float(self._visa.query("SWE:TIME?"))
+            self._check_errors()
+        return result
+
+    def set_sweep_hold_time(self, channel: int, hold_time: float) -> None:
+        _check_channel(channel)
+        if hold_time < 0:
+            raise ValueError(f"hold_time must be non-negative, got {hold_time}")
+        self._write_checked(f"SWE:HTIM {hold_time}")
+
+    def get_sweep_hold_time(self, channel: int) -> float:
+        _check_channel(channel)
+        with self._visa.lock():
+            result = float(self._visa.query("SWE:HTIM?"))
+            self._check_errors()
+        return result
+
+    def set_sweep_return_time(self, channel: int, return_time: float) -> None:
+        _check_channel(channel)
+        if return_time < 0:
+            raise ValueError(f"return_time must be non-negative, got {return_time}")
+        self._write_checked(f"SWE:RTIM {return_time}")
+
+    def get_sweep_return_time(self, channel: int) -> float:
+        _check_channel(channel)
+        with self._visa.lock():
+            result = float(self._visa.query("SWE:RTIM?"))
+            self._check_errors()
+        return result
+
+    def fire_sweep_trigger(self, channel: int) -> None:
+        _check_channel(channel)
+        with self._visa.lock():
+            if not self.get_sweep_state(channel):
+                raise ValueError(
+                    f"Cannot fire a sweep trigger on channel {channel} unless sweep mode is already"
+                    " enabled, call sweep_enable(channel, True) first"
+                )
+            source = self.get_sweep_trigger(channel)
+            if source is not SweepTriggerSource.MANUAL:
+                raise ValueError(
+                    f"Cannot fire a sweep trigger on channel {channel} unless the trigger source is"
+                    f" already MANUAL, call set_sweep_trigger(channel, SweepTriggerSource.MANUAL) first. Current source: {source.name}"
+                )
+            self._write_checked("*TRG")
 
     def _write_frequency_and_phase(self, frequency_hz: float, phase_deg: float) -> None:
         self._visa.write(f"FREQ {frequency_hz}")

--- a/packages/instro-unstable/instro/unstable/awg/drivers/keysight_33521b.py
+++ b/packages/instro-unstable/instro/unstable/awg/drivers/keysight_33521b.py
@@ -463,12 +463,7 @@ class Keysight33521B(AWGDriverBase):
             raise TypeError(f"sweep_type must be a SweepType, got {type(sweep_type).__name__}")
         if sweep_type not in _SWEEP_SPACING:
             raise ValueError(f"the Keysight 33521B does not support {sweep_type.name} sweep spacing")
-        with self._visa.lock():
-            carrier_name = self._visa.query("FUNC?").strip()
-            if carrier_name == "DC":
-                raise ValueError(f"the Keysight 33521B cannot sweep a StaticValue (DC) waveform on channel {channel}")
-            self._visa.write(f"SWE:SPAC {_SWEEP_SPACING[sweep_type]}")
-            self._check_errors()
+        self._write_checked(f"SWE:SPAC {_SWEEP_SPACING[sweep_type]}")
 
     def get_sweep_type(self, channel: int) -> SweepType:
         _check_channel(channel)

--- a/tests/unstable/awg/keysight/test_keysight_33521b_hardware.py
+++ b/tests/unstable/awg/keysight/test_keysight_33521b_hardware.py
@@ -723,13 +723,7 @@ def test_25_set_sweep_linear_on_every_valid_carrier(driver: Keysight33521B, carr
     assert driver.get_sweep_state(CHANNEL) is False
 
 
-def test_26_set_sweep_rejects_staticvalue_carrier_and_step_spacing(driver: Keysight33521B) -> None:
-    driver.set_waveform(CHANNEL, StaticValue(value=TEST_OFFSET_V))
-
-    with pytest.raises(ValueError, match="cannot sweep a StaticValue"):
-        driver.set_sweep(CHANNEL, SweepType.LINEAR)
-    driver._check_errors()
-
+def test_26_set_sweep_rejects_step_spacing(driver: Keysight33521B) -> None:
     driver.set_waveform(CHANNEL, Sine(frequency_hz=TEST_FREQUENCY_HZ))
     with pytest.raises(ValueError, match="does not support STEP sweep spacing"):
         driver.set_sweep(CHANNEL, SweepType.STEP)
@@ -746,21 +740,15 @@ def test_27_get_sweep_type_matches_configured_type(driver: Keysight33521B, sweep
 
 
 def test_28_sweep_enable_actually_drives_frequency_mode(driver: Keysight33521B) -> None:
-    """Bench check for a manual ambiguity, not resolved from the PDF alone.
-
-    The SWEep-subsystem tutorial's last enable step is `SWEep:STATe ON`, but the FREQuency-subsystem's
-    own worked example enables sweep output via `FREQuency:MODE SWEep` alone and never touches
-    `SWEep:STATe`. This driver implements `sweep_enable`/`get_sweep_state` against `SWEep:STATe` on the
-    assumption the two registers are aliased/interlocked (mirroring how `BURSt:STATe` and every
-    modulation `:STAT` node behave elsewhere on this instrument). If `FREQuency:MODE?` does not read
-    back `SWE` here, that assumption is wrong and `sweep_enable`/`get_sweep_state` need to drive
-    `FREQuency:MODE` directly instead.
-    """
+    """Bench check for a manual ambiguity: does SWEep:STATe ON actually alias to FREQuency:MODE SWEep?"""
     driver.set_waveform(CHANNEL, Sine(frequency_hz=TEST_FREQUENCY_HZ))
     driver.set_sweep(CHANNEL, SweepType.LINEAR)
     driver.sweep_enable(CHANNEL, True)
     driver._check_errors()
 
+    # The SWEep tutorial ends in SWEep:STATe ON; the FREQuency tutorial enables sweep via
+    # FREQuency:MODE SWEep alone and never touches SWEep:STATe. This assumes the two are
+    # aliased, mirroring how BURSt:STATe behaves elsewhere on this instrument.
     freq_mode = driver._visa.query("FREQ:MODE?").strip()
     assert freq_mode == "SWE", (
         f"SWEep:STATe ON did not switch FREQuency:MODE to SWEep (got {freq_mode!r} instead);"
@@ -877,13 +865,13 @@ def test_37_set_sweep_hold_and_return_time_reject_negative_value(driver: Keysigh
     driver._check_errors()
 
 
-def test_38_set_sweep_accepts_untracked_arbitrary_carrier(driver: Keysight33521B) -> None:
-    """Regression: pop the cache to simulate a driver instance that never downloaded this Arbitrary."""
-    driver.set_waveform(CHANNEL, Arbitrary(samples=_ARB_SAMPLES, sample_rate_hz=100_000.0))
-    driver._check_errors()
-    driver._arb_waveforms.pop(CHANNEL)
-
+def test_38_set_sweep_accepts_staticvalue_but_enable_is_rejected_by_hardware(driver: Keysight33521B) -> None:
+    """Hardware-confirmed: SWE:SPAC accepts a DC carrier, but SWE:STAT ON on it raises -221 "Settings conflict"."""
+    driver.set_waveform(CHANNEL, StaticValue(value=TEST_OFFSET_V))
     driver.set_sweep(CHANNEL, SweepType.LINEAR)
     driver._check_errors()
 
     assert driver.get_sweep_type(CHANNEL) is SweepType.LINEAR
+
+    with pytest.raises(RuntimeError, match=r'-221,"Settings conflict; not able to sweep this function"'):
+        driver.sweep_enable(CHANNEL, True)

--- a/tests/unstable/awg/keysight/test_keysight_33521b_hardware.py
+++ b/tests/unstable/awg/keysight/test_keysight_33521b_hardware.py
@@ -845,19 +845,19 @@ def test_35_set_sweep_time_rejects_non_positive_value(driver: Keysight33521B) ->
     driver._check_errors()
 
 
-def test_36_sweep_hold_and_return_time_roundtrip(driver: Keysight33521B) -> None:
+def test_36_sweep_stop_hold_and_return_time_roundtrip(driver: Keysight33521B) -> None:
     driver.set_waveform(CHANNEL, Sine(frequency_hz=TEST_FREQUENCY_HZ))
-    driver.set_sweep_hold_time(CHANNEL, 3.4)
+    driver.set_sweep_stop_hold_time(CHANNEL, 3.4)
     driver.set_sweep_return_time(CHANNEL, 5.6)
     driver._check_errors()
 
-    assert driver.get_sweep_hold_time(CHANNEL) == pytest.approx(3.4, rel=0.01)
+    assert driver.get_sweep_stop_hold_time(CHANNEL) == pytest.approx(3.4, rel=0.01)
     assert driver.get_sweep_return_time(CHANNEL) == pytest.approx(5.6, rel=0.01)
 
 
-def test_37_set_sweep_hold_and_return_time_reject_negative_value(driver: Keysight33521B) -> None:
+def test_37_set_sweep_stop_hold_and_return_time_reject_negative_value(driver: Keysight33521B) -> None:
     with pytest.raises(ValueError, match="hold_time must be non-negative"):
-        driver.set_sweep_hold_time(CHANNEL, -0.1)
+        driver.set_sweep_stop_hold_time(CHANNEL, -0.1)
     driver._check_errors()
 
     with pytest.raises(ValueError, match="return_time must be non-negative"):

--- a/tests/unstable/awg/keysight/test_keysight_33521b_hardware.py
+++ b/tests/unstable/awg/keysight/test_keysight_33521b_hardware.py
@@ -21,6 +21,8 @@ from instro.unstable.awg.types import (
     Sine,
     Square,
     StaticValue,
+    SweepTriggerSource,
+    SweepType,
     Triangle,
     Waveform,
 )
@@ -686,3 +688,202 @@ def test_46_set_burst_period_rejects_non_positive_value(driver: Keysight33521B) 
         driver.set_burst_period(CHANNEL, 0.0)
 
     driver._check_errors()
+
+
+# ---------------------------------------------------------------------------
+# Sweep
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "carrier",
+    [
+        Sine(frequency_hz=TEST_FREQUENCY_HZ),
+        Square(frequency_hz=TEST_FREQUENCY_HZ),
+        Sawtooth(frequency_hz=TEST_FREQUENCY_HZ),
+        Triangle(frequency_hz=TEST_FREQUENCY_HZ),
+        Pulse(frequency_hz=TEST_FREQUENCY_HZ, width_s=0.0002),
+        Arbitrary(samples=_ARB_SAMPLES, sample_rate_hz=100_000.0),
+    ],
+    ids=["sine", "square", "sawtooth", "triangle", "pulse", "arbitrary"],
+)
+def test_25_set_sweep_linear_on_every_valid_carrier(driver: Keysight33521B, carrier: Waveform) -> None:
+    driver.set_waveform(CHANNEL, carrier)
+    driver.set_sweep(CHANNEL, SweepType.LINEAR)
+    driver._check_errors()
+
+    assert driver.get_sweep_type(CHANNEL) is SweepType.LINEAR
+
+    driver.sweep_enable(CHANNEL, True)
+    driver._check_errors()
+    assert driver.get_sweep_state(CHANNEL) is True
+
+    driver.sweep_enable(CHANNEL, False)
+    driver._check_errors()
+    assert driver.get_sweep_state(CHANNEL) is False
+
+
+def test_26_set_sweep_rejects_staticvalue_carrier_and_step_spacing(driver: Keysight33521B) -> None:
+    driver.set_waveform(CHANNEL, StaticValue(value=TEST_OFFSET_V))
+
+    with pytest.raises(ValueError, match="cannot sweep a StaticValue"):
+        driver.set_sweep(CHANNEL, SweepType.LINEAR)
+    driver._check_errors()
+
+    driver.set_waveform(CHANNEL, Sine(frequency_hz=TEST_FREQUENCY_HZ))
+    with pytest.raises(ValueError, match="does not support STEP sweep spacing"):
+        driver.set_sweep(CHANNEL, SweepType.STEP)
+    driver._check_errors()
+
+
+@pytest.mark.parametrize("sweep_type", [SweepType.LINEAR, SweepType.LOG], ids=["linear", "log"])
+def test_27_get_sweep_type_matches_configured_type(driver: Keysight33521B, sweep_type: SweepType) -> None:
+    driver.set_waveform(CHANNEL, Sine(frequency_hz=TEST_FREQUENCY_HZ))
+    driver.set_sweep(CHANNEL, sweep_type)
+    driver._check_errors()
+
+    assert driver.get_sweep_type(CHANNEL) is sweep_type
+
+
+def test_28_sweep_enable_actually_drives_frequency_mode(driver: Keysight33521B) -> None:
+    """Bench check for a manual ambiguity, not resolved from the PDF alone.
+
+    The SWEep-subsystem tutorial's last enable step is `SWEep:STATe ON`, but the FREQuency-subsystem's
+    own worked example enables sweep output via `FREQuency:MODE SWEep` alone and never touches
+    `SWEep:STATe`. This driver implements `sweep_enable`/`get_sweep_state` against `SWEep:STATe` on the
+    assumption the two registers are aliased/interlocked (mirroring how `BURSt:STATe` and every
+    modulation `:STAT` node behave elsewhere on this instrument). If `FREQuency:MODE?` does not read
+    back `SWE` here, that assumption is wrong and `sweep_enable`/`get_sweep_state` need to drive
+    `FREQuency:MODE` directly instead.
+    """
+    driver.set_waveform(CHANNEL, Sine(frequency_hz=TEST_FREQUENCY_HZ))
+    driver.set_sweep(CHANNEL, SweepType.LINEAR)
+    driver.sweep_enable(CHANNEL, True)
+    driver._check_errors()
+
+    freq_mode = driver._visa.query("FREQ:MODE?").strip()
+    assert freq_mode == "SWE", (
+        f"SWEep:STATe ON did not switch FREQuency:MODE to SWEep (got {freq_mode!r} instead);"
+        " sweep_enable/get_sweep_state must be reimplemented against FREQuency:MODE"
+    )
+
+    driver.sweep_enable(CHANNEL, False)
+    driver._check_errors()
+
+
+@pytest.mark.parametrize(
+    "source",
+    [SweepTriggerSource.INTERNAL, SweepTriggerSource.EXTERNAL, SweepTriggerSource.MANUAL],
+    ids=["internal", "external", "manual"],
+)
+def test_29_sweep_trigger_roundtrip_matches_configured_source(
+    driver: Keysight33521B, source: SweepTriggerSource
+) -> None:
+    """Confirms the driver's IMM/EXT/BUS <-> INTERNAL/EXTERNAL/MANUAL mapping against real TRIGger:SOURce state."""
+    driver.set_waveform(CHANNEL, Sine(frequency_hz=TEST_FREQUENCY_HZ))
+    driver.set_sweep(CHANNEL, SweepType.LINEAR)
+    driver._check_errors()
+
+    driver.set_sweep_trigger(CHANNEL, source)
+    driver._check_errors()
+
+    assert driver.get_sweep_trigger(CHANNEL) is source
+
+
+def test_30_set_sweep_trigger_rejects_invalid_channel(driver: Keysight33521B) -> None:
+    with pytest.raises(ValueError, match="only supports 1 channel"):
+        driver.set_sweep_trigger(INVALID_CHANNEL, SweepTriggerSource.MANUAL)
+
+    driver._check_errors()
+
+
+def test_31_fire_sweep_trigger_fires_when_source_already_manual(driver: Keysight33521B) -> None:
+    """*TRG only fires once TRIGger:SOURce is BUS (mapped from SweepTriggerSource.MANUAL)."""
+    driver.set_waveform(CHANNEL, Sine(frequency_hz=TEST_FREQUENCY_HZ))
+    driver.set_sweep(CHANNEL, SweepType.LINEAR)
+    driver.set_sweep_trigger(CHANNEL, SweepTriggerSource.MANUAL)
+    driver._check_errors()
+
+    driver.output_enable(CHANNEL, True)
+    driver.sweep_enable(CHANNEL, True)
+    driver.fire_sweep_trigger(CHANNEL)
+    driver._check_errors()
+
+    driver.output_enable(CHANNEL, False)
+    driver.sweep_enable(CHANNEL, False)
+
+
+def test_32_fire_sweep_trigger_rejects_non_manual_source_and_when_not_enabled(driver: Keysight33521B) -> None:
+    driver.set_waveform(CHANNEL, Sine(frequency_hz=TEST_FREQUENCY_HZ))
+    driver.set_sweep(CHANNEL, SweepType.LINEAR)
+    driver.set_sweep_trigger(CHANNEL, SweepTriggerSource.EXTERNAL)
+    driver.sweep_enable(CHANNEL, True)
+    driver._check_errors()
+
+    with pytest.raises(ValueError, match="already MANUAL"):
+        driver.fire_sweep_trigger(CHANNEL)
+
+    driver.sweep_enable(CHANNEL, False)
+    driver._check_errors()
+
+    with pytest.raises(ValueError, match="sweep mode is already"):
+        driver.fire_sweep_trigger(CHANNEL)
+
+    driver._check_errors()
+
+
+def test_33_sweep_start_end_freq_roundtrip(driver: Keysight33521B) -> None:
+    driver.set_waveform(CHANNEL, Sine(frequency_hz=TEST_FREQUENCY_HZ))
+    driver.set_sweep_start_freq(CHANNEL, 100.0)
+    driver.set_sweep_end_freq(CHANNEL, 1000.0)
+    driver._check_errors()
+
+    assert driver.get_sweep_start_freq(CHANNEL) == pytest.approx(100.0, rel=FREQUENCY_TOLERANCE_REL)
+    assert driver.get_sweep_end_freq(CHANNEL) == pytest.approx(1000.0, rel=FREQUENCY_TOLERANCE_REL)
+
+
+def test_34_sweep_time_roundtrip(driver: Keysight33521B) -> None:
+    driver.set_waveform(CHANNEL, Sine(frequency_hz=TEST_FREQUENCY_HZ))
+    driver.set_sweep_time(CHANNEL, 0.5)
+    driver._check_errors()
+
+    assert driver.get_sweep_time(CHANNEL) == pytest.approx(0.5, rel=0.01)
+
+
+def test_35_set_sweep_time_rejects_non_positive_value(driver: Keysight33521B) -> None:
+    with pytest.raises(ValueError, match="sweep_time must be positive"):
+        driver.set_sweep_time(CHANNEL, 0.0)
+
+    driver._check_errors()
+
+
+def test_36_sweep_hold_and_return_time_roundtrip(driver: Keysight33521B) -> None:
+    driver.set_waveform(CHANNEL, Sine(frequency_hz=TEST_FREQUENCY_HZ))
+    driver.set_sweep_hold_time(CHANNEL, 3.4)
+    driver.set_sweep_return_time(CHANNEL, 5.6)
+    driver._check_errors()
+
+    assert driver.get_sweep_hold_time(CHANNEL) == pytest.approx(3.4, rel=0.01)
+    assert driver.get_sweep_return_time(CHANNEL) == pytest.approx(5.6, rel=0.01)
+
+
+def test_37_set_sweep_hold_and_return_time_reject_negative_value(driver: Keysight33521B) -> None:
+    with pytest.raises(ValueError, match="hold_time must be non-negative"):
+        driver.set_sweep_hold_time(CHANNEL, -0.1)
+    driver._check_errors()
+
+    with pytest.raises(ValueError, match="return_time must be non-negative"):
+        driver.set_sweep_return_time(CHANNEL, -0.1)
+    driver._check_errors()
+
+
+def test_38_set_sweep_accepts_untracked_arbitrary_carrier(driver: Keysight33521B) -> None:
+    """Regression: pop the cache to simulate a driver instance that never downloaded this Arbitrary."""
+    driver.set_waveform(CHANNEL, Arbitrary(samples=_ARB_SAMPLES, sample_rate_hz=100_000.0))
+    driver._check_errors()
+    driver._arb_waveforms.pop(CHANNEL)
+
+    driver.set_sweep(CHANNEL, SweepType.LINEAR)
+    driver._check_errors()
+
+    assert driver.get_sweep_type(CHANNEL) is SweepType.LINEAR

--- a/tests/unstable/awg/keysight/test_keysight_33521b_software.py
+++ b/tests/unstable/awg/keysight/test_keysight_33521b_software.py
@@ -1281,23 +1281,23 @@ def test_61_set_sweep_time_rejects_non_positive_value_and_invalid_channel(
     keysight_visa.write.assert_not_called()
 
 
-def test_62_sweep_hold_and_return_time_roundtrip(keysight: Keysight33521B, keysight_visa: MagicMock) -> None:
-    keysight.set_sweep_hold_time(1, 3.4)
+def test_62_sweep_stop_hold_and_return_time_roundtrip(keysight: Keysight33521B, keysight_visa: MagicMock) -> None:
+    keysight.set_sweep_stop_hold_time(1, 3.4)
     keysight.set_sweep_return_time(1, 5.6)
     assert keysight_visa.write.call_args_list == [call("SWE:HTIM 3.4"), call("SWE:RTIM 5.6")]
 
     _query_sequence(keysight_visa, ["3.400000E+00", "5.600000E+00"])
-    assert keysight.get_sweep_hold_time(1) == pytest.approx(3.4)
+    assert keysight.get_sweep_stop_hold_time(1) == pytest.approx(3.4)
     assert keysight.get_sweep_return_time(1) == pytest.approx(5.6)
 
 
-def test_63_set_sweep_hold_and_return_time_reject_negative_value_and_invalid_channel(
+def test_63_set_sweep_stop_hold_and_return_time_reject_negative_value_and_invalid_channel(
     keysight: Keysight33521B, keysight_visa: MagicMock
 ) -> None:
     with pytest.raises(ValueError, match="hold_time must be non-negative"):
-        keysight.set_sweep_hold_time(1, -0.1)
+        keysight.set_sweep_stop_hold_time(1, -0.1)
     with pytest.raises(ValueError, match="only supports 1 channel"):
-        keysight.set_sweep_hold_time(2, 0.1)
+        keysight.set_sweep_stop_hold_time(2, 0.1)
 
     with pytest.raises(ValueError, match="return_time must be non-negative"):
         keysight.set_sweep_return_time(1, -0.1)

--- a/tests/unstable/awg/keysight/test_keysight_33521b_software.py
+++ b/tests/unstable/awg/keysight/test_keysight_33521b_software.py
@@ -1093,8 +1093,6 @@ def test_67_set_burst_accepts_untracked_arbitrary_carrier(keysight: Keysight3352
 def test_47_set_sweep_writes_spacing_for_each_supported_type(
     keysight: Keysight33521B, keysight_visa: MagicMock, sweep_type: SweepType, expected_spacing: str
 ) -> None:
-    _query_sequence(keysight_visa, ["SIN"])
-
     keysight.set_sweep(1, sweep_type)
 
     assert keysight_visa.write.call_args_list == [call(f"SWE:SPAC {expected_spacing}")]
@@ -1110,24 +1108,20 @@ def test_48_set_sweep_rejects_step_spacing(keysight: Keysight33521B, keysight_vi
 
 
 @pytest.mark.parametrize(
-    ("channel", "sweep_type", "carrier_responses", "match"),
+    ("channel", "sweep_type", "match"),
     [
-        (2, SweepType.LINEAR, [], "only supports 1 channel"),
-        (1, "LINEAR", [], "sweep_type must be a SweepType"),
-        (1, SweepType.LINEAR, ["DC"], "cannot sweep a StaticValue"),
+        (2, SweepType.LINEAR, "only supports 1 channel"),
+        (1, "LINEAR", "sweep_type must be a SweepType"),
     ],
-    ids=["invalid_channel", "invalid_sweep_type", "staticvalue_carrier"],
+    ids=["invalid_channel", "invalid_sweep_type"],
 )
 def test_49_set_sweep_rejects_invalid_input(
     keysight: Keysight33521B,
     keysight_visa: MagicMock,
     channel: int,
     sweep_type: SweepType,
-    carrier_responses: list[str],
     match: str,
 ) -> None:
-    _query_sequence(keysight_visa, carrier_responses)
-
     with pytest.raises((ValueError, TypeError), match=match):
         keysight.set_sweep(channel, sweep_type)
 
@@ -1311,12 +1305,3 @@ def test_63_set_sweep_hold_and_return_time_reject_negative_value_and_invalid_cha
         keysight.set_sweep_return_time(2, 0.1)
 
     keysight_visa.write.assert_not_called()
-
-
-def test_64_set_sweep_accepts_untracked_arbitrary_carrier(keysight: Keysight33521B, keysight_visa: MagicMock) -> None:
-    """Regression: an Arbitrary carrier this driver instance never downloaded is still a valid sweep carrier."""
-    _query_sequence(keysight_visa, ["ARB"])
-
-    keysight.set_sweep(1, SweepType.LINEAR)
-
-    assert keysight_visa.write.call_args_list == [call("SWE:SPAC LIN")]

--- a/tests/unstable/awg/keysight/test_keysight_33521b_software.py
+++ b/tests/unstable/awg/keysight/test_keysight_33521b_software.py
@@ -21,6 +21,8 @@ from instro.unstable.awg.types import (
     Sine,
     Square,
     StaticValue,
+    SweepTriggerSource,
+    SweepType,
     Triangle,
     Waveform,
 )
@@ -1076,3 +1078,245 @@ def test_67_set_burst_accepts_untracked_arbitrary_carrier(keysight: Keysight3352
     keysight.set_burst(1, BurstType.NCYCLE)
 
     assert keysight_visa.write.call_args_list == [call("BURS:MODE TRIG")]
+
+
+# ---------------------------------------------------------------------------
+# Sweep
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("sweep_type", "expected_spacing"),
+    [(SweepType.LINEAR, "LIN"), (SweepType.LOG, "LOG")],
+    ids=["linear", "log"],
+)
+def test_47_set_sweep_writes_spacing_for_each_supported_type(
+    keysight: Keysight33521B, keysight_visa: MagicMock, sweep_type: SweepType, expected_spacing: str
+) -> None:
+    _query_sequence(keysight_visa, ["SIN"])
+
+    keysight.set_sweep(1, sweep_type)
+
+    assert keysight_visa.write.call_args_list == [call(f"SWE:SPAC {expected_spacing}")]
+
+
+def test_48_set_sweep_rejects_step_spacing(keysight: Keysight33521B, keysight_visa: MagicMock) -> None:
+    """The 33521B's SWEep:SPACing only accepts LINear/LOGarithmic, unlike Rigol's LIN/LOG/STEP."""
+    with pytest.raises(ValueError, match="does not support STEP sweep spacing"):
+        keysight.set_sweep(1, SweepType.STEP)
+
+    keysight_visa.write.assert_not_called()
+    keysight_visa.query.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("channel", "sweep_type", "carrier_responses", "match"),
+    [
+        (2, SweepType.LINEAR, [], "only supports 1 channel"),
+        (1, "LINEAR", [], "sweep_type must be a SweepType"),
+        (1, SweepType.LINEAR, ["DC"], "cannot sweep a StaticValue"),
+    ],
+    ids=["invalid_channel", "invalid_sweep_type", "staticvalue_carrier"],
+)
+def test_49_set_sweep_rejects_invalid_input(
+    keysight: Keysight33521B,
+    keysight_visa: MagicMock,
+    channel: int,
+    sweep_type: SweepType,
+    carrier_responses: list[str],
+    match: str,
+) -> None:
+    _query_sequence(keysight_visa, carrier_responses)
+
+    with pytest.raises((ValueError, TypeError), match=match):
+        keysight.set_sweep(channel, sweep_type)
+
+    keysight_visa.write.assert_not_called()
+
+
+def test_50_get_sweep_type_parses_every_spacing_and_rejects_unknown(
+    keysight: Keysight33521B, keysight_visa: MagicMock
+) -> None:
+    _query_sequence(keysight_visa, ["LIN"])
+    assert keysight.get_sweep_type(1) is SweepType.LINEAR
+
+    _query_sequence(keysight_visa, ["LOG"])
+    assert keysight.get_sweep_type(1) is SweepType.LOG
+
+    _query_sequence(keysight_visa, ["STE"])
+    with pytest.raises(ValueError, match="unsupported sweep type 'STE'"):
+        keysight.get_sweep_type(1)
+
+
+def test_51_sweep_enable_writes_swe_stat_and_get_sweep_state_parses_it(
+    keysight: Keysight33521B, keysight_visa: MagicMock
+) -> None:
+    keysight.sweep_enable(1, True)
+    keysight.sweep_enable(1, False)
+    assert keysight_visa.write.call_args_list == [call("SWE:STAT ON"), call("SWE:STAT OFF")]
+
+    _query_sequence(keysight_visa, ["1"])
+    assert keysight.get_sweep_state(1) is True
+
+    _query_sequence(keysight_visa, ["0"])
+    assert keysight.get_sweep_state(1) is False
+
+
+@pytest.mark.parametrize(
+    ("source", "expected_token"),
+    [
+        (SweepTriggerSource.INTERNAL, "IMM"),
+        (SweepTriggerSource.EXTERNAL, "EXT"),
+        (SweepTriggerSource.MANUAL, "BUS"),
+    ],
+    ids=["internal", "external", "manual"],
+)
+def test_52_set_sweep_trigger_writes_mapped_source_token(
+    keysight: Keysight33521B, keysight_visa: MagicMock, source: SweepTriggerSource, expected_token: str
+) -> None:
+    """The 33521B has no SWEep:TRIG:SOUR; it's the shared TRIGger:SOURce node with IMM/EXT/BUS tokens."""
+    keysight.set_sweep_trigger(1, source)
+
+    keysight_visa.write.assert_called_once_with(f"TRIG:SOUR {expected_token}")
+
+
+def test_53_set_sweep_trigger_rejects_invalid_source_and_channel(
+    keysight: Keysight33521B, keysight_visa: MagicMock
+) -> None:
+    with pytest.raises(TypeError, match="source must be a SweepTriggerSource"):
+        keysight.set_sweep_trigger(1, "INT")  # type: ignore[arg-type]
+
+    with pytest.raises(ValueError, match="only supports 1 channel"):
+        keysight.set_sweep_trigger(2, SweepTriggerSource.INTERNAL)
+
+    keysight_visa.write.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    ("token", "expected_source"),
+    [("IMM", SweepTriggerSource.INTERNAL), ("EXT", SweepTriggerSource.EXTERNAL), ("BUS", SweepTriggerSource.MANUAL)],
+    ids=["internal", "external", "manual"],
+)
+def test_54_get_sweep_trigger_parses_every_mapped_source(
+    keysight: Keysight33521B, keysight_visa: MagicMock, token: str, expected_source: SweepTriggerSource
+) -> None:
+    _query_sequence(keysight_visa, [token])
+
+    assert keysight.get_sweep_trigger(1) is expected_source
+    assert _real_query_calls(keysight_visa) == [call("TRIG:SOUR?")]
+
+
+def test_55_get_sweep_trigger_rejects_unknown_source_and_invalid_channel(
+    keysight: Keysight33521B, keysight_visa: MagicMock
+) -> None:
+    """Regression guard: TIMer is a real TRIGger:SOURce value with no SweepTriggerSource counterpart."""
+    with pytest.raises(ValueError, match="only supports 1 channel"):
+        keysight.get_sweep_trigger(2)
+    keysight_visa.query.assert_not_called()
+
+    _query_sequence(keysight_visa, ["TIM"])
+    with pytest.raises(ValueError, match="unsupported trigger source 'TIM'"):
+        keysight.get_sweep_trigger(1)
+
+
+def test_56_fire_sweep_trigger_fires_when_source_already_manual(
+    keysight: Keysight33521B, keysight_visa: MagicMock
+) -> None:
+    """*TRG, not TRIGger:IMMediate, is the documented software-trigger command for this instrument."""
+    _query_sequence(keysight_visa, ["1", "BUS"])
+
+    keysight.fire_sweep_trigger(1)
+
+    assert _real_query_calls(keysight_visa) == [call("SWE:STAT?"), call("TRIG:SOUR?")]
+    assert keysight_visa.write.call_args_list == [call("*TRG")]
+
+
+def test_57_fire_sweep_trigger_rejects_non_manual_source_and_invalid_channel(
+    keysight: Keysight33521B, keysight_visa: MagicMock
+) -> None:
+    _query_sequence(keysight_visa, ["1", "EXT"])
+
+    with pytest.raises(ValueError, match="already MANUAL"):
+        keysight.fire_sweep_trigger(1)
+
+    with pytest.raises(ValueError, match="only supports 1 channel"):
+        keysight.fire_sweep_trigger(2)
+
+    keysight_visa.write.assert_not_called()
+
+
+def test_58_fire_sweep_trigger_rejects_when_sweep_not_enabled(
+    keysight: Keysight33521B, keysight_visa: MagicMock
+) -> None:
+    _query_sequence(keysight_visa, ["0"])
+
+    with pytest.raises(ValueError, match="sweep mode is already"):
+        keysight.fire_sweep_trigger(1)
+
+    assert _real_query_calls(keysight_visa) == [call("SWE:STAT?")]
+    keysight_visa.write.assert_not_called()
+
+
+def test_59_sweep_start_end_freq_roundtrip(keysight: Keysight33521B, keysight_visa: MagicMock) -> None:
+    keysight.set_sweep_start_freq(1, 100.0)
+    keysight.set_sweep_end_freq(1, 1000.0)
+    assert keysight_visa.write.call_args_list == [call("FREQ:STAR 100.0"), call("FREQ:STOP 1000.0")]
+
+    _query_sequence(keysight_visa, ["1.000000E+02", "1.000000E+03"])
+    assert keysight.get_sweep_start_freq(1) == pytest.approx(100.0)
+    assert keysight.get_sweep_end_freq(1) == pytest.approx(1000.0)
+
+
+def test_60_sweep_time_roundtrip(keysight: Keysight33521B, keysight_visa: MagicMock) -> None:
+    keysight.set_sweep_time(1, 0.5)
+    keysight_visa.write.assert_called_once_with("SWE:TIME 0.5")
+
+    _query_sequence(keysight_visa, ["5.000000E-01"])
+    assert keysight.get_sweep_time(1) == pytest.approx(0.5)
+
+
+def test_61_set_sweep_time_rejects_non_positive_value_and_invalid_channel(
+    keysight: Keysight33521B, keysight_visa: MagicMock
+) -> None:
+    with pytest.raises(ValueError, match="sweep_time must be positive"):
+        keysight.set_sweep_time(1, 0.0)
+
+    with pytest.raises(ValueError, match="only supports 1 channel"):
+        keysight.set_sweep_time(2, 0.1)
+
+    keysight_visa.write.assert_not_called()
+
+
+def test_62_sweep_hold_and_return_time_roundtrip(keysight: Keysight33521B, keysight_visa: MagicMock) -> None:
+    keysight.set_sweep_hold_time(1, 3.4)
+    keysight.set_sweep_return_time(1, 5.6)
+    assert keysight_visa.write.call_args_list == [call("SWE:HTIM 3.4"), call("SWE:RTIM 5.6")]
+
+    _query_sequence(keysight_visa, ["3.400000E+00", "5.600000E+00"])
+    assert keysight.get_sweep_hold_time(1) == pytest.approx(3.4)
+    assert keysight.get_sweep_return_time(1) == pytest.approx(5.6)
+
+
+def test_63_set_sweep_hold_and_return_time_reject_negative_value_and_invalid_channel(
+    keysight: Keysight33521B, keysight_visa: MagicMock
+) -> None:
+    with pytest.raises(ValueError, match="hold_time must be non-negative"):
+        keysight.set_sweep_hold_time(1, -0.1)
+    with pytest.raises(ValueError, match="only supports 1 channel"):
+        keysight.set_sweep_hold_time(2, 0.1)
+
+    with pytest.raises(ValueError, match="return_time must be non-negative"):
+        keysight.set_sweep_return_time(1, -0.1)
+    with pytest.raises(ValueError, match="only supports 1 channel"):
+        keysight.set_sweep_return_time(2, 0.1)
+
+    keysight_visa.write.assert_not_called()
+
+
+def test_64_set_sweep_accepts_untracked_arbitrary_carrier(keysight: Keysight33521B, keysight_visa: MagicMock) -> None:
+    """Regression: an Arbitrary carrier this driver instance never downloaded is still a valid sweep carrier."""
+    _query_sequence(keysight_visa, ["ARB"])
+
+    keysight.set_sweep(1, SweepType.LINEAR)
+
+    assert keysight_visa.write.call_args_list == [call("SWE:SPAC LIN")]


### PR DESCRIPTION
## Summary

This PR implements the sweep base functions from 


## Type of change

- [ ] Bug fix (`fix`)
- [x] New feature (`feat`)
- [ ] Breaking change (`feat!` / `fix!`)
- [ ] Refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] Chore / tooling (`chore`)

## Verification

<img width="927" height="788" alt="Screenshot 2026-08-19 at 5 12 06 PM" src="https://github.com/user-attachments/assets/b00e313c-5930-4d38-b6a8-c99af93debd3" />

<img width="1627" height="844" alt="Screenshot 2026-08-19 at 5 13 30 PM" src="https://github.com/user-attachments/assets/0b51bdf2-73be-40b5-93d8-5e0ae96f1a2b" />


## Tests

- [x] Unit tests added or updated
- [ ] Existing tests cover this change
- [ ] No tests — explain why:

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(driver): add support for Keysight E36300`)
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] Documentation updated if user-facing behavior changed
- [x] Code follows the style/conventions of the surrounding code

## Notes for reviewers