### PR TITLE
fix(ljm): stop() stops the stream

### DIFF
--- a/packages/instro-daq-labjack/instro/daq/drivers/labjack/t_series.py
+++ b/packages/instro-daq-labjack/instro/daq/drivers/labjack/t_series.py
@@ -8,9 +8,10 @@ from dataclasses import dataclass
 from queue import Empty, Queue
 from typing import Mapping
 
+from instro.daq.drivers.labjack.t_series_models import LJ_T4, LJ_T7, LJ_T8, LJ_Model
+
 from instro.daq import DAQDriverBase, HWTimingException
 from instro.daq.drivers import HWTimestamper
-from instro.daq.drivers.labjack.t_series_models import LJ_T4, LJ_T7, LJ_T8, LJ_Model
 from instro.daq.scaling.thermocouple import kelvin_to_unit, unit_to_kelvin
 from instro.daq.types import (
     AnalogChannel,
@@ -132,7 +133,6 @@ class LabJackTSeriesDriver(DAQDriverBase):
 
     def close(self):
         """Disconnect from LabJack device."""
-        self.stop()
         if self._handle is not None:
             ljm.close(self._handle)
             self._handle = None
@@ -376,9 +376,13 @@ class LabJackTSeriesDriver(DAQDriverBase):
         self._actual_sample_rate = actual_scan_rate
         self._actual_sample_period = round(1e9 / actual_scan_rate)
 
-        ljm.setStreamCallback(self._handle, self._stream_callback)
-
         self._streaming_active = True
+        try:
+            ljm.setStreamCallback(self._handle, self._stream_callback)
+        except ljm.LJMError:
+            self._streaming_active = False
+            self._stop_stream()
+            raise
 
     def _stream_callback(self, arg):
         # The lock keeps this read strictly before stop()'s eStreamStop, so it cannot fail.

--- a/packages/instro-daq-labjack/instro/daq/drivers/labjack/t_series.py
+++ b/packages/instro-daq-labjack/instro/daq/drivers/labjack/t_series.py
@@ -1,6 +1,7 @@
 import atexit
 import logging
 import math
+import threading
 import time
 import weakref
 from dataclasses import dataclass
@@ -83,6 +84,7 @@ class LabJackTSeriesDriver(DAQDriverBase):
         self._global_scan_rate: float | None = None
         self._global_scans_per_read: int | None = None
         self._streaming_active: bool = False
+        self._stream_lock = threading.Lock()  # orders the LJM callback's read against stop()
         self._actual_sample_period: int | None = None
         self._actual_sample_rate: float | None = None
         self._timestamper: HWTimestamper | None = None  # None until first hw-timed read
@@ -102,20 +104,35 @@ class LabJackTSeriesDriver(DAQDriverBase):
         self._stop_stream()
 
     def _stop_stream(self):
+        """Stop the stream, tolerating a handle with no stream running."""
         try:
             ljm.eStreamStop(self._handle)
-        except ljm.LJMError as e:
-            pass
+        except ljm.LJMError as error:
+            logger.debug("eStreamStop on handle %s reported: %s", self._handle, error)
 
     def stop(self, **kwargs):
         """Stop the DAQ device."""
-        if self._streaming_active:
-            # TODO add debug logger
-            # ljm.eStreamStop(self._handle)
+        with self._stream_lock:
+            if not self._streaming_active:
+                return
             self._streaming_active = False
+        # Released before unregistering: LJM waits on an in-flight callback, which wants this lock.
+        ljm.setStreamCallback(self._handle, None)
+        self._stop_stream()
+        self._timestamper = None
+        self._drain_stream_queue()
+
+    def _drain_stream_queue(self):
+        """Discard scans the callback queued before the stream stopped."""
+        while True:
+            try:
+                self._data_queue.get_nowait()
+            except Empty:
+                break
 
     def close(self):
         """Disconnect from LabJack device."""
+        self.stop()
         if self._handle is not None:
             ljm.close(self._handle)
             self._handle = None
@@ -364,7 +381,11 @@ class LabJackTSeriesDriver(DAQDriverBase):
         self._streaming_active = True
 
     def _stream_callback(self, arg):
-        response = ljm.eStreamRead(self._handle)
+        # The lock keeps this read strictly before stop()'s eStreamStop, so it cannot fail.
+        with self._stream_lock:
+            if not self._streaming_active:
+                return
+            response = ljm.eStreamRead(self._handle)
         ai_timestamp = time.time_ns()  # TODO read from labjack. It has some capabilities here.
 
         self._data_queue.put_nowait((response, ai_timestamp))
@@ -391,6 +412,8 @@ class LabJackTSeriesDriver(DAQDriverBase):
     def fetch_analog(
         self,
     ) -> LabJackData:
+        if not self._streaming_active:
+            raise RuntimeError("No active scan. Call start() before fetch_analog().")
         # Is receiving data from the ljm registered callback.
         try:
             callback_data = self._data_queue.get(timeout=5)
@@ -398,7 +421,7 @@ class LabJackTSeriesDriver(DAQDriverBase):
             samples, self._points_in_fifo, self.points_in_buffer = labjack_data[0], labjack_data[1], labjack_data[2]
             return LabJackData(data=samples, timestamp=timestamp, dt=self._actual_sample_period)
         except Empty:
-            raise TimeoutError(f"LabJack timeout. No data received.")
+            raise TimeoutError("LabJack timeout. No data received.")
 
     def get_actual_sample_rate(self) -> float | None:
         return self._actual_sample_rate

--- a/packages/instro-daq-labjack/instro/daq/drivers/labjack/t_series.py
+++ b/packages/instro-daq-labjack/instro/daq/drivers/labjack/t_series.py
@@ -376,11 +376,14 @@ class LabJackTSeriesDriver(DAQDriverBase):
         self._actual_sample_rate = actual_scan_rate
         self._actual_sample_period = round(1e9 / actual_scan_rate)
 
-        self._streaming_active = True
+        with self._stream_lock:
+            self._streaming_active = True
+
         try:
             ljm.setStreamCallback(self._handle, self._stream_callback)
         except ljm.LJMError:
-            self._streaming_active = False
+            with self._stream_lock:
+                self._streaming_active = False
             self._stop_stream()
             raise
 

--- a/packages/instro-daq-labjack/instro/daq/drivers/labjack/t_series.py
+++ b/packages/instro-daq-labjack/instro/daq/drivers/labjack/t_series.py
@@ -8,10 +8,9 @@ from dataclasses import dataclass
 from queue import Empty, Queue
 from typing import Mapping
 
-from instro.daq.drivers.labjack.t_series_models import LJ_T4, LJ_T7, LJ_T8, LJ_Model
-
 from instro.daq import DAQDriverBase, HWTimingException
 from instro.daq.drivers import HWTimestamper
+from instro.daq.drivers.labjack.t_series_models import LJ_T4, LJ_T7, LJ_T8, LJ_Model
 from instro.daq.scaling.thermocouple import kelvin_to_unit, unit_to_kelvin
 from instro.daq.types import (
     AnalogChannel,

--- a/tests/daq/labjack/test_labjack_t4_hardware.py
+++ b/tests/daq/labjack/test_labjack_t4_hardware.py
@@ -796,6 +796,62 @@ class TestLabJackT4Hardware(unittest.TestCase):
         """Relay control is not supported by the LabJack driver."""
         self.skipTest("DAQDriverBase relays unsupported by LabJack")
 
+    # =====================================================================
+    # 17. stop() halts the stream engine, and a restart works in one session
+    # =====================================================================
+    def test_17_stream_stop_and_restart(self):
+        """stop() stops the device stream and retires the LJM callback, so a second start() succeeds."""
+
+        def step():
+            daq = self._create_daq()
+            try:
+                self._configure_ai(daq)
+                daq.configure_ai_hw_sample_rate(
+                    sample_rate=SAMPLE_RATE_HZ,
+                    samples_per_channel=SAMPLES_PER_CHANNEL,
+                )
+                driver = daq.driver
+
+                daq.start()
+                time.sleep(0.5)
+                first = daq.get_channel(f"{NAME}.{AI_ALIAS}", 50, True)
+                self.assertGreaterEqual(len(first.values), 1, "stream delivered no samples before stop()")
+                daq.stop()
+
+                # The device stream engine is off, so open() has no leftover stream to clear.
+                enabled = ljm.eReadName(driver._handle, "STREAM_ENABLE")
+                self.assertEqual(enabled, 0, f"stop() left the stream running (STREAM_ENABLE={enabled})")
+
+                # The callback is retired, so nothing refills the queue stop() drained.
+                self.assertTrue(driver._data_queue.empty(), "stop() left scans queued")
+                time.sleep(0.3)
+                self.assertTrue(driver._data_queue.empty(), "the callback queued scans after stop()")
+
+                # Fetching after stop() reports no active scan instead of stalling for the 5 s timeout.
+                with self.assertRaises(RuntimeError):
+                    daq.read_analog()
+                print("         stop(): STREAM_ENABLE=0, queue empty, read_analog() raises RuntimeError")
+
+                # A second start() in one session used to fail on an already-active stream.
+                daq.start()
+                try:
+                    time.sleep(0.5)
+                    second = daq.get_channel(f"{NAME}.{AI_ALIAS}", 50, True)
+                    self.assertGreaterEqual(len(second.values), 1, "restarted stream delivered no samples")
+                    self.assertTrue(all(math.isfinite(v) for v in second.values), "non-finite samples after restart")
+                    print(f"         restart delivered {len(second.values)} samples on {AI_ALIAS}")
+                finally:
+                    daq.stop()
+            finally:
+                daq.close()
+
+        self._run_step(
+            "Stream stop and restart",
+            "Start HW-timed acquisition and stop it. Verify STREAM_ENABLE reads 0, the LJM callback queues "
+            "nothing more, and a second start() in the same session streams real samples.",
+            step,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/daq/labjack/test_labjack_t7_hardware.py
+++ b/tests/daq/labjack/test_labjack_t7_hardware.py
@@ -1092,6 +1092,62 @@ class TestLabJackT7Hardware(unittest.TestCase):
         """Relay control is not supported by the LabJack driver."""
         self.skipTest("DAQDriverBase relays unsupported by LabJack")
 
+    # =====================================================================
+    # 22. stop() halts the stream engine, and a restart works in one session
+    # =====================================================================
+    def test_22_stream_stop_and_restart(self):
+        """stop() stops the device stream and retires the LJM callback, so a second start() succeeds."""
+
+        def step():
+            daq = self._create_daq()
+            try:
+                self._configure_ai(daq)
+                daq.configure_ai_hw_sample_rate(
+                    sample_rate=SAMPLE_RATE_HZ,
+                    samples_per_channel=SAMPLES_PER_CHANNEL,
+                )
+                driver = daq.driver
+
+                daq.start()
+                time.sleep(0.5)
+                first = daq.get_channel(f"{NAME}.{AI0_ALIAS}", 50, True)
+                self.assertGreaterEqual(len(first.values), 1, "stream delivered no samples before stop()")
+                daq.stop()
+
+                # The device stream engine is off, so open() has no leftover stream to clear.
+                enabled = ljm.eReadName(driver._handle, "STREAM_ENABLE")
+                self.assertEqual(enabled, 0, f"stop() left the stream running (STREAM_ENABLE={enabled})")
+
+                # The callback is retired, so nothing refills the queue stop() drained.
+                self.assertTrue(driver._data_queue.empty(), "stop() left scans queued")
+                time.sleep(0.3)
+                self.assertTrue(driver._data_queue.empty(), "the callback queued scans after stop()")
+
+                # Fetching after stop() reports no active scan instead of stalling for the 5 s timeout.
+                with self.assertRaises(RuntimeError):
+                    daq.read_analog()
+                print("         stop(): STREAM_ENABLE=0, queue empty, read_analog() raises RuntimeError")
+
+                # A second start() in one session used to fail on an already-active stream.
+                daq.start()
+                try:
+                    time.sleep(0.5)
+                    second = daq.get_channel(f"{NAME}.{AI0_ALIAS}", 50, True)
+                    self.assertGreaterEqual(len(second.values), 1, "restarted stream delivered no samples")
+                    self.assertTrue(all(math.isfinite(v) for v in second.values), "non-finite samples after restart")
+                    print(f"         restart delivered {len(second.values)} samples on {AI0_ALIAS}")
+                finally:
+                    daq.stop()
+            finally:
+                daq.close()
+
+        self._run_step(
+            "Stream stop and restart",
+            "Start HW-timed acquisition and stop it. Verify STREAM_ENABLE reads 0, the LJM callback queues "
+            "nothing more, and a second start() in the same session streams real samples.",
+            step,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/daq/labjack/test_labjack_t8_hardware.py
+++ b/tests/daq/labjack/test_labjack_t8_hardware.py
@@ -1252,6 +1252,60 @@ class TestLabJackT8Hardware(unittest.TestCase):
             step,
         )
 
+    # ==================================================================
+    # 25. stop() halts the stream engine, and a restart works in one session
+    # ==================================================================
+    def test_25_stream_stop_and_restart(self):
+        """stop() stops the device stream and retires the LJM callback, so a second start() succeeds."""
+
+        def step(start_ns: int):
+            print(f"         [start {self._ts(start_ns)}]")
+            daq = self._create_daq()
+            try:
+                self._configure_ai(daq, AI_CHANNEL_0, AI_ALIAS_0)
+                daq.configure_ai_hw_sample_rate(sample_rate=SAMPLE_RATE_HZ, samples_per_channel=SAMPLES_PER_CHANNEL)
+                driver = daq.driver
+
+                daq.start()
+                time.sleep(0.5)
+                first = daq.get_channel(f"{NAME}.{AI_ALIAS_0}", 50, True)
+                self.assertGreaterEqual(len(first.values), 1, "stream delivered no samples before stop()")
+                daq.stop()
+
+                # The device stream engine is off, so open() has no leftover stream to clear.
+                enabled = ljm.eReadName(driver._handle, "STREAM_ENABLE")
+                self.assertEqual(enabled, 0, f"stop() left the stream running (STREAM_ENABLE={enabled})")
+
+                # The callback is retired, so nothing refills the queue stop() drained.
+                self.assertTrue(driver._data_queue.empty(), "stop() left scans queued")
+                time.sleep(0.3)
+                self.assertTrue(driver._data_queue.empty(), "the callback queued scans after stop()")
+
+                # Fetching after stop() reports no active scan instead of stalling for the 5 s timeout.
+                with self.assertRaises(RuntimeError):
+                    daq.read_analog()
+                print("         stop(): STREAM_ENABLE=0, queue empty, read_analog() raises RuntimeError")
+
+                # A second start() in one session used to fail on an already-active stream.
+                daq.start()
+                try:
+                    time.sleep(0.5)
+                    second = daq.get_channel(f"{NAME}.{AI_ALIAS_0}", 50, True)
+                    self.assertGreaterEqual(len(second.values), 1, "restarted stream delivered no samples")
+                    self.assertTrue(all(math.isfinite(v) for v in second.values), "non-finite samples after restart")
+                    print(f"         restart delivered {len(second.values)} samples on {AI_ALIAS_0}")
+                finally:
+                    daq.stop()
+            finally:
+                daq.close()
+
+        self._run_step(
+            "Stream stop and restart",
+            "Start HW-timed acquisition and stop it. Verify STREAM_ENABLE reads 0, the LJM callback queues "
+            "nothing more, and a second start() in the same session streams real samples.",
+            step,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Oh no! Our current `stop()` implementation for the LabJack driver had `ljm.eStreamStop(self._handle)` commented out which means that calling `stop()` on a LabJack backed `InstroDAQ` doesn't actually stop the stream. This is not right. I don't think we were seeing problems due to this because `start()` also tried to stop an existing stream.

This PR adds better tracking of the `_stream_active` flag and actually stops the device's stream when `stop()` is called.

## Type of change

- [x] Bug fix (`fix`)
- [ ] New feature (`feat`)
- [ ] Breaking change (`feat!` / `fix!`)
- [ ] Refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] Chore / tooling (`chore`)

## Verification

Added a test that starts a device, stops it, verifies it's actually stopped, then starts it again. This was physically validated on T4, T7, and T8 hardware:
<img width="1134" height="74" alt="Screen Shot 2026-08-20 at 10 50 08 506 AM" src="https://github.com/user-attachments/assets/5596beac-5d71-4674-a491-1b013a8119ef" />
<img width="1107" height="79" alt="Screen Shot 2026-08-20 at 10 51 23 960 AM" src="https://github.com/user-attachments/assets/ed7b3e70-1c44-460f-95ad-2f97a4489be2" />
<img width="1102" height="75" alt="Screen Shot 2026-08-20 at 10 52 08 692 AM" src="https://github.com/user-attachments/assets/54a41dff-8ab1-4184-b024-a890f98325f8" />

## Tests

- [x] Unit tests added or updated
- [ ] Existing tests cover this change
- [ ] No tests — explain why:

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(driver): add support for Keysight E36300`)
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] Documentation updated if user-facing behavior changed
- [x] Code follows the style/conventions of the surrounding code