### PR TITLE
refactor(modbus): drop ModbusUnit, one unit_id name, keep legacy configs

### DIFF
--- a/docs/guides/instrumentation/examples/modbus/labjack_t4_loopback_test.mdx
+++ b/docs/guides/instrumentation/examples/modbus/labjack_t4_loopback_test.mdx
@@ -45,8 +45,8 @@ CONFIG = {
         "host": HOST,
         "port": PORT,
         "timeout": 3.0,
+        "unit_id": 1,
     },
-    "unit_id": 1,
     "registers": [
         # Device identity
         {"name": "product_id", "starting_address": 60000, "register_type": "holding", "data_type": "float32"},

--- a/docs/guides/instrumentation/examples/modbus/labjack_t4_loopback_test.mdx
+++ b/docs/guides/instrumentation/examples/modbus/labjack_t4_loopback_test.mdx
@@ -46,7 +46,7 @@ CONFIG = {
         "port": PORT,
         "timeout": 3.0,
     },
-    "modbus_unit_id": 1,
+    "unit_id": 1,
     "registers": [
         # Device identity
         {"name": "product_id", "starting_address": 60000, "register_type": "holding", "data_type": "float32"},

--- a/docs/guides/instrumentation/examples/modbus/modbus_example.mdx
+++ b/docs/guides/instrumentation/examples/modbus/modbus_example.mdx
@@ -32,7 +32,7 @@ CONFIG_PATH = Path(__file__).parent / "simulated_modbus_device.json"
 
 
 def main():
-    device = ModbusDevice(str(CONFIG_PATH), connection=CONNECTION, modbus_unit_id=1, autostart=True)
+    device = ModbusDevice(str(CONFIG_PATH), connection=CONNECTION, unit_id=1, autostart=True)
     device.add_publisher(
         NominalCorePublisher("ri.catalog.cerulean-staging.dataset.056356ba-5c64-479c-9fc8-da0eba27ae0b")
     )

--- a/docs/guides/instrumentation/examples/modbus/programmatic_config_example.mdx
+++ b/docs/guides/instrumentation/examples/modbus/programmatic_config_example.mdx
@@ -85,7 +85,7 @@ config = ModbusConfig(
 
 
 def main():
-    device = ModbusDevice(config, connection=transport.at(1), autostart=True)
+    device = ModbusDevice(config, connection=transport, modbus_unit_id=1, autostart=True)
 
     try:
         print(f"Connected to {config.device.name}")

--- a/docs/guides/instrumentation/examples/modbus/programmatic_config_example.mdx
+++ b/docs/guides/instrumentation/examples/modbus/programmatic_config_example.mdx
@@ -85,7 +85,7 @@ config = ModbusConfig(
 
 
 def main():
-    device = ModbusDevice(config, connection=transport, modbus_unit_id=1, autostart=True)
+    device = ModbusDevice(config, connection=transport, unit_id=1, autostart=True)
 
     try:
         print(f"Connected to {config.device.name}")

--- a/docs/guides/instrumentation/examples/modbus/shared_bus_example.mdx
+++ b/docs/guides/instrumentation/examples/modbus/shared_bus_example.mdx
@@ -6,7 +6,7 @@ title: "two ModbusDevices sharing one Modbus TCP connection"
 """Example: two ModbusDevices sharing one Modbus TCP connection.
 
 Demonstrates the shared-bus pattern: one ModbusTCPTransport passed to each
-device, with each device's own `modbus_unit_id`. The transport opens once, for
+device, with each device's own `unit_id`. The transport opens once, for
 whichever device opens first, and stays open until the last device closes it --
 the way one RS-485 multi-drop line (or a TCP-to-serial gateway fronting one)
 serves several unit addresses over a single connection.
@@ -28,8 +28,8 @@ CONFIG_PATH = Path(__file__).parent / "simulated_modbus_device.json"
 def main() -> None:
     transport = ModbusTCPTransport(host="127.0.0.1", port=5020)
 
-    unit_1 = ModbusDevice(config=CONFIG_PATH, connection=transport, modbus_unit_id=1, name="unit_1")
-    unit_2 = ModbusDevice(config=CONFIG_PATH, connection=transport, modbus_unit_id=2, name="unit_2")
+    unit_1 = ModbusDevice(config=CONFIG_PATH, connection=transport, unit_id=1, name="unit_1")
+    unit_2 = ModbusDevice(config=CONFIG_PATH, connection=transport, unit_id=2, name="unit_2")
 
     unit_1.open()
     unit_2.open()  # shares the connection unit_1 already opened; no second socket

--- a/docs/guides/instrumentation/examples/modbus/shared_bus_example.mdx
+++ b/docs/guides/instrumentation/examples/modbus/shared_bus_example.mdx
@@ -5,11 +5,11 @@ title: "two ModbusDevices sharing one Modbus TCP connection"
 ```python shared_bus_example.py
 """Example: two ModbusDevices sharing one Modbus TCP connection.
 
-Demonstrates the shared-bus pattern: one ModbusTCPTransport, and one ModbusUnit
-per device address bound via `.at()`. The transport opens once, for whichever
-device opens first, and stays open until the last device closes it -- the way
-one RS-485 multi-drop line (or a TCP-to-serial gateway fronting one) serves
-several unit addresses over a single connection.
+Demonstrates the shared-bus pattern: one ModbusTCPTransport passed to each
+device, with each device's own `modbus_unit_id`. The transport opens once, for
+whichever device opens first, and stays open until the last device closes it --
+the way one RS-485 multi-drop line (or a TCP-to-serial gateway fronting one)
+serves several unit addresses over a single connection.
 
 Start the sim server first:
     python -m instro.modbus.sim_server
@@ -28,8 +28,8 @@ CONFIG_PATH = Path(__file__).parent / "simulated_modbus_device.json"
 def main() -> None:
     transport = ModbusTCPTransport(host="127.0.0.1", port=5020)
 
-    unit_1 = ModbusDevice(config=CONFIG_PATH, connection=transport.at(1), name="unit_1")
-    unit_2 = ModbusDevice(config=CONFIG_PATH, connection=transport.at(2), name="unit_2")
+    unit_1 = ModbusDevice(config=CONFIG_PATH, connection=transport, modbus_unit_id=1, name="unit_1")
+    unit_2 = ModbusDevice(config=CONFIG_PATH, connection=transport, modbus_unit_id=2, name="unit_2")
 
     unit_1.open()
     unit_2.open()  # shares the connection unit_1 already opened; no second socket

--- a/docs/guides/instrumentation/protocols/modbus.mdx
+++ b/docs/guides/instrumentation/protocols/modbus.mdx
@@ -58,9 +58,9 @@ modbus_device.close()
     "transport": "tcp",
     "host": "<device ip address>",
     "port": 502,
-    "timeout": 3.0
+    "timeout": 3.0,
+    "unit_id": 1
   },
-  "unit_id": 1,
   "timing": {
     "poll_interval": 1.0
   },
@@ -422,9 +422,9 @@ ModbusDevice is configured through a JSON file. Every config file must include:
     "transport": "tcp",
     "host": "<device ip address>",
     "port": 502,
-    "timeout": 3.0
+    "timeout": 3.0,
+    "unit_id": 1
   },
-  "unit_id": 1,
   "timing": {
     "poll_interval": 1.0,
     "write_delay_ms": 100
@@ -514,7 +514,7 @@ Metadata about the physical device. The `name` field is used as a prefix for cha
 
 ### Connection Section
 
-The unit/slave address belongs to the device, not the connection: set it with the top-level `unit_id` field (see [Parameters](#parameters)), or pass `unit_id` to the `ModbusDevice` constructor. The connection block also accepts a `unit_id` field for compatibility with existing configs; it means the same thing, and an address given in more than one place must agree. When the device shares a transport with others, the address is required; see [Sharing One Bus Across Multiple Units](#sharing-one-bus-across-multiple-units).
+Set the unit/slave address with the connection block's `unit_id` field, or pass `unit_id` to the `ModbusDevice` constructor; an address given in both places must agree. When the device shares a transport with others, the constructor argument is required; see [Sharing One Bus Across Multiple Units](#sharing-one-bus-across-multiple-units).
 
 #### TCP Connection
 
@@ -524,7 +524,7 @@ The unit/slave address belongs to the device, not the connection: set it with th
 | `host` | Yes | | IP address or hostname |
 | `port` | No | `502` | TCP port (1 to 65535) |
 | `timeout` | No | `3.0` | Response timeout in seconds |
-| `unit_id` | No | | Unit/slave address (0 to 255). Equivalent to the top-level `unit_id` |
+| `unit_id` | No | `1` | Unit/slave address (0 to 255) |
 
 #### RTU (Serial) Connection
 
@@ -538,7 +538,7 @@ The unit/slave address belongs to the device, not the connection: set it with th
 | `bytesize` | No | `8` | Data bits: `5`, `6`, `7`, or `8` |
 | `timeout` | No | `3.0` | Response timeout in seconds |
 | `framer` | No | `"rtu"` | Serial transmission mode: `"rtu"` or `"ascii"` |
-| `unit_id` | No | | Unit/slave address (0 to 247; 248-255 are reserved on a serial line). Equivalent to the top-level `unit_id` |
+| `unit_id` | No | `1` | Unit/slave address (0 to 247; 248-255 are reserved on a serial line) |
 
 **Common serial port paths:**
 
@@ -723,7 +723,7 @@ device = ModbusDevice(config, connection=transport, unit_id=1, autostart=True)
 |-----------|----------|---------|-------------|
 | `config` | Yes | | Path to a JSON file, a `dict`, or a `ModbusConfig` instance |
 | `connection` | No | | A `ModbusTransport` (pass the same instance to several devices to share one line) or a `dict`. Takes precedence over the connection in the config. Required if the config does not include a connection section. |
-| `unit_id` | No | | Unit/slave address (0 to 255; 0 to 247 on an RTU/ASCII transport, since 248-255 are reserved on a real serial line). May also come from the config (top-level `unit_id` or `connection.unit_id`); values given in more than one place must agree. Required alongside a shared `ModbusTransport`. Defaults to 1 only when the device builds its own private transport. |
+| `unit_id` | No | | Unit/slave address (0 to 255; 0 to 247 on an RTU/ASCII transport, since 248-255 are reserved on a real serial line). May also come from the connection block's `unit_id` field; values given in both places must agree. Required alongside a shared `ModbusTransport`. Defaults to 1 only when the device builds its own private transport. |
 | `name` | No | `device.name` | Override the instrument name used for channel naming |
 | `publishers` | No | `None` | List of publishers to attach at construction time |
 | `autostart` | No | `False` | If `True` and the config contains a `timing` section, opens the connection and starts background polling on instantiation |
@@ -864,9 +864,9 @@ The only difference for RTU is in the config file. The Python code is identical:
     "parity": "N",
     "stopbits": 1,
     "bytesize": 8,
-    "timeout": 2.0
+    "timeout": 2.0,
+    "unit_id": 1
   },
-  "unit_id": 1,
   "registers": [
     {
       "name": "temperature",

--- a/docs/guides/instrumentation/protocols/modbus.mdx
+++ b/docs/guides/instrumentation/protocols/modbus.mdx
@@ -514,7 +514,7 @@ Metadata about the physical device. The `name` field is used as a prefix for cha
 
 ### Connection Section
 
-The unit/slave address is not part of the connection block: set it with the top-level `modbus_unit_id` field (see [Parameters](#parameters)), or pass `modbus_unit_id` to the `ModbusDevice` constructor. Keeping the address off the connection block is what lets several devices share one transport; see [Sharing one connection across unit addresses](#sharing-one-connection-across-unit-addresses).
+The unit/slave address belongs to the device, not the connection: set it with the top-level `modbus_unit_id` field (see [Parameters](#parameters)), or pass `modbus_unit_id` to the `ModbusDevice` constructor. The connection block also accepts a `unit_id` field for compatibility with existing configs; it means the same thing, and an address given in more than one place must agree. When the device shares a transport with others, the address is required; see [Sharing One Bus Across Multiple Units](#sharing-one-bus-across-multiple-units).
 
 #### TCP Connection
 
@@ -524,6 +524,7 @@ The unit/slave address is not part of the connection block: set it with the top-
 | `host` | Yes | | IP address or hostname |
 | `port` | No | `502` | TCP port (1 to 65535) |
 | `timeout` | No | `3.0` | Response timeout in seconds |
+| `unit_id` | No | | Unit/slave address (0 to 255). Equivalent to the top-level `modbus_unit_id` |
 
 #### RTU (Serial) Connection
 
@@ -537,6 +538,7 @@ The unit/slave address is not part of the connection block: set it with the top-
 | `bytesize` | No | `8` | Data bits: `5`, `6`, `7`, or `8` |
 | `timeout` | No | `3.0` | Response timeout in seconds |
 | `framer` | No | `"rtu"` | Serial transmission mode: `"rtu"` or `"ascii"` |
+| `unit_id` | No | | Unit/slave address (0 to 247; 248-255 are reserved on a serial line). Equivalent to the top-level `modbus_unit_id` |
 
 **Common serial port paths:**
 
@@ -628,7 +630,7 @@ device = ModbusDevice(
 
 ## Sharing One Bus Across Multiple Units
 
-An RS-485 multi-drop line, or a TCP-to-serial gateway fronting one, often serves several physical devices at different unit addresses over what is one physical connection. Build a single transport, bind one unit address per device with `.at()`, and pass the resulting `ModbusUnit` as each device's `connection`:
+An RS-485 multi-drop line, or a TCP-to-serial gateway fronting one, often serves several physical devices at different unit addresses over what is one physical connection. Build a single transport and pass it as each device's `connection`, with each device's own `modbus_unit_id`:
 
 ```python
 from instro.lib.transports import ModbusTCPTransport
@@ -636,8 +638,8 @@ from instro.modbus import ModbusDevice
 
 transport = ModbusTCPTransport(host="192.168.1.100", port=502)
 
-flow_meter = ModbusDevice(config="flow_meter.json", connection=transport.at(1))
-level_sensor = ModbusDevice(config="level_sensor.json", connection=transport.at(2))
+flow_meter = ModbusDevice(config="flow_meter.json", connection=transport, modbus_unit_id=1)
+level_sensor = ModbusDevice(config="level_sensor.json", connection=transport, modbus_unit_id=2)
 
 flow_meter.open()
 level_sensor.open()   # shares the connection flow_meter already opened
@@ -646,7 +648,7 @@ flow_meter.close()    # connection stays open: level_sensor still holds it
 level_sensor.close()  # last owner leaves: connection tears down
 ```
 
-The connection opens for the first device and stays open until the last one closes, the same shared-ownership rule every `instro` transport follows. See [Sharing one connection across unit addresses](/instrumentation/transports/modbus#sharing-one-connection-across-unit-addresses) for the transport-level detail, including `.at()`'s docstring for the unit-address validation and holder accounting.
+The connection opens for the first device and stays open until the last one closes, the same shared-ownership rule every `instro` transport follows. A shared transport requires an explicit `modbus_unit_id` per device: two devices silently defaulting to the same address on one line is the failure this guards against. See [Sharing one connection across unit addresses](/instrumentation/transports/modbus#sharing-one-connection-across-unit-addresses) for the transport-level detail.
 
 ## Creating a ModbusDevice Instance
 
@@ -708,7 +710,7 @@ config = ModbusConfig(
 )
 
 transport = ModbusTCPTransport(host="192.168.1.100", port=502)
-device = ModbusDevice(config, connection=transport.at(1), autostart=True)
+device = ModbusDevice(config, connection=transport, modbus_unit_id=1, autostart=True)
 ```
 
 </Tab>
@@ -720,8 +722,8 @@ device = ModbusDevice(config, connection=transport.at(1), autostart=True)
 | Parameter | Required | Default | Description |
 |-----------|----------|---------|-------------|
 | `config` | Yes | | Path to a JSON file, a `dict`, or a `ModbusConfig` instance |
-| `connection` | No | | A `ModbusUnit` (from `transport.at(unit_id)`), a bare `ModbusTransport`, or a `dict`. Takes precedence over the connection in the config. Required if the config does not include a connection section. |
-| `modbus_unit_id` | No | | Unit/slave address (0 to 255 at this field's own boundary; narrowed to 0-247 once bound to an RTU/ASCII transport via `.at()`, since 248-255 are reserved on a real serial line). Required alongside a bare shared `ModbusTransport`; rejected alongside an already-bound `ModbusUnit`. Defaults to 1 only when the device builds its own private transport. |
+| `connection` | No | | A `ModbusTransport` (pass the same instance to several devices to share one line) or a `dict`. Takes precedence over the connection in the config. Required if the config does not include a connection section. |
+| `modbus_unit_id` | No | | Unit/slave address (0 to 255; 0 to 247 on an RTU/ASCII transport, since 248-255 are reserved on a real serial line). May also come from the config (top-level `modbus_unit_id` or `connection.unit_id`); values given in more than one place must agree. Required alongside a shared `ModbusTransport`. Defaults to 1 only when the device builds its own private transport. |
 | `name` | No | `device.name` | Override the instrument name used for channel naming |
 | `publishers` | No | `None` | List of publishers to attach at construction time |
 | `autostart` | No | `False` | If `True` and the config contains a `timing` section, opens the connection and starts background polling on instantiation |

--- a/docs/guides/instrumentation/protocols/modbus.mdx
+++ b/docs/guides/instrumentation/protocols/modbus.mdx
@@ -60,7 +60,7 @@ modbus_device.close()
     "port": 502,
     "timeout": 3.0
   },
-  "modbus_unit_id": 1,
+  "unit_id": 1,
   "timing": {
     "poll_interval": 1.0
   },
@@ -424,7 +424,7 @@ ModbusDevice is configured through a JSON file. Every config file must include:
     "port": 502,
     "timeout": 3.0
   },
-  "modbus_unit_id": 1,
+  "unit_id": 1,
   "timing": {
     "poll_interval": 1.0,
     "write_delay_ms": 100
@@ -514,7 +514,7 @@ Metadata about the physical device. The `name` field is used as a prefix for cha
 
 ### Connection Section
 
-The unit/slave address belongs to the device, not the connection: set it with the top-level `modbus_unit_id` field (see [Parameters](#parameters)), or pass `modbus_unit_id` to the `ModbusDevice` constructor. The connection block also accepts a `unit_id` field for compatibility with existing configs; it means the same thing, and an address given in more than one place must agree. When the device shares a transport with others, the address is required; see [Sharing One Bus Across Multiple Units](#sharing-one-bus-across-multiple-units).
+The unit/slave address belongs to the device, not the connection: set it with the top-level `unit_id` field (see [Parameters](#parameters)), or pass `unit_id` to the `ModbusDevice` constructor. The connection block also accepts a `unit_id` field for compatibility with existing configs; it means the same thing, and an address given in more than one place must agree. When the device shares a transport with others, the address is required; see [Sharing One Bus Across Multiple Units](#sharing-one-bus-across-multiple-units).
 
 #### TCP Connection
 
@@ -524,7 +524,7 @@ The unit/slave address belongs to the device, not the connection: set it with th
 | `host` | Yes | | IP address or hostname |
 | `port` | No | `502` | TCP port (1 to 65535) |
 | `timeout` | No | `3.0` | Response timeout in seconds |
-| `unit_id` | No | | Unit/slave address (0 to 255). Equivalent to the top-level `modbus_unit_id` |
+| `unit_id` | No | | Unit/slave address (0 to 255). Equivalent to the top-level `unit_id` |
 
 #### RTU (Serial) Connection
 
@@ -538,7 +538,7 @@ The unit/slave address belongs to the device, not the connection: set it with th
 | `bytesize` | No | `8` | Data bits: `5`, `6`, `7`, or `8` |
 | `timeout` | No | `3.0` | Response timeout in seconds |
 | `framer` | No | `"rtu"` | Serial transmission mode: `"rtu"` or `"ascii"` |
-| `unit_id` | No | | Unit/slave address (0 to 247; 248-255 are reserved on a serial line). Equivalent to the top-level `modbus_unit_id` |
+| `unit_id` | No | | Unit/slave address (0 to 247; 248-255 are reserved on a serial line). Equivalent to the top-level `unit_id` |
 
 **Common serial port paths:**
 
@@ -630,7 +630,7 @@ device = ModbusDevice(
 
 ## Sharing One Bus Across Multiple Units
 
-An RS-485 multi-drop line, or a TCP-to-serial gateway fronting one, often serves several physical devices at different unit addresses over what is one physical connection. Build a single transport and pass it as each device's `connection`, with each device's own `modbus_unit_id`:
+An RS-485 multi-drop line, or a TCP-to-serial gateway fronting one, often serves several physical devices at different unit addresses over what is one physical connection. Build a single transport and pass it as each device's `connection`, with each device's own `unit_id`:
 
 ```python
 from instro.lib.transports import ModbusTCPTransport
@@ -638,8 +638,8 @@ from instro.modbus import ModbusDevice
 
 transport = ModbusTCPTransport(host="192.168.1.100", port=502)
 
-flow_meter = ModbusDevice(config="flow_meter.json", connection=transport, modbus_unit_id=1)
-level_sensor = ModbusDevice(config="level_sensor.json", connection=transport, modbus_unit_id=2)
+flow_meter = ModbusDevice(config="flow_meter.json", connection=transport, unit_id=1)
+level_sensor = ModbusDevice(config="level_sensor.json", connection=transport, unit_id=2)
 
 flow_meter.open()
 level_sensor.open()   # shares the connection flow_meter already opened
@@ -648,7 +648,7 @@ flow_meter.close()    # connection stays open: level_sensor still holds it
 level_sensor.close()  # last owner leaves: connection tears down
 ```
 
-The connection opens for the first device and stays open until the last one closes, the same shared-ownership rule every `instro` transport follows. A shared transport requires an explicit `modbus_unit_id` per device: two devices silently defaulting to the same address on one line is the failure this guards against. See [Sharing one connection across unit addresses](/instrumentation/transports/modbus#sharing-one-connection-across-unit-addresses) for the transport-level detail.
+The connection opens for the first device and stays open until the last one closes, the same shared-ownership rule every `instro` transport follows. A shared transport requires an explicit `unit_id` per device: two devices silently defaulting to the same address on one line is the failure this guards against. See [Sharing one connection across unit addresses](/instrumentation/transports/modbus#sharing-one-connection-across-unit-addresses) for the transport-level detail.
 
 ## Creating a ModbusDevice Instance
 
@@ -710,7 +710,7 @@ config = ModbusConfig(
 )
 
 transport = ModbusTCPTransport(host="192.168.1.100", port=502)
-device = ModbusDevice(config, connection=transport, modbus_unit_id=1, autostart=True)
+device = ModbusDevice(config, connection=transport, unit_id=1, autostart=True)
 ```
 
 </Tab>
@@ -723,7 +723,7 @@ device = ModbusDevice(config, connection=transport, modbus_unit_id=1, autostart=
 |-----------|----------|---------|-------------|
 | `config` | Yes | | Path to a JSON file, a `dict`, or a `ModbusConfig` instance |
 | `connection` | No | | A `ModbusTransport` (pass the same instance to several devices to share one line) or a `dict`. Takes precedence over the connection in the config. Required if the config does not include a connection section. |
-| `modbus_unit_id` | No | | Unit/slave address (0 to 255; 0 to 247 on an RTU/ASCII transport, since 248-255 are reserved on a real serial line). May also come from the config (top-level `modbus_unit_id` or `connection.unit_id`); values given in more than one place must agree. Required alongside a shared `ModbusTransport`. Defaults to 1 only when the device builds its own private transport. |
+| `unit_id` | No | | Unit/slave address (0 to 255; 0 to 247 on an RTU/ASCII transport, since 248-255 are reserved on a real serial line). May also come from the config (top-level `unit_id` or `connection.unit_id`); values given in more than one place must agree. Required alongside a shared `ModbusTransport`. Defaults to 1 only when the device builds its own private transport. |
 | `name` | No | `device.name` | Override the instrument name used for channel naming |
 | `publishers` | No | `None` | List of publishers to attach at construction time |
 | `autostart` | No | `False` | If `True` and the config contains a `timing` section, opens the connection and starts background polling on instantiation |
@@ -866,7 +866,7 @@ The only difference for RTU is in the config file. The Python code is identical:
     "bytesize": 8,
     "timeout": 2.0
   },
-  "modbus_unit_id": 1,
+  "unit_id": 1,
   "registers": [
     {
       "name": "temperature",
@@ -916,13 +916,13 @@ finally:
 
 | Method | Purpose |
 |--------|---------|
-| `ModbusDevice(config, connection=None, name=None, publishers=None, autostart=False, modbus_unit_id=None)` | Create a new Modbus client from a JSON config file, `dict`, or `ModbusConfig` instance. Optionally pass a separate connection and/or unit address. |
+| `ModbusDevice(config, connection=None, name=None, publishers=None, autostart=False, unit_id=None)` | Create a new Modbus client from a JSON config file, `dict`, or `ModbusConfig` instance. Optionally pass a separate connection and/or unit address. |
 | `add_publisher(publisher)` | Attach a publisher for automatic data streaming |
 | `open()` | Open connection to the Modbus device (TCP or RTU) |
 | `close()` | Close connection and stop background polling |
 | `read(alias, **kwargs)` | Read a register by alias, apply scaling, return `Measurement` |
 | `write(alias, value, **kwargs)` | Write a value to a register by alias (accepts strings for `write_value_map` registers), apply reverse scaling, return `Command` |
-| `modbus_unit_id` | Property (read-only): the Modbus unit/slave address this device is bound to |
+| `unit_id` | Property (read-only): the Modbus unit/slave address this device is bound to |
 | `get_channel(channel_name, length=1, wait_for_new_samples=False, timeout=10.0)` | Retrieve buffered poll data for a channel |
 | `start()` | Start background polling daemon |
 | `stop()` | Stop background polling daemon |

--- a/docs/guides/instrumentation/transports/modbus.mdx
+++ b/docs/guides/instrumentation/transports/modbus.mdx
@@ -21,35 +21,33 @@ For a config-driven device where the register map lives in a JSON file rather th
 
 ## Quickstart
 
-A Modbus transport holds no unit address of its own: it serves any number of unit addresses on the line. Bind one with `.at(unit_id)`, which returns a `ModbusUnit` that forwards every I/O method with that address supplied:
+A Modbus transport holds no unit address of its own: it serves any number of unit addresses on the line. Every I/O method takes the target's `unit_id` as a keyword argument:
 
 ```python
 from instro.lib.transports import ModbusTCPTransport
 
-transport = ModbusTCPTransport(host="192.168.1.50", port=502)
-modbus = transport.at(1)  # bind the unit/slave address once
+modbus = ModbusTCPTransport(host="192.168.1.50", port=502)
 
 modbus.open()
 try:
     # Raw function-code access by address.
-    setpoint_regs = modbus.read_holding_registers(0x0100, count=2)
+    setpoint_regs = modbus.read_holding_registers(0x0100, count=2, unit_id=1)
 
     # Typed access decodes across registers, applying byte/word/long swaps.
-    process_value = modbus.read_typed("input", 0x0000, "float32")
-    modbus.write_typed("holding", 0x0100, 72.5, "float32")
+    process_value = modbus.read_typed("input", 0x0000, "float32", unit_id=1)
+    modbus.write_typed("holding", 0x0100, 72.5, "float32", unit_id=1)
 finally:
     modbus.close()
 ```
 
-Use `ModbusRTUTransport` for serial devices. It supports both Modbus serial-line transmission modes — RTU framing (the default) and ASCII framing, via `framer`:
+Use `ModbusRTUTransport` for serial devices. It supports both Modbus serial-line transmission modes: RTU framing (the default) and ASCII framing, via `framer`:
 
 ```python
 from instro.lib.transports import ModbusRTUTransport
 
-transport = ModbusRTUTransport(port="/dev/ttyUSB0", baudrate=19200)
-modbus = transport.at(1)
+modbus = ModbusRTUTransport(port="/dev/ttyUSB0", baudrate=19200)
 
-ascii_transport = ModbusRTUTransport(port="/dev/ttyUSB1", framer="ascii")
+ascii_modbus = ModbusRTUTransport(port="/dev/ttyUSB1", framer="ascii")
 ```
 
 ## Register and data types
@@ -77,8 +75,8 @@ Values wider than 16 bits span consecutive registers. `DataType` names the encod
 `read_typed` and `write_typed` handle the multi-register encode and decode, so callers work in native Python types rather than assembling 16-bit words:
 
 ```python
-process_value = modbus.read_typed("input", 0x0000, "float32")
-modbus.write_typed("holding", 0x0100, 72.5, "float32")
+process_value = modbus.read_typed("input", 0x0000, "float32", unit_id=1)
+modbus.write_typed("holding", 0x0100, 72.5, "float32", unit_id=1)
 ```
 
 Modbus itself does not specify how a multi-register value is ordered, so vendors differ. Three keyword flags cover the common permutations, all defaulting to `False` (big-endian, high word first):
@@ -91,7 +89,7 @@ Modbus itself does not specify how a multi-register value is ordered, so vendors
 
 ```python
 # A device that reports float32 low-word-first.
-flow_rate = modbus.read_typed("input", 0x0010, "float32", word_swap=True)
+flow_rate = modbus.read_typed("input", 0x0010, "float32", unit_id=1, word_swap=True)
 ```
 
 Four rules the typed path enforces:
@@ -109,43 +107,34 @@ Hold the [transport lock](/instrumentation/transports/overview#atomic-multi-step
 
 ```python
 with modbus.lock():
-    modbus.write_holding_register(0x00FF, page)
-    values = modbus.read_holding_registers(0x0000, count=8)
+    modbus.write_holding_register(0x00FF, page, unit_id=1)
+    values = modbus.read_holding_registers(0x0000, count=8, unit_id=1)
 ```
 
 Note that a transport error inside the block closes the dead socket before re-raising, so the next op after the `with` reconnects rather than reusing it.
 
 ## Sharing one connection across unit addresses
 
-An RS-485 multi-drop line, or a TCP-to-serial gateway fronting one, often serves several devices at different unit addresses over what is physically one connection. Build a single transport and call `.at(unit_id)` once per address instead of opening a connection per device:
+An RS-485 multi-drop line, or a TCP-to-serial gateway fronting one, often serves several devices at different unit addresses over what is physically one connection. Build a single transport and address each device by `unit_id` per call instead of opening a connection per device. Callers that share the transport pass a holder identity to `open`/`close`, so the connection opens once and tears down only when the last owner leaves:
 
 ```python
-transport = ModbusTCPTransport(host="192.168.1.50", port=502)
+modbus = ModbusTCPTransport(host="192.168.1.50", port=502)
 
-flow_meter = transport.at(1)
-level_sensor = transport.at(2)
+flow_meter, level_sensor = object(), object()  # any owner identity, typically a driver instance
 
-flow_meter.open()
-level_sensor.open()   # shares the connection flow_meter already opened
+modbus.open(flow_meter)
+modbus.open(level_sensor)   # shares the connection flow_meter already opened
 
-flow_rate = flow_meter.read_typed("input", 0x0000, "float32")
-level = level_sensor.read_typed("input", 0x0000, "float32")
+flow_rate = modbus.read_typed("input", 0x0000, "float32", unit_id=1)
+level = modbus.read_typed("input", 0x0000, "float32", unit_id=2)
 
-flow_meter.close()    # connection stays open: level_sensor still holds it
-level_sensor.close()  # last owner leaves: connection tears down
+modbus.close(flow_meter)    # connection stays open: level_sensor still holds it
+modbus.close(level_sensor)  # last owner leaves: connection tears down
 ```
 
-`.at()` is the single validation funnel for the unit address and the only way to obtain a `ModbusUnit`; see its docstring on `ModbusTransport` for the holder-accounting details of how the shared connection opens once and closes when the last unit leaves. The valid range is 0-255 on `ModbusTCPTransport` and 0-247 on `ModbusRTUTransport` — Modbus over Serial Line reserves 248-255, so a real RTU/ASCII slave will never have one of those addresses. This is the same shared-ownership mechanism described in [Transports: shared ownership](/instrumentation/transports/overview#shared-ownership), applied to one line instead of one device with two categories.
+The valid `unit_id` range is 0 to 255 on `ModbusTCPTransport` and 0 to 247 on `ModbusRTUTransport` (Modbus over Serial Line reserves 248-255, so a real RTU/ASCII slave will never have one of those addresses); `check_unit_id()` validates an address against the transport's range up front. This is the same shared-ownership mechanism described in [Transports: shared ownership](/instrumentation/transports/overview#shared-ownership), applied to one line instead of one device with two categories.
 
-`ModbusUnit` is a normal type you can type-hint with in your own code, for example a helper that reads a sensor from any bound unit:
-
-```python
-from instro.lib.transports import ModbusUnit
-
-
-def read_temperature(unit: ModbusUnit) -> float:
-    return unit.read_typed("input", 0x0000, "float32")
-```
+For config-driven devices, [`ModbusDevice`](/instrumentation/protocols/modbus) wraps this pattern: pass the same transport to several devices, each with its own `modbus_unit_id`.
 
 ## Configuration
 
@@ -169,34 +158,31 @@ def read_temperature(unit: ModbusUnit) -> float:
 | `timeout` | `float` | `3.0` | Response timeout in seconds |
 | `framer` | `"rtu"`, `"ascii"` | `"rtu"` | Modbus serial-line transmission mode |
 
-Neither transport carries a unit address: bind one with `.at(unit_id)`, which returns the `ModbusUnit` you pass around. The valid range is 0 to 255 on `ModbusTCPTransport` and 0 to 247 on `ModbusRTUTransport` (248-255 are reserved on a real serial line, never assigned to a slave).
+Neither transport carries a unit address: every I/O method takes `unit_id` as a keyword argument. The valid range is 0 to 255 on `ModbusTCPTransport` and 0 to 247 on `ModbusRTUTransport` (248-255 are reserved on a real serial line, never assigned to a slave).
 
 ## Method reference
 
 | Method | Purpose |
 | --- | --- |
 | `ModbusTCPTransport(host, port=502, timeout=3.0)` / `ModbusRTUTransport(port, ..., framer="rtu")` | Construct the transport. No I/O yet. |
-| `transport.at(unit_id)` | Bind a unit address (0-255 for TCP, 0-247 for RTU), returning a `ModbusUnit`. |
+| `check_unit_id(unit_id)` | Validate a unit address against the transport's range (0-255 for TCP, 0-247 for RTU) and return it. |
 | `is_open` | Property: `True` once opened and not closed. Stays `True` across a dropped socket, which the next op reconnects. |
-| `unit_id` | Property on `ModbusUnit`: the bound unit/slave address. |
 | `open(holder=None)` | Connect. Idempotent. See [Lifecycle](/instrumentation/transports/overview#lifecycle). |
 | `close(holder=None)` | Disconnect. See [Shared ownership](/instrumentation/transports/overview#shared-ownership). |
 | `lock()` | The reentrant lock, for atomic multi-step sequences. |
-| `read_holding_registers(address, count)` | FC03. Returns `list[int]`. |
-| `read_input_registers(address, count)` | FC04. Returns `list[int]`. |
-| `write_holding_register(address, value)` | FC06. Writes one 16-bit register. |
-| `write_holding_registers(address, values)` | FC16. Writes consecutive registers. |
-| `read_coils(address, count)` | FC01. Returns `list[bool]`. |
-| `write_coil(address, value)` | FC05. Writes one coil. |
-| `write_coils(address, values)` | FC15. Writes consecutive coils. |
-| `read_discrete_inputs(address, count)` | FC02. Returns `list[bool]`. |
-| `read_typed(register_type, address, data_type, *, byte_swap, word_swap, long_swap)` | Read and decode across registers. |
-| `write_typed(register_type, address, value, data_type, *, byte_swap, word_swap, long_swap)` | Encode and write across registers. |
+| `read_holding_registers(address, count, *, unit_id)` | FC03. Returns `list[int]`. |
+| `read_input_registers(address, count, *, unit_id)` | FC04. Returns `list[int]`. |
+| `write_holding_register(address, value, *, unit_id)` | FC06. Writes one 16-bit register. |
+| `write_holding_registers(address, values, *, unit_id)` | FC16. Writes consecutive registers. |
+| `read_coils(address, count, *, unit_id)` | FC01. Returns `list[bool]`. |
+| `write_coil(address, value, *, unit_id)` | FC05. Writes one coil. |
+| `write_coils(address, values, *, unit_id)` | FC15. Writes consecutive coils. |
+| `read_discrete_inputs(address, count, *, unit_id)` | FC02. Returns `list[bool]`. |
+| `read_typed(register_type, address, data_type, *, unit_id, byte_swap, word_swap, long_swap)` | Read and decode across registers. |
+| `write_typed(register_type, address, value, data_type, *, unit_id, byte_swap, word_swap, long_swap)` | Encode and write across registers. |
 | `register_count(data_type)` | Module-level function. Registers the type spans. |
 | `decode_registers(registers, data_type, byte_swap, word_swap, long_swap)` | Module-level function. Raw registers to a typed value. |
 | `encode_value(value, data_type, byte_swap, word_swap, long_swap)` | Module-level function. Typed value to raw registers. |
-
-`ModbusUnit`'s I/O methods (shown above) omit `unit_id`, since it is already bound; calling the same method directly on the transport requires passing `unit_id` as a keyword.
 
 ## Error handling
 

--- a/docs/guides/instrumentation/transports/modbus.mdx
+++ b/docs/guides/instrumentation/transports/modbus.mdx
@@ -134,7 +134,7 @@ modbus.close(level_sensor)  # last owner leaves: connection tears down
 
 The valid `unit_id` range is 0 to 255 on `ModbusTCPTransport` and 0 to 247 on `ModbusRTUTransport` (Modbus over Serial Line reserves 248-255, so a real RTU/ASCII slave will never have one of those addresses); `check_unit_id()` validates an address against the transport's range up front. This is the same shared-ownership mechanism described in [Transports: shared ownership](/instrumentation/transports/overview#shared-ownership), applied to one line instead of one device with two categories.
 
-For config-driven devices, [`ModbusDevice`](/instrumentation/protocols/modbus) wraps this pattern: pass the same transport to several devices, each with its own `modbus_unit_id`.
+For config-driven devices, [`ModbusDevice`](/instrumentation/protocols/modbus) wraps this pattern: pass the same transport to several devices, each with its own `unit_id`.
 
 ## Configuration
 

--- a/docs/guides/instrumentation/transports/overview.mdx
+++ b/docs/guides/instrumentation/transports/overview.mdx
@@ -12,7 +12,7 @@ Concrete instrument drivers compose a transport in their constructor rather than
 ## Available transports
 
 - **[`VisaDriver`](/instrumentation/transports/visa)**: VISA-attached instruments over GPIB, USB-TMC, TCP/IP (SOCKET, VXI-11, HiSLIP), and RS-232/RS-485. The transport every shipped SCPI driver sits on.
-- **[`ModbusTCPTransport`/`ModbusRTUTransport`](/instrumentation/transports/modbus)**: Modbus TCP and RTU, with raw function-code access, typed register encode and decode, and `.at(unit_id)` to address multiple units over one shared line.
+- **[`ModbusTCPTransport`/`ModbusRTUTransport`](/instrumentation/transports/modbus)**: Modbus TCP and RTU, with raw function-code access, typed register encode and decode, and per-call `unit_id` addressing so multiple units share one line.
 
 For a protocol neither one covers, [implement a transport](#implementing-a-transport) by subclassing `TransportBase`.
 

--- a/docs/reference/src/protocols/modbus.md
+++ b/docs/reference/src/protocols/modbus.md
@@ -34,7 +34,7 @@ config = ModbusConfig(
     ],
 )
 transport = ModbusTCPTransport(host="192.168.1.10")
-device = ModbusDevice(config, connection=transport.at(1), autostart=True)
+device = ModbusDevice(config, connection=transport, modbus_unit_id=1, autostart=True)
 ```
 
 ## Sample Config

--- a/docs/reference/src/protocols/modbus.md
+++ b/docs/reference/src/protocols/modbus.md
@@ -67,12 +67,12 @@ description shared across environments.
 
     ```json
     {
-        "unit_id": 1,
         "connection": {
             "transport": "tcp",
             "host": "192.168.1.10",
             "port": 502,
-            "timeout": 3.0
+            "timeout": 3.0,
+            "unit_id": 1
         }
     }
     ```
@@ -81,7 +81,6 @@ description shared across environments.
 
     ```json
     {
-        "unit_id": 1,
         "connection": {
             "transport": "rtu",
             "port": "/dev/ttyUSB0",
@@ -89,7 +88,8 @@ description shared across environments.
             "parity": "N",
             "stopbits": 1,
             "bytesize": 8,
-            "timeout": 3.0
+            "timeout": 3.0,
+            "unit_id": 1
         }
     }
     ```

--- a/docs/reference/src/protocols/modbus.md
+++ b/docs/reference/src/protocols/modbus.md
@@ -34,7 +34,7 @@ config = ModbusConfig(
     ],
 )
 transport = ModbusTCPTransport(host="192.168.1.10")
-device = ModbusDevice(config, connection=transport, modbus_unit_id=1, autostart=True)
+device = ModbusDevice(config, connection=transport, unit_id=1, autostart=True)
 ```
 
 ## Sample Config
@@ -67,7 +67,7 @@ description shared across environments.
 
     ```json
     {
-        "modbus_unit_id": 1,
+        "unit_id": 1,
         "connection": {
             "transport": "tcp",
             "host": "192.168.1.10",
@@ -81,7 +81,7 @@ description shared across environments.
 
     ```json
     {
-        "modbus_unit_id": 1,
+        "unit_id": 1,
         "connection": {
             "transport": "rtu",
             "port": "/dev/ttyUSB0",

--- a/examples/modbus/labjack_t4_loopback_test.py
+++ b/examples/modbus/labjack_t4_loopback_test.py
@@ -40,8 +40,8 @@ CONFIG = {
         "host": HOST,
         "port": PORT,
         "timeout": 3.0,
+        "unit_id": 1,
     },
-    "unit_id": 1,
     "registers": [
         # Device identity
         {"name": "product_id", "starting_address": 60000, "register_type": "holding", "data_type": "float32"},

--- a/examples/modbus/labjack_t4_loopback_test.py
+++ b/examples/modbus/labjack_t4_loopback_test.py
@@ -41,7 +41,7 @@ CONFIG = {
         "port": PORT,
         "timeout": 3.0,
     },
-    "modbus_unit_id": 1,
+    "unit_id": 1,
     "registers": [
         # Device identity
         {"name": "product_id", "starting_address": 60000, "register_type": "holding", "data_type": "float32"},

--- a/examples/modbus/modbus_example.py
+++ b/examples/modbus/modbus_example.py
@@ -27,7 +27,7 @@ CONFIG_PATH = Path(__file__).parent / "simulated_modbus_device.json"
 
 
 def main():
-    device = ModbusDevice(str(CONFIG_PATH), connection=CONNECTION, modbus_unit_id=1, autostart=True)
+    device = ModbusDevice(str(CONFIG_PATH), connection=CONNECTION, unit_id=1, autostart=True)
     device.add_publisher(
         NominalCorePublisher("ri.catalog.cerulean-staging.dataset.056356ba-5c64-479c-9fc8-da0eba27ae0b")
     )

--- a/examples/modbus/programmatic_config_example.py
+++ b/examples/modbus/programmatic_config_example.py
@@ -80,7 +80,7 @@ config = ModbusConfig(
 
 
 def main():
-    device = ModbusDevice(config, connection=transport, modbus_unit_id=1, autostart=True)
+    device = ModbusDevice(config, connection=transport, unit_id=1, autostart=True)
 
     try:
         print(f"Connected to {config.device.name}")

--- a/examples/modbus/programmatic_config_example.py
+++ b/examples/modbus/programmatic_config_example.py
@@ -80,7 +80,7 @@ config = ModbusConfig(
 
 
 def main():
-    device = ModbusDevice(config, connection=transport.at(1), autostart=True)
+    device = ModbusDevice(config, connection=transport, modbus_unit_id=1, autostart=True)
 
     try:
         print(f"Connected to {config.device.name}")

--- a/examples/modbus/shared_bus_example.py
+++ b/examples/modbus/shared_bus_example.py
@@ -1,7 +1,7 @@
 """Example: two ModbusDevices sharing one Modbus TCP connection.
 
 Demonstrates the shared-bus pattern: one ModbusTCPTransport passed to each
-device, with each device's own `modbus_unit_id`. The transport opens once, for
+device, with each device's own `unit_id`. The transport opens once, for
 whichever device opens first, and stays open until the last device closes it --
 the way one RS-485 multi-drop line (or a TCP-to-serial gateway fronting one)
 serves several unit addresses over a single connection.
@@ -23,8 +23,8 @@ CONFIG_PATH = Path(__file__).parent / "simulated_modbus_device.json"
 def main() -> None:
     transport = ModbusTCPTransport(host="127.0.0.1", port=5020)
 
-    unit_1 = ModbusDevice(config=CONFIG_PATH, connection=transport, modbus_unit_id=1, name="unit_1")
-    unit_2 = ModbusDevice(config=CONFIG_PATH, connection=transport, modbus_unit_id=2, name="unit_2")
+    unit_1 = ModbusDevice(config=CONFIG_PATH, connection=transport, unit_id=1, name="unit_1")
+    unit_2 = ModbusDevice(config=CONFIG_PATH, connection=transport, unit_id=2, name="unit_2")
 
     unit_1.open()
     unit_2.open()  # shares the connection unit_1 already opened; no second socket

--- a/examples/modbus/shared_bus_example.py
+++ b/examples/modbus/shared_bus_example.py
@@ -1,10 +1,10 @@
 """Example: two ModbusDevices sharing one Modbus TCP connection.
 
-Demonstrates the shared-bus pattern: one ModbusTCPTransport, and one ModbusUnit
-per device address bound via `.at()`. The transport opens once, for whichever
-device opens first, and stays open until the last device closes it -- the way
-one RS-485 multi-drop line (or a TCP-to-serial gateway fronting one) serves
-several unit addresses over a single connection.
+Demonstrates the shared-bus pattern: one ModbusTCPTransport passed to each
+device, with each device's own `modbus_unit_id`. The transport opens once, for
+whichever device opens first, and stays open until the last device closes it --
+the way one RS-485 multi-drop line (or a TCP-to-serial gateway fronting one)
+serves several unit addresses over a single connection.
 
 Start the sim server first:
     python -m instro.modbus.sim_server
@@ -23,8 +23,8 @@ CONFIG_PATH = Path(__file__).parent / "simulated_modbus_device.json"
 def main() -> None:
     transport = ModbusTCPTransport(host="127.0.0.1", port=5020)
 
-    unit_1 = ModbusDevice(config=CONFIG_PATH, connection=transport.at(1), name="unit_1")
-    unit_2 = ModbusDevice(config=CONFIG_PATH, connection=transport.at(2), name="unit_2")
+    unit_1 = ModbusDevice(config=CONFIG_PATH, connection=transport, modbus_unit_id=1, name="unit_1")
+    unit_2 = ModbusDevice(config=CONFIG_PATH, connection=transport, modbus_unit_id=2, name="unit_2")
 
     unit_1.open()
     unit_2.open()  # shares the connection unit_1 already opened; no second socket

--- a/instro/lib/transports/__init__.py
+++ b/instro/lib/transports/__init__.py
@@ -5,7 +5,6 @@ from instro.lib.transports.modbus import (
     ModbusRTUTransport,
     ModbusTCPTransport,
     ModbusTransport,
-    ModbusUnit,
     RegisterType,
 )
 from instro.lib.transports.transport_base import TransportBase
@@ -26,7 +25,6 @@ __all__ = [
     "ModbusRTUTransport",
     "ModbusTCPTransport",
     "ModbusTransport",
-    "ModbusUnit",
     "Parity",
     "RegisterType",
     "SerialConfig",

--- a/instro/lib/transports/modbus.py
+++ b/instro/lib/transports/modbus.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import abc
 import functools
 import struct
-import threading
 from typing import Literal
 
 from pymodbus.client import ModbusSerialClient, ModbusTcpClient
@@ -175,7 +174,7 @@ def _modbus_op(fn):
 
 
 class ModbusTransport(TransportBase, abc.ABC):
-    """Abstract Modbus line: owns the session, locking, and every wire op, addressed per call or bound once via :meth:`at`. Annotate against it; construct a concrete subclass."""
+    """Abstract Modbus line: owns the session, locking, and every wire op, addressed per call via ``unit_id``. Annotate against it; construct a concrete subclass."""
 
     # Highest valid unit_id; ModbusRTUTransport narrows this to 247 (Modbus over Serial Line
     # spec 2.2 reserves 248-255 rather than assigning them to slaves).
@@ -209,11 +208,11 @@ class ModbusTransport(TransportBase, abc.ABC):
         """Build, connect, and return this physical layer's pymodbus client; raise ``ConnectionError`` naming the target on failure."""
         ...
 
-    def at(self, unit_id: int) -> ModbusUnit:
-        """Bind ``unit_id`` (0 to :attr:`_max_unit_id`) to this transport, returning a ``ModbusUnit`` that addresses it — call once per device to share one connection across several units."""
+    def check_unit_id(self, unit_id: int) -> int:
+        """Validate ``unit_id`` against this physical layer's range (0 to :attr:`_max_unit_id`) and return it."""
         if not 0 <= unit_id <= self._max_unit_id:
             raise ValueError(f"unit_id must be between 0 and {self._max_unit_id}, got {unit_id}")
-        return ModbusUnit(self, unit_id)
+        return unit_id
 
     @_modbus_op
     def read_holding_registers(self, address: int, count: int, *, unit_id: int) -> list[int]:
@@ -351,7 +350,7 @@ class ModbusTransport(TransportBase, abc.ABC):
 
 
 class ModbusTCPTransport(ModbusTransport):
-    """A Modbus TCP line. One socket, addressed per wire op or through ``at()``."""
+    """A Modbus TCP line. One socket, addressed per wire op via ``unit_id``."""
 
     def __init__(self, host: str, port: int = 502, timeout: float = 3.0) -> None:
         """Construct from the socket's own fields; no unit address lives here."""
@@ -374,7 +373,7 @@ class ModbusTCPTransport(ModbusTransport):
 
 
 class ModbusRTUTransport(ModbusTransport):
-    """A Modbus serial line (RTU or ASCII framing). One port, addressed per wire op or through ``at()``."""
+    """A Modbus serial line (RTU or ASCII framing). One port, addressed per wire op via ``unit_id``."""
 
     _max_unit_id = 247
 
@@ -427,115 +426,3 @@ class ModbusRTUTransport(ModbusTransport):
             client.close()
             raise ConnectionError(f"Failed to connect to Modbus device at {self._port}")
         return client
-
-
-class ModbusUnit:
-    """A ``ModbusTransport`` bound to one unit address by ``at()``; forwards every wire op with that address supplied."""
-
-    def __init__(self, transport: ModbusTransport, unit_id: int) -> None:
-        """Bind ``unit_id`` to ``transport``. Obtain one from ``transport.at(unit_id)``, which validates the range."""
-        self._transport = transport
-        self._unit_id = unit_id
-
-    @property
-    def transport(self) -> ModbusTransport:
-        """The transport this unit is bound to; rebinding to another address goes through it."""
-        return self._transport
-
-    @property
-    def unit_id(self) -> int:
-        """The bound unit address."""
-        return self._unit_id
-
-    def open(self, holder: object | None = None) -> bool:
-        """Open the underlying transport, passing the caller's own holder identity through."""
-        return self._transport.open(holder)
-
-    def close(self, holder: object | None = None) -> None:
-        """Close the underlying transport, passing the caller's own holder identity through."""
-        self._transport.close(holder)
-
-    @property
-    def is_open(self) -> bool:
-        """Whether the underlying transport is open."""
-        return self._transport.is_open
-
-    def lock(self) -> threading.RLock:
-        """The underlying transport's reentrant lock, shared by every unit bound to it."""
-        return self._transport.lock()
-
-    def read_holding_registers(self, address: int, count: int) -> list[int]:
-        """Read holding registers by address (FC03) at the bound unit."""
-        return self._transport.read_holding_registers(address, count, unit_id=self._unit_id)
-
-    def read_input_registers(self, address: int, count: int) -> list[int]:
-        """Read input registers by address (FC04) at the bound unit."""
-        return self._transport.read_input_registers(address, count, unit_id=self._unit_id)
-
-    def write_holding_register(self, address: int, value: int) -> None:
-        """Write a single holding register by address (FC06) at the bound unit."""
-        self._transport.write_holding_register(address, value, unit_id=self._unit_id)
-
-    def write_holding_registers(self, address: int, values: list[int]) -> None:
-        """Write multiple holding registers by address (FC16) at the bound unit."""
-        self._transport.write_holding_registers(address, values, unit_id=self._unit_id)
-
-    def read_coils(self, address: int, count: int) -> list[bool]:
-        """Read coils by address (FC01) at the bound unit."""
-        return self._transport.read_coils(address, count, unit_id=self._unit_id)
-
-    def write_coil(self, address: int, value: bool) -> None:
-        """Write a single coil by address (FC05) at the bound unit."""
-        self._transport.write_coil(address, value, unit_id=self._unit_id)
-
-    def write_coils(self, address: int, values: list[bool]) -> None:
-        """Write multiple coils by address (FC15) at the bound unit."""
-        self._transport.write_coils(address, values, unit_id=self._unit_id)
-
-    def read_discrete_inputs(self, address: int, count: int) -> list[bool]:
-        """Read discrete inputs by address (FC02) at the bound unit."""
-        return self._transport.read_discrete_inputs(address, count, unit_id=self._unit_id)
-
-    def read_typed(
-        self,
-        register_type: RegisterType,
-        address: int,
-        data_type: DataType,
-        *,
-        byte_swap: bool = False,
-        word_swap: bool = False,
-        long_swap: bool = False,
-    ) -> int | float | bool:
-        """Read ``address`` as ``data_type`` at the bound unit."""
-        return self._transport.read_typed(
-            register_type,
-            address,
-            data_type,
-            unit_id=self._unit_id,
-            byte_swap=byte_swap,
-            word_swap=word_swap,
-            long_swap=long_swap,
-        )
-
-    def write_typed(
-        self,
-        register_type: RegisterType,
-        address: int,
-        value: int | float | bool,
-        data_type: DataType,
-        *,
-        byte_swap: bool = False,
-        word_swap: bool = False,
-        long_swap: bool = False,
-    ) -> None:
-        """Encode ``value`` as ``data_type`` and write it to ``address`` at the bound unit."""
-        self._transport.write_typed(
-            register_type,
-            address,
-            value,
-            data_type,
-            unit_id=self._unit_id,
-            byte_swap=byte_swap,
-            word_swap=word_swap,
-            long_swap=long_swap,
-        )

--- a/instro/modbus/modbus.py
+++ b/instro/modbus/modbus.py
@@ -33,7 +33,7 @@ class ModbusDevice(Instrument):
         name: str | None = None,
         publishers: list[Publisher] | None = None,
         autostart: bool = False,
-        modbus_unit_id: int | None = None,
+        unit_id: int | None = None,
         **kwargs,
     ):
         """Initialize a ModbusDevice.
@@ -41,7 +41,7 @@ class ModbusDevice(Instrument):
         Args:
             config: A ``ModbusConfig``, a dict (validated via Pydantic), or a path to a JSON config.
             connection: Overrides ``config.connection``. Accepts a ``ModbusTransport`` (pass the
-                same instance to several devices to share one line; ``modbus_unit_id`` is then
+                same instance to several devices to share one line; ``unit_id`` is then
                 required), or a dict (with ``transport`` = ``"tcp"`` / ``"rtu"``), which builds a
                 private transport. Required if the config has no ``connection`` section.
             name: Channel-name prefix; falls back to ``config.device.name``.
@@ -49,8 +49,8 @@ class ModbusDevice(Instrument):
             autostart: When True, open the connection and start background polling.
                 Requires a ``timing`` section (with ``poll_interval``) — passing
                 ``autostart=True`` without one is an error.
-            modbus_unit_id: Modbus unit/slave address (0-255; 0-247 on serial). May also come
-                from the config (top-level ``modbus_unit_id`` or ``connection.unit_id``); values
+            unit_id: Modbus unit/slave address (0-255; 0-247 on serial). May also come
+                from the config (top-level ``unit_id`` or ``connection.unit_id``); values
                 given in more than one place must agree. Required alongside a shared transport;
                 defaults to 1 when this device builds its own private transport.
             **kwargs: Default tags applied to every emitted Measurement/Command.
@@ -66,14 +66,14 @@ class ModbusDevice(Instrument):
         else:
             resolved_config = ModbusConfig.from_json(config)
 
-        transport, unit_id = self._resolve_connection(connection, resolved_config, modbus_unit_id)
+        transport, unit_id = self._resolve_connection(connection, resolved_config, unit_id)
 
         instrument_name = name or resolved_config.device.name
         super().__init__(name=instrument_name, publishers=publishers, **kwargs)
 
         self._config = resolved_config
         self._transport = transport
-        self._modbus_unit_id = unit_id
+        self._unit_id = unit_id
         self._opened = False
 
         self._define_background_daemon()
@@ -105,7 +105,7 @@ class ModbusDevice(Instrument):
     def _resolve_connection(
         connection: ModbusTransport | dict | None,
         config: ModbusConfig,
-        modbus_unit_id: int | None,
+        unit_id: int | None,
     ) -> tuple[ModbusTransport, int]:
         """Resolve ``connection`` into a transport and the unit address this device talks at."""
         shared = False
@@ -130,8 +130,8 @@ class ModbusDevice(Instrument):
                 )
 
         candidates = {
-            "modbus_unit_id (constructor)": modbus_unit_id,
-            "modbus_unit_id (config)": config.modbus_unit_id,
+            "unit_id (constructor)": unit_id,
+            "unit_id (config)": config.unit_id,
             "connection.unit_id": connection_unit_id,
         }
         given: dict[str, int] = {source: value for source, value in candidates.items() if value is not None}
@@ -142,7 +142,7 @@ class ModbusDevice(Instrument):
             unit_id = next(iter(given.values()))
         elif shared:
             raise ValueError(
-                "A shared ModbusTransport needs an explicit unit address: pass modbus_unit_id "
+                "A shared ModbusTransport needs an explicit unit address: pass unit_id "
                 "to the constructor or set it in the config."
             )
         else:
@@ -152,9 +152,9 @@ class ModbusDevice(Instrument):
         return transport, transport.check_unit_id(unit_id)
 
     @property
-    def modbus_unit_id(self) -> int:
+    def unit_id(self) -> int:
         """Modbus unit/slave address this device is bound to. Read-only: set once at construction, via the constructor kwarg or the config."""
-        return self._modbus_unit_id
+        return self._unit_id
 
     def _require_ready_locked(self) -> None:
         """Reject I/O during shutdown, before this device opened, or before the transport is open."""
@@ -191,7 +191,7 @@ class ModbusDevice(Instrument):
                 reg.register_type,
                 reg.starting_address,
                 reg.data_type,
-                unit_id=self._modbus_unit_id,
+                unit_id=self._unit_id,
                 byte_swap=reg.byte_swap,
                 word_swap=reg.word_swap,
                 long_swap=reg.long_swap,
@@ -218,19 +218,13 @@ class ModbusDevice(Instrument):
             self._require_ready_locked()
             match first.register_type:
                 case "holding":
-                    raw_regs = self._transport.read_holding_registers(
-                        start_address, total_count, unit_id=self._modbus_unit_id
-                    )
+                    raw_regs = self._transport.read_holding_registers(start_address, total_count, unit_id=self._unit_id)
                 case "input":
-                    raw_regs = self._transport.read_input_registers(
-                        start_address, total_count, unit_id=self._modbus_unit_id
-                    )
+                    raw_regs = self._transport.read_input_registers(start_address, total_count, unit_id=self._unit_id)
                 case "coil":
-                    raw_bits = self._transport.read_coils(start_address, total_count, unit_id=self._modbus_unit_id)
+                    raw_bits = self._transport.read_coils(start_address, total_count, unit_id=self._unit_id)
                 case "discrete":
-                    raw_bits = self._transport.read_discrete_inputs(
-                        start_address, total_count, unit_id=self._modbus_unit_id
-                    )
+                    raw_bits = self._transport.read_discrete_inputs(start_address, total_count, unit_id=self._unit_id)
                 case _:
                     raise ValueError(f"Unknown register type: {first.register_type}")
 
@@ -319,7 +313,7 @@ class ModbusDevice(Instrument):
                 reg.starting_address,
                 wire_value,
                 reg.data_type,
-                unit_id=self._modbus_unit_id,
+                unit_id=self._unit_id,
                 byte_swap=reg.byte_swap,
                 word_swap=reg.word_swap,
                 long_swap=reg.long_swap,

--- a/instro/modbus/modbus.py
+++ b/instro/modbus/modbus.py
@@ -50,9 +50,9 @@ class ModbusDevice(Instrument):
                 Requires a ``timing`` section (with ``poll_interval``) — passing
                 ``autostart=True`` without one is an error.
             unit_id: Modbus unit/slave address (0-255; 0-247 on serial). May also come
-                from the config (top-level ``unit_id`` or ``connection.unit_id``); values
-                given in more than one place must agree. Required alongside a shared transport;
-                defaults to 1 when this device builds its own private transport.
+                from the connection block's ``unit_id`` field; values given in both places
+                must agree. Required alongside a shared transport; defaults to 1 when this
+                device builds its own private transport.
             **kwargs: Default tags applied to every emitted Measurement/Command.
 
         Raises:
@@ -131,7 +131,6 @@ class ModbusDevice(Instrument):
 
         candidates = {
             "unit_id (constructor)": unit_id,
-            "unit_id (config)": config.unit_id,
             "connection.unit_id": connection_unit_id,
         }
         given: dict[str, int] = {source: value for source, value in candidates.items() if value is not None}

--- a/instro/modbus/modbus.py
+++ b/instro/modbus/modbus.py
@@ -10,7 +10,7 @@ from pydantic import TypeAdapter
 from instro.lib import Command, Instrument, Measurement
 from instro.lib.instrument import publish_command, publish_measurement
 from instro.lib.publishers import Publisher
-from instro.lib.transports.modbus import ModbusTransport, ModbusUnit, decode_registers
+from instro.lib.transports.modbus import ModbusTransport, decode_registers
 
 from .types import (
     BOOL_DATA_TYPES,
@@ -29,7 +29,7 @@ class ModbusDevice(Instrument):
     def __init__(
         self,
         config: ModbusConfig | dict | Path | str,
-        connection: ModbusUnit | ModbusTransport | dict | None = None,
+        connection: ModbusTransport | dict | None = None,
         name: str | None = None,
         publishers: list[Publisher] | None = None,
         autostart: bool = False,
@@ -40,24 +40,24 @@ class ModbusDevice(Instrument):
 
         Args:
             config: A ``ModbusConfig``, a dict (validated via Pydantic), or a path to a JSON config.
-            connection: Overrides ``config.connection``. Accepts a ``ModbusUnit`` from
-                ``transport.at(unit_id)`` (the way to share one line across devices), a bare
-                ``ModbusTransport`` (then ``modbus_unit_id`` is required), or a dict (with
-                ``transport`` = ``"tcp"`` / ``"rtu"``), which builds a private transport.
-                Required if the config has no ``connection`` section.
+            connection: Overrides ``config.connection``. Accepts a ``ModbusTransport`` (pass the
+                same instance to several devices to share one line; ``modbus_unit_id`` is then
+                required), or a dict (with ``transport`` = ``"tcp"`` / ``"rtu"``), which builds a
+                private transport. Required if the config has no ``connection`` section.
             name: Channel-name prefix; falls back to ``config.device.name``.
             publishers: Publishers that receive emitted Measurement/Command data.
             autostart: When True, open the connection and start background polling.
                 Requires a ``timing`` section (with ``poll_interval``) — passing
                 ``autostart=True`` without one is an error.
-            modbus_unit_id: Modbus unit/slave address (0-255). Required alongside a bare
-                shared transport; rejected alongside an already-bound ``ModbusUnit``.
-                Defaults to 1 only when this device builds its own private transport.
+            modbus_unit_id: Modbus unit/slave address (0-255; 0-247 on serial). May also come
+                from the config (top-level ``modbus_unit_id`` or ``connection.unit_id``); values
+                given in more than one place must agree. Required alongside a shared transport;
+                defaults to 1 when this device builds its own private transport.
             **kwargs: Default tags applied to every emitted Measurement/Command.
 
         Raises:
-            ValueError: No connection in args or config, an address that is missing, doubly
-                supplied, or out of range, or ``autostart=True`` with no ``timing`` section.
+            ValueError: No connection in args or config, an address that is missing, conflicting,
+                or out of range, or ``autostart=True`` with no ``timing`` section.
         """
         if isinstance(config, ModbusConfig):
             resolved_config = config
@@ -66,13 +66,14 @@ class ModbusDevice(Instrument):
         else:
             resolved_config = ModbusConfig.from_json(config)
 
-        bound_unit = self._resolve_connection(connection, resolved_config, modbus_unit_id)
+        transport, unit_id = self._resolve_connection(connection, resolved_config, modbus_unit_id)
 
         instrument_name = name or resolved_config.device.name
         super().__init__(name=instrument_name, publishers=publishers, **kwargs)
 
         self._config = resolved_config
-        self._modbus = bound_unit
+        self._transport = transport
+        self._modbus_unit_id = unit_id
         self._opened = False
 
         self._define_background_daemon()
@@ -102,70 +103,64 @@ class ModbusDevice(Instrument):
 
     @staticmethod
     def _resolve_connection(
-        connection: ModbusUnit | ModbusTransport | dict | None,
+        connection: ModbusTransport | dict | None,
         config: ModbusConfig,
         modbus_unit_id: int | None,
-    ) -> ModbusUnit:
-        """Resolve ``connection`` and the address into one address-bound ``ModbusUnit``, binding through ``at()``."""
+    ) -> tuple[ModbusTransport, int]:
+        """Resolve ``connection`` into a transport and the unit address this device talks at."""
+        shared = False
+        connection_unit_id: int | None = None
         match connection:
-            case ModbusUnit():
-                if modbus_unit_id is not None or config.modbus_unit_id is not None:
-                    raise ValueError(
-                        "connection is already bound to a unit address, so modbus_unit_id is "
-                        "ambiguous. Drop modbus_unit_id, or pass the bare transport instead of "
-                        "transport.at(...)."
-                    )
-                return connection
             case ModbusTransport():
-                address = ModbusDevice._resolved_unit_id(modbus_unit_id, config)
-                if address is None:
-                    raise ValueError(
-                        "A shared ModbusTransport needs a unit address: pass "
-                        "connection=transport.at(unit_id), or set modbus_unit_id on the "
-                        "constructor or in the config."
-                    )
-                return connection.at(address)
+                shared = True
+                transport = connection
             case dict():
                 # Pydantic owns the tcp/rtu dispatch and the bad-`transport` error; there is no
                 # hand-written branch on the "transport" key.
-                built: ModbusTransport = TypeAdapter(_ConnectionConfig).validate_python(connection).build()
-                return built.at(ModbusDevice._private_address(modbus_unit_id, config))
+                block: _ConnectionConfig = TypeAdapter(_ConnectionConfig).validate_python(connection)
+                transport = block.build()
+                connection_unit_id = block.unit_id
             case None if config.connection is not None:
-                built = config.connection.build()
-                return built.at(ModbusDevice._private_address(modbus_unit_id, config))
+                transport = config.connection.build()
+                connection_unit_id = config.connection.unit_id
             case _:
                 raise ValueError(
                     "No connection configuration provided. Either include a 'connection' section "
                     "in the config or pass a 'connection' argument to ModbusDevice()."
                 )
 
-    @staticmethod
-    def _resolved_unit_id(modbus_unit_id: int | None, config: ModbusConfig) -> int | None:
-        """Resolve the constructor kwarg against the config field; the kwarg wins, but a differing config value is a named error, not a silent override."""
-        if modbus_unit_id is not None and config.modbus_unit_id is not None and modbus_unit_id != config.modbus_unit_id:
+        candidates = {
+            "modbus_unit_id (constructor)": modbus_unit_id,
+            "modbus_unit_id (config)": config.modbus_unit_id,
+            "connection.unit_id": connection_unit_id,
+        }
+        given: dict[str, int] = {source: value for source, value in candidates.items() if value is not None}
+        if len(set(given.values())) > 1:
+            listed = ", ".join(f"{source}={value}" for source, value in given.items())
+            raise ValueError(f"Conflicting unit addresses: {listed}. Specify only one.")
+        if given:
+            unit_id = next(iter(given.values()))
+        elif shared:
             raise ValueError(
-                f"modbus_unit_id={modbus_unit_id} (constructor) conflicts with "
-                f"config.modbus_unit_id={config.modbus_unit_id} (config). Specify only one."
+                "A shared ModbusTransport needs an explicit unit address: pass modbus_unit_id "
+                "to the constructor or set it in the config."
             )
-        return modbus_unit_id if modbus_unit_id is not None else config.modbus_unit_id
-
-    @staticmethod
-    def _private_address(modbus_unit_id: int | None, config: ModbusConfig) -> int:
-        """Address for a transport this device built privately; defaults to 1 because nobody else can reach it."""
-        # `is not None` throughout: 0 is the broadcast address and must not be rewritten to 1.
-        resolved = ModbusDevice._resolved_unit_id(modbus_unit_id, config)
-        return resolved if resolved is not None else 1
+        else:
+            # `is not None` throughout: 0 is the broadcast address and must not be rewritten to 1.
+            # Defaulting is safe only here, on a transport nobody else can reach.
+            unit_id = 1
+        return transport, transport.check_unit_id(unit_id)
 
     @property
     def modbus_unit_id(self) -> int:
-        """Modbus unit/slave address this device is bound to. Read-only: set once at construction, via the constructor kwarg, the config field, or an already-bound ``ModbusUnit``."""
-        return self._modbus.unit_id
+        """Modbus unit/slave address this device is bound to. Read-only: set once at construction, via the constructor kwarg or the config."""
+        return self._modbus_unit_id
 
     def _require_ready_locked(self) -> None:
         """Reject I/O during shutdown, before this device opened, or before the transport is open."""
         if self._background_stop_event.is_set():
             raise RuntimeError("Instrument is shutting down.")
-        if not self._opened or not self._modbus.is_open:
+        if not self._opened or not self._transport.is_open:
             raise RuntimeError("Modbus client not connected. Call open() first.")
 
     # ============ Connection Management ============
@@ -173,7 +168,7 @@ class ModbusDevice(Instrument):
     def open(self) -> None:
         """Open the Modbus TCP/RTU connection, registering this device as an owner of the transport."""
         self._background_stop_event.clear()
-        self._modbus.open(self)
+        self._transport.open(self)
         self._opened = True
 
     def close(self) -> None:
@@ -181,7 +176,7 @@ class ModbusDevice(Instrument):
         self._background_stop_event.set()
         super().close()
         if self._opened:
-            self._modbus.close(self)
+            self._transport.close(self)
             self._opened = False
 
     # ============ Semantic Access (by alias) ============
@@ -190,12 +185,13 @@ class ModbusDevice(Instrument):
     def read(self, alias: str, **kwargs) -> Measurement:
         """Read the register named ``alias`` and return the scaled value."""
         reg = self._config.get_register(alias)
-        with self._modbus.lock():
+        with self._transport.lock():
             self._require_ready_locked()
-            raw_value = self._modbus.read_typed(
+            raw_value = self._transport.read_typed(
                 reg.register_type,
                 reg.starting_address,
                 reg.data_type,
+                unit_id=self._modbus_unit_id,
                 byte_swap=reg.byte_swap,
                 word_swap=reg.word_swap,
                 long_swap=reg.long_swap,
@@ -218,17 +214,23 @@ class ModbusDevice(Instrument):
         else:
             total_count = (last.starting_address + last.register_count) - start_address
 
-        with self._modbus.lock():
+        with self._transport.lock():
             self._require_ready_locked()
             match first.register_type:
                 case "holding":
-                    raw_regs = self._modbus.read_holding_registers(start_address, total_count)
+                    raw_regs = self._transport.read_holding_registers(
+                        start_address, total_count, unit_id=self._modbus_unit_id
+                    )
                 case "input":
-                    raw_regs = self._modbus.read_input_registers(start_address, total_count)
+                    raw_regs = self._transport.read_input_registers(
+                        start_address, total_count, unit_id=self._modbus_unit_id
+                    )
                 case "coil":
-                    raw_bits = self._modbus.read_coils(start_address, total_count)
+                    raw_bits = self._transport.read_coils(start_address, total_count, unit_id=self._modbus_unit_id)
                 case "discrete":
-                    raw_bits = self._modbus.read_discrete_inputs(start_address, total_count)
+                    raw_bits = self._transport.read_discrete_inputs(
+                        start_address, total_count, unit_id=self._modbus_unit_id
+                    )
                 case _:
                     raise ValueError(f"Unknown register type: {first.register_type}")
 
@@ -310,13 +312,14 @@ class ModbusDevice(Instrument):
         # already constrained the value to bool or 0/1, so coercing here is safe.
         wire_value = bool(raw_value) if reg.register_type == "coil" else raw_value
 
-        with self._modbus.lock():
+        with self._transport.lock():
             self._require_ready_locked()
-            self._modbus.write_typed(
+            self._transport.write_typed(
                 reg.register_type,
                 reg.starting_address,
                 wire_value,
                 reg.data_type,
+                unit_id=self._modbus_unit_id,
                 byte_swap=reg.byte_swap,
                 word_swap=reg.word_swap,
                 long_swap=reg.long_swap,

--- a/instro/modbus/types.py
+++ b/instro/modbus/types.py
@@ -352,7 +352,6 @@ class ModbusConfig(BaseModel):
     device: DeviceInfo
     timing: TimingConfig | None = None
     connection: _ConnectionConfig | None = None
-    unit_id: int | None = Field(default=None, ge=0, le=255)
     registers: list[RegisterDef] = Field(default_factory=list)
 
     def model_post_init(self, __context) -> None:

--- a/instro/modbus/types.py
+++ b/instro/modbus/types.py
@@ -38,18 +38,6 @@ __all__ = [
 
 # ============ Connection Config (private: the declarative path only) ============
 
-_UNIT_ID_MOVED = (
-    "unit_id has moved off the connection block and been renamed: set modbus_unit_id at "
-    "the top level of the config, or pass ModbusDevice(modbus_unit_id=...)"
-)
-
-
-def _reject_moved_unit_id(data: object) -> object:
-    """Reject a stale ``unit_id`` key inside a connection block, naming where it went."""
-    if isinstance(data, dict) and "unit_id" in data:
-        raise ValueError(_UNIT_ID_MOVED)
-    return data
-
 
 class _TCPConnectionConfig(BaseModel):
     """Declarative Modbus TCP connection block. Private: users construct ``ModbusTCPTransport`` directly."""
@@ -58,12 +46,7 @@ class _TCPConnectionConfig(BaseModel):
     host: str
     port: int = Field(default=502, ge=1, le=65535)
     timeout: float = Field(default=3.0, gt=0, description="Response timeout in seconds")
-
-    @model_validator(mode="before")
-    @classmethod
-    def _reject_unit_id(cls, data: object) -> object:
-        """Reject the pre-rename ``connection.unit_id`` key with a message naming its new home."""
-        return _reject_moved_unit_id(data)
+    unit_id: int | None = Field(default=None, ge=0, le=255)
 
     def build(self) -> ModbusTransport:
         """Build the transport this block describes."""
@@ -81,12 +64,8 @@ class _RTUConnectionConfig(BaseModel):
     bytesize: Literal[5, 6, 7, 8] = 8
     timeout: float = Field(default=3.0, gt=0, description="Response timeout in seconds")
     framer: Literal["rtu", "ascii"] = "rtu"
-
-    @model_validator(mode="before")
-    @classmethod
-    def _reject_unit_id(cls, data: object) -> object:
-        """Reject the pre-rename ``connection.unit_id`` key with a message naming its new home."""
-        return _reject_moved_unit_id(data)
+    # 248-255 are reserved per Modbus over Serial Line spec 2.2, so the serial block caps at 247.
+    unit_id: int | None = Field(default=None, ge=0, le=247)
 
     def build(self) -> ModbusTransport:
         """Build the transport this block describes."""

--- a/instro/modbus/types.py
+++ b/instro/modbus/types.py
@@ -352,7 +352,7 @@ class ModbusConfig(BaseModel):
     device: DeviceInfo
     timing: TimingConfig | None = None
     connection: _ConnectionConfig | None = None
-    modbus_unit_id: int | None = Field(default=None, ge=0, le=255)
+    unit_id: int | None = Field(default=None, ge=0, le=255)
     registers: list[RegisterDef] = Field(default_factory=list)
 
     def model_post_init(self, __context) -> None:

--- a/tests/lib/test_modbus_driver.py
+++ b/tests/lib/test_modbus_driver.py
@@ -1,4 +1,4 @@
-"""Tests for the Modbus transports and bound units against a simulated Modbus TCP server."""
+"""Tests for the Modbus transports against a simulated Modbus TCP server."""
 
 from __future__ import annotations
 
@@ -136,12 +136,6 @@ def bus(modbus_server):
     transport.close()
 
 
-@pytest.fixture
-def unit(bus):
-    """A ModbusUnit bound to the sim server's unit 1."""
-    return bus.at(1)
-
-
 # ============ Lifecycle ============
 
 
@@ -202,110 +196,110 @@ class TestLifecycle:
 
 
 class TestRawOps:
-    def test_read_holding_registers(self, unit):
-        assert unit.read_holding_registers(100, 1) == [TEST_DATA["holding_uint16"]]
+    def test_read_holding_registers(self, bus):
+        assert bus.read_holding_registers(100, 1, unit_id=1) == [TEST_DATA["holding_uint16"]]
 
-    def test_read_input_registers(self, unit):
-        assert unit.read_input_registers(0, 1) == [TEST_DATA["input_uint16"]]
+    def test_read_input_registers(self, bus):
+        assert bus.read_input_registers(0, 1, unit_id=1) == [TEST_DATA["input_uint16"]]
 
-    def test_read_coils(self, unit):
-        assert unit.read_coils(0, 2) == [TEST_DATA["coil_1"], TEST_DATA["coil_2"]]
+    def test_read_coils(self, bus):
+        assert bus.read_coils(0, 2, unit_id=1) == [TEST_DATA["coil_1"], TEST_DATA["coil_2"]]
 
-    def test_read_discrete_inputs(self, unit):
-        assert unit.read_discrete_inputs(0, 2) == [TEST_DATA["discrete_1"], TEST_DATA["discrete_2"]]
+    def test_read_discrete_inputs(self, bus):
+        assert bus.read_discrete_inputs(0, 2, unit_id=1) == [TEST_DATA["discrete_1"], TEST_DATA["discrete_2"]]
 
-    def test_write_holding_register_readback(self, unit):
-        unit.write_holding_register(150, 4242)
-        assert unit.read_holding_registers(150, 1) == [4242]
+    def test_write_holding_register_readback(self, bus):
+        bus.write_holding_register(150, 4242, unit_id=1)
+        assert bus.read_holding_registers(150, 1, unit_id=1) == [4242]
 
-    def test_write_holding_registers_readback(self, unit):
-        unit.write_holding_registers(160, [11, 22, 33])
-        assert unit.read_holding_registers(160, 3) == [11, 22, 33]
+    def test_write_holding_registers_readback(self, bus):
+        bus.write_holding_registers(160, [11, 22, 33], unit_id=1)
+        assert bus.read_holding_registers(160, 3, unit_id=1) == [11, 22, 33]
 
-    def test_write_coil_readback(self, unit):
-        unit.write_coil(5, True)
-        assert unit.read_coils(5, 1) == [True]
+    def test_write_coil_readback(self, bus):
+        bus.write_coil(5, True, unit_id=1)
+        assert bus.read_coils(5, 1, unit_id=1) == [True]
 
-    def test_write_coils_readback(self, unit):
-        unit.write_coils(6, [True, False, True])
-        assert unit.read_coils(6, 3) == [True, False, True]
+    def test_write_coils_readback(self, bus):
+        bus.write_coils(6, [True, False, True], unit_id=1)
+        assert bus.read_coils(6, 3, unit_id=1) == [True, False, True]
 
-    def test_read_beyond_datastore_raises_modbus_error(self, unit):
+    def test_read_beyond_datastore_raises_modbus_error(self, bus):
         # Valid Modbus address, but past the sim datastore -> device returns IllegalDataAddress.
         with pytest.raises(RuntimeError, match="Modbus error"):
-            unit.read_holding_registers(500, 1)
+            bus.read_holding_registers(500, 1, unit_id=1)
 
 
 # ============ Typed Access ============
 
 
 class TestTypedAccess:
-    def test_read_typed_input_uint16(self, unit):
-        assert unit.read_typed("input", 0, "uint16") == TEST_DATA["input_uint16"]
+    def test_read_typed_input_uint16(self, bus):
+        assert bus.read_typed("input", 0, "uint16", unit_id=1) == TEST_DATA["input_uint16"]
 
-    def test_read_typed_input_int16(self, unit):
-        assert unit.read_typed("input", 1, "int16") == TEST_DATA["input_int16"]
+    def test_read_typed_input_int16(self, bus):
+        assert bus.read_typed("input", 1, "int16", unit_id=1) == TEST_DATA["input_int16"]
 
-    def test_read_typed_input_uint32(self, unit):
-        assert unit.read_typed("input", 10, "uint32") == TEST_DATA["input_uint32"]
+    def test_read_typed_input_uint32(self, bus):
+        assert bus.read_typed("input", 10, "uint32", unit_id=1) == TEST_DATA["input_uint32"]
 
-    def test_read_typed_input_float32(self, unit):
-        assert unit.read_typed("input", 30, "float32") == pytest.approx(TEST_DATA["input_float32"], rel=1e-5)
+    def test_read_typed_input_float32(self, bus):
+        assert bus.read_typed("input", 30, "float32", unit_id=1) == pytest.approx(TEST_DATA["input_float32"], rel=1e-5)
 
-    def test_read_typed_input_float64(self, unit):
-        assert unit.read_typed("input", 40, "float64") == pytest.approx(TEST_DATA["input_float64"], rel=1e-10)
+    def test_read_typed_input_float64(self, bus):
+        assert bus.read_typed("input", 40, "float64", unit_id=1) == pytest.approx(TEST_DATA["input_float64"], rel=1e-10)
 
-    def test_read_typed_holding_word_swap(self, unit):
-        assert unit.read_typed("holding", 130, "uint32", word_swap=True) == TEST_DATA["holding_word_swap"]
+    def test_read_typed_holding_word_swap(self, bus):
+        assert bus.read_typed("holding", 130, "uint32", unit_id=1, word_swap=True) == TEST_DATA["holding_word_swap"]
 
-    def test_read_typed_coil_returns_bool(self, unit):
-        result = unit.read_typed("coil", 1, "bool")
+    def test_read_typed_coil_returns_bool(self, bus):
+        result = bus.read_typed("coil", 1, "bool", unit_id=1)
         assert result is True
 
-    def test_read_typed_discrete_returns_bool(self, unit):
-        result = unit.read_typed("discrete", 1, "bool")
+    def test_read_typed_discrete_returns_bool(self, bus):
+        result = bus.read_typed("discrete", 1, "bool", unit_id=1)
         assert result is False
 
-    def test_read_typed_coil_rejects_non_bool_dtype(self, unit):
+    def test_read_typed_coil_rejects_non_bool_dtype(self, bus):
         with pytest.raises(ValueError, match="single-bit; data_type must be 'bool'"):
-            unit.read_typed("coil", 1, "uint16")
+            bus.read_typed("coil", 1, "uint16", unit_id=1)
 
-    def test_read_typed_discrete_rejects_non_bool_dtype(self, unit):
+    def test_read_typed_discrete_rejects_non_bool_dtype(self, bus):
         with pytest.raises(ValueError, match="single-bit; data_type must be 'bool'"):
-            unit.read_typed("discrete", 1, "uint16")
+            bus.read_typed("discrete", 1, "uint16", unit_id=1)
 
-    def test_read_typed_unknown_register_type_raises(self, unit):
+    def test_read_typed_unknown_register_type_raises(self, bus):
         with pytest.raises(ValueError, match="Unknown register type"):
-            unit.read_typed("bogus", 0, "uint16")
+            bus.read_typed("bogus", 0, "uint16", unit_id=1)
 
-    def test_write_typed_holding_single_register_readback(self, unit):
-        unit.write_typed("holding", 170, 4321, "uint16")
-        assert unit.read_typed("holding", 170, "uint16") == 4321
+    def test_write_typed_holding_single_register_readback(self, bus):
+        bus.write_typed("holding", 170, 4321, "uint16", unit_id=1)
+        assert bus.read_typed("holding", 170, "uint16", unit_id=1) == 4321
 
-    def test_write_typed_holding_multi_register_readback(self, unit):
-        unit.write_typed("holding", 172, -123456789, "int32")
-        assert unit.read_typed("holding", 172, "int32") == -123456789
+    def test_write_typed_holding_multi_register_readback(self, bus):
+        bus.write_typed("holding", 172, -123456789, "int32", unit_id=1)
+        assert bus.read_typed("holding", 172, "int32", unit_id=1) == -123456789
 
-    def test_write_typed_holding_float_roundtrip(self, unit):
-        unit.write_typed("holding", 176, 3.14159, "float32")
-        assert unit.read_typed("holding", 176, "float32") == pytest.approx(3.14159, rel=1e-5)
+    def test_write_typed_holding_float_roundtrip(self, bus):
+        bus.write_typed("holding", 176, 3.14159, "float32", unit_id=1)
+        assert bus.read_typed("holding", 176, "float32", unit_id=1) == pytest.approx(3.14159, rel=1e-5)
 
-    def test_write_typed_coil_readback(self, unit):
-        unit.write_typed("coil", 8, True, "bool")
-        assert unit.read_typed("coil", 8, "bool") is True
+    def test_write_typed_coil_readback(self, bus):
+        bus.write_typed("coil", 8, True, "bool", unit_id=1)
+        assert bus.read_typed("coil", 8, "bool", unit_id=1) is True
 
-    def test_write_typed_coil_rejects_non_bool_dtype(self, unit):
+    def test_write_typed_coil_rejects_non_bool_dtype(self, bus):
         with pytest.raises(ValueError, match="single-bit; data_type must be 'bool'"):
-            unit.write_typed("coil", 8, True, "uint16")
+            bus.write_typed("coil", 8, True, "uint16", unit_id=1)
 
-    def test_write_typed_coil_rejects_non_bool_value(self, unit):
+    def test_write_typed_coil_rejects_non_bool_value(self, bus):
         # Strict: no numeric coercion. Even 1/0 must be passed as real booleans.
         with pytest.raises(ValueError, match="coil writes require a bool value"):
-            unit.write_typed("coil", 8, 1, "bool")
+            bus.write_typed("coil", 8, 1, "bool", unit_id=1)
 
-    def test_write_typed_read_only_raises(self, unit):
+    def test_write_typed_read_only_raises(self, bus):
         with pytest.raises(ValueError, match="read-only"):
-            unit.write_typed("input", 0, 1, "uint16")
+            bus.write_typed("input", 0, 1, "uint16", unit_id=1)
 
 
 # ============ Pure Codec ============
@@ -383,13 +377,13 @@ class TestCodec:
 
 
 class TestLock:
-    def test_lock_is_reentrant_and_serializes_ops(self, unit):
+    def test_lock_is_reentrant_and_serializes_ops(self, bus):
         # Holding the lock lets the same thread issue ops inside the with-block (RLock).
-        with unit.lock():
-            assert unit.read_holding_registers(100, 1) == [TEST_DATA["holding_uint16"]]
+        with bus.lock():
+            assert bus.read_holding_registers(100, 1, unit_id=1) == [TEST_DATA["holding_uint16"]]
 
-    def test_lock_returns_same_object(self, unit):
-        assert unit.lock() is unit.lock()
+    def test_lock_returns_same_object(self, bus):
+        assert bus.lock() is bus.lock()
 
 
 # ============ Shared Ownership ============
@@ -451,7 +445,7 @@ class TestSharedOwnership:
         transport.close(a)
 
 
-# ============ ModbusTransport / ModbusUnit ============
+# ============ ModbusTransport ============
 
 
 class TestTransportConstruction:
@@ -544,74 +538,26 @@ class TestPerCallAddressing:
             transport.read_holding_registers(100, 1, unit_id=1)
 
 
-class TestBoundUnit:
-    def test_at_binds_an_address_that_routes(self, bus):
-        assert bus.at(1).read_holding_registers(100, 1) == [TEST_DATA["holding_uint16"]]
-        assert bus.at(SECOND_UNIT).read_holding_registers(100, 1) == [SECOND_UNIT_HOLDING]
-
-    def test_two_bound_units_share_one_transport(self, bus):
-        first, second = bus.at(1), bus.at(SECOND_UNIT)
-        assert first.transport is second.transport is bus
-        assert first.lock() is bus.lock()
-
-    def test_at_exposes_its_binding(self, bus):
-        unit = bus.at(7)
-        assert (unit.transport, unit.unit_id) == (bus, 7)
-
+class TestUnitIdValidation:
     @pytest.mark.parametrize("unit_id", [-1, 256])
-    def test_at_rejects_out_of_range(self, unit_id):
+    def test_check_unit_id_rejects_out_of_range(self, unit_id):
         with pytest.raises(ValueError, match="unit_id"):
-            ModbusTCPTransport(host="h").at(unit_id)
+            ModbusTCPTransport(host="h").check_unit_id(unit_id)
 
     @pytest.mark.parametrize("unit_id", [248, 255])
-    def test_rtu_at_rejects_reserved_addresses(self, unit_id):
+    def test_rtu_rejects_reserved_addresses(self, unit_id):
         # Modbus over Serial Line spec 2.2: 248-255 are reserved, not individual slave addresses.
         with pytest.raises(ValueError, match="unit_id"):
-            ModbusRTUTransport(port="/dev/ttyUSB0").at(unit_id)
+            ModbusRTUTransport(port="/dev/ttyUSB0").check_unit_id(unit_id)
 
     @pytest.mark.parametrize("unit_id", [0, 247])
-    def test_rtu_at_accepts_boundary_addresses(self, unit_id):
-        assert ModbusRTUTransport(port="/dev/ttyUSB0").at(unit_id).unit_id == unit_id
+    def test_rtu_accepts_boundary_addresses(self, unit_id):
+        assert ModbusRTUTransport(port="/dev/ttyUSB0").check_unit_id(unit_id) == unit_id
 
-    def test_bound_unit_refuses_a_second_address(self, bus):
-        with pytest.raises(TypeError):
-            bus.at(1).read_holding_registers(100, 1, unit_id=SECOND_UNIT)  # type: ignore[call-arg]
-
-    def test_bound_unit_typed_roundtrip(self, bus):
-        unit = bus.at(1)
-        unit.write_typed("holding", 180, 3.14159, "float32")
-        assert unit.read_typed("holding", 180, "float32") == pytest.approx(3.14159, rel=1e-5)
-
-    def test_bound_unit_writes_reach_only_its_own_unit(self, bus):
-        bus.at(SECOND_UNIT).write_holding_register(101, 777)
-        assert bus.at(SECOND_UNIT).read_holding_registers(101, 1) == [777]
-        assert bus.at(1).read_holding_registers(101, 1) == [0]
-
-    def test_bound_unit_passes_holder_identity_through(self, modbus_server):
-        transport = ModbusTCPTransport(host="127.0.0.1", port=TEST_PORT)
-        first, second = transport.at(1), transport.at(SECOND_UNIT)
-        holder_a, holder_b = object(), object()
-
-        assert first.open(holder_a) is True
-        assert second.open(holder_b) is False  # the session was already up
-        assert transport.is_open and first.is_open
-
-        first.close(holder_a)
-        assert transport.is_open  # holder_b still owns it
-
-        second.close(holder_b)
-        assert not transport.is_open
-
-    def test_a_rebound_unit_does_not_strand_a_holder(self, modbus_server):
-        # Reassigning an address builds a new ModbusUnit; because the unit forwards the
-        # caller's identity rather than its own, the original holder still closes the session.
-        transport = ModbusTCPTransport(host="127.0.0.1", port=TEST_PORT)
-        holder = object()
-        transport.at(1).open(holder)
-
-        transport.at(SECOND_UNIT).close(holder)
-
-        assert not transport.is_open
+    def test_writes_reach_only_the_addressed_unit(self, bus):
+        bus.write_holding_register(101, 777, unit_id=SECOND_UNIT)
+        assert bus.read_holding_registers(101, 1, unit_id=SECOND_UNIT) == [777]
+        assert bus.read_holding_registers(101, 1, unit_id=1) == [0]
 
 
 class TestTransportConnect:
@@ -648,15 +594,15 @@ class TestTransportConnect:
             )
             transport.close()
 
-    def test_rtu_opens_one_serial_client_across_two_bound_units(self):
+    def test_rtu_opens_one_serial_client_across_two_holders(self):
         # pymodbus opens serial exclusive=True, so a second construction is the bug this fixes.
         with patch("instro.lib.transports.modbus.ModbusSerialClient") as mock_cls:
             mock_cls.return_value.connect.return_value = True
             transport = ModbusRTUTransport(port="/dev/ttyUSB0")
             holder_a, holder_b = object(), object()
 
-            transport.at(3).open(holder_a)
-            transport.at(7).open(holder_b)
+            transport.open(holder_a)
+            transport.open(holder_b)
 
             assert mock_cls.call_count == 1
             transport.close(holder_a)

--- a/tests/modbus/configs/test_config_types.json
+++ b/tests/modbus/configs/test_config_types.json
@@ -12,7 +12,7 @@
     "host": "127.0.0.1",
     "port": 5021
   },
-  "modbus_unit_id": 1,
+  "unit_id": 1,
   "timing": {
     "poll_interval": 0.5,
     "write_delay_ms": 50

--- a/tests/modbus/configs/test_config_types.json
+++ b/tests/modbus/configs/test_config_types.json
@@ -10,9 +10,9 @@
   "connection": {
     "transport": "tcp",
     "host": "127.0.0.1",
-    "port": 5021
+    "port": 5021,
+    "unit_id": 1
   },
-  "unit_id": 1,
   "timing": {
     "poll_interval": 0.5,
     "write_delay_ms": 50

--- a/tests/modbus/configs/test_readwrite_device.json
+++ b/tests/modbus/configs/test_readwrite_device.json
@@ -8,7 +8,8 @@
   "connection": {
     "transport": "tcp",
     "host": "127.0.0.1",
-    "port": 5022
+    "port": 5022,
+    "unit_id": 1
   },
   "registers": [
     { "name": "input_uint16",  "starting_address": 0,  "register_type": "input",   "data_type": "uint16" },

--- a/tests/modbus/test_modbus_autostart.py
+++ b/tests/modbus/test_modbus_autostart.py
@@ -97,7 +97,7 @@ class TestAutostart:
         )
         dev = ModbusDevice(config=config, autostart=True)
         try:
-            assert dev._modbus.is_open  # open() ran
+            assert dev._transport.is_open  # open() ran
         finally:
             dev.close()
 
@@ -111,6 +111,6 @@ class TestAutostart:
         )
         dev = ModbusDevice(config=config)
         try:
-            assert not dev._modbus.is_open
+            assert not dev._transport.is_open
         finally:
             dev.close()

--- a/tests/modbus/test_modbus_config_types.py
+++ b/tests/modbus/test_modbus_config_types.py
@@ -77,6 +77,14 @@ class TestConnectionDiscriminator:
         config = ModbusConfig(device=DeviceInfo(name="no_conn"))
         assert config.connection is None
 
+    def test_connection_unit_id_accepted(self):
+        assert _TCPConnectionConfig(host="127.0.0.1", unit_id=5).unit_id == 5
+
+    def test_rtu_connection_rejects_reserved_unit_id(self):
+        # Modbus over Serial Line spec 2.2: 248-255 are reserved, not individual slave addresses.
+        with pytest.raises(ValidationError):
+            _RTUConnectionConfig(port="/dev/ttyUSB0", unit_id=248)
+
     def test_rtu_build_passes_framer_through(self):
         with patch("instro.lib.transports.modbus.ModbusSerialClient") as mock_cls:
             mock_cls.return_value.connect.return_value = True

--- a/tests/modbus/test_modbus_shared_bus.py
+++ b/tests/modbus/test_modbus_shared_bus.py
@@ -1,9 +1,9 @@
 """Feature test: two ModbusDevices share one transport, each with its own unit address (GH #262).
 
 Encodes the primary user story end-to-end: construct one ModbusTCPTransport, pass it to several
-devices each with its own ``modbus_unit_id``, and have each read and write only its own unit over
+devices each with its own ``unit_id``, and have each read and write only its own unit over
 the one session — surviving the first device's close and released by the last. Also pins the shape
-the addresses now live in: no unit_id on a transport, ``modbus_unit_id`` on the device (with the
+the addresses now live in: no unit_id on a transport, ``unit_id`` on the device (with the
 pre-existing ``connection.unit_id`` config key still accepted), and no
 ModbusDriver/TCPConnection/RTUConnection. A second, narrow scenario proves the same one-session
 invariant on the serial path with a mocked pymodbus client, since CI has no RS-485 line.
@@ -111,10 +111,9 @@ def test_two_devices_share_one_connection(two_unit_server):
 
     shared_bus = ModbusTCPTransport(host=HOST, port=TEST_PORT)
     assert not hasattr(shared_bus, "unit_id")
-    assert not hasattr(shared_bus, "modbus_unit_id")
 
     # A shared transport with no address is an error, never a silent unit 1.
-    with pytest.raises(ValueError, match="modbus_unit_id"):
+    with pytest.raises(ValueError, match="unit_id"):
         ModbusDevice(config=DEVICE_CONFIG, connection=shared_bus, name="unaddressed")
 
     # Disagreeing addresses from two sources are a named error, never a silent pick.
@@ -123,17 +122,17 @@ def test_two_devices_share_one_connection(two_unit_server):
             config=DEVICE_CONFIG,
             connection={"transport": "tcp", "host": HOST, "port": TEST_PORT, "unit_id": FLOW_UNIT},
             name="doubly_addressed",
-            modbus_unit_id=PUMP_UNIT,
+            unit_id=PUMP_UNIT,
         )
 
-    flow_meter = ModbusDevice(config=DEVICE_CONFIG, connection=shared_bus, modbus_unit_id=FLOW_UNIT, name="flow_meter")
-    pump = ModbusDevice(config=DEVICE_CONFIG, connection=shared_bus, modbus_unit_id=PUMP_UNIT, name="pump")
+    flow_meter = ModbusDevice(config=DEVICE_CONFIG, connection=shared_bus, unit_id=FLOW_UNIT, name="flow_meter")
+    pump = ModbusDevice(config=DEVICE_CONFIG, connection=shared_bus, unit_id=PUMP_UNIT, name="pump")
 
     flow_meter.open()
     pump.open()
 
     assert shared_bus.is_open
-    assert (flow_meter.modbus_unit_id, pump.modbus_unit_id) == (FLOW_UNIT, PUMP_UNIT)
+    assert (flow_meter.unit_id, pump.unit_id) == (FLOW_UNIT, PUMP_UNIT)
 
     # Required per call on the transport, on an open session: omission is a TypeError, never unit 1.
     with pytest.raises(TypeError):
@@ -161,7 +160,7 @@ def test_two_devices_share_one_connection(two_unit_server):
         config=DEVICE_CONFIG,
         connection={"transport": "tcp", "host": HOST, "port": TEST_PORT},
         name="solo",
-        modbus_unit_id=FLOW_UNIT,
+        unit_id=FLOW_UNIT,
     )
     solo.open()
     assert solo.read("setpoint").latest == FLOW_VALUE
@@ -170,13 +169,13 @@ def test_two_devices_share_one_connection(two_unit_server):
 
 def test_pre_rename_connection_unit_id_still_works(two_unit_server):
     # Regression gate for existing configs: the connection-block unit_id predates the
-    # top-level modbus_unit_id field and must keep loading and routing, not raise.
+    # top-level unit_id field and must keep loading and routing, not raise.
     legacy = ModbusDevice(
         config=DEVICE_CONFIG,
         connection={"transport": "tcp", "host": HOST, "port": TEST_PORT, "unit_id": PUMP_UNIT},
         name="legacy",
     )
-    assert legacy.modbus_unit_id == PUMP_UNIT
+    assert legacy.unit_id == PUMP_UNIT
     legacy.open()
     legacy.write("setpoint", 3333)
     assert legacy.read("setpoint").latest == 3333
@@ -187,37 +186,37 @@ def test_pre_rename_connection_unit_id_still_works(two_unit_server):
         "connection": {"transport": "tcp", "host": HOST, "port": TEST_PORT, "unit_id": FLOW_UNIT},
     }
     from_config = ModbusDevice(config=config_with_nested, name="legacy_config")
-    assert from_config.modbus_unit_id == FLOW_UNIT
+    assert from_config.unit_id == FLOW_UNIT
     from_config.open()
     # The nested address routes: this device sees the flow unit, not the 3333 just written at pump.
     assert from_config.read("setpoint").latest != 3333
     from_config.close()
 
 
-def test_modbus_unit_id_conflict_between_constructor_and_config_is_rejected(two_unit_server):
-    config_with_address = {**DEVICE_CONFIG, "modbus_unit_id": FLOW_UNIT}
+def test_unit_id_conflict_between_constructor_and_config_is_rejected(two_unit_server):
+    config_with_address = {**DEVICE_CONFIG, "unit_id": FLOW_UNIT}
     connection = {"transport": "tcp", "host": HOST, "port": TEST_PORT}
 
     # Constructor kwarg disagrees with the config field: a named error, not a silent override.
-    with pytest.raises(ValueError, match="modbus_unit_id"):
-        ModbusDevice(config=config_with_address, connection=connection, modbus_unit_id=PUMP_UNIT)
+    with pytest.raises(ValueError, match="unit_id"):
+        ModbusDevice(config=config_with_address, connection=connection, unit_id=PUMP_UNIT)
 
     # Agreeing values are not a conflict.
-    device = ModbusDevice(config=config_with_address, connection=connection, modbus_unit_id=FLOW_UNIT)
-    assert device.modbus_unit_id == FLOW_UNIT
+    device = ModbusDevice(config=config_with_address, connection=connection, unit_id=FLOW_UNIT)
+    assert device.unit_id == FLOW_UNIT
 
 
-def test_modbus_unit_id_is_read_only(two_unit_server):
+def test_unit_id_is_read_only(two_unit_server):
     # No public setter at all: the address is bound once at construction (constructor kwarg
     # or config) and never reassignable afterward, open or closed. Reassigning it, even to
     # redirect a live/polling connection, is not an API this class offers, rather than an
     # error path within one.
     shared_bus = ModbusTCPTransport(host=HOST, port=TEST_PORT)
-    device = ModbusDevice(config=DEVICE_CONFIG, connection=shared_bus, modbus_unit_id=FLOW_UNIT, name="reassign_check")
+    device = ModbusDevice(config=DEVICE_CONFIG, connection=shared_bus, unit_id=FLOW_UNIT, name="reassign_check")
 
     with pytest.raises(AttributeError):
-        device.modbus_unit_id = PUMP_UNIT
-    assert device.modbus_unit_id == FLOW_UNIT
+        device.unit_id = PUMP_UNIT
+    assert device.unit_id == FLOW_UNIT
 
 
 def test_two_devices_share_one_serial_port():
@@ -229,8 +228,8 @@ def test_two_devices_share_one_serial_port():
         serial_client.return_value.connect.return_value = True
 
         bus = ModbusRTUTransport(port="/dev/ttyUSB0", baudrate=19200)
-        flow = ModbusDevice(config=DEVICE_CONFIG, connection=bus, modbus_unit_id=FLOW_UNIT, name="flow_meter")
-        pump = ModbusDevice(config=DEVICE_CONFIG, connection=bus, modbus_unit_id=PUMP_UNIT, name="pump")
+        flow = ModbusDevice(config=DEVICE_CONFIG, connection=bus, unit_id=FLOW_UNIT, name="flow_meter")
+        pump = ModbusDevice(config=DEVICE_CONFIG, connection=bus, unit_id=PUMP_UNIT, name="pump")
 
         flow.open()
         pump.open()

--- a/tests/modbus/test_modbus_shared_bus.py
+++ b/tests/modbus/test_modbus_shared_bus.py
@@ -1,9 +1,10 @@
-"""Feature test: two ModbusDevices share one transport, each bound to its own unit via at() (GH #262).
+"""Feature test: two ModbusDevices share one transport, each with its own unit address (GH #262).
 
-Encodes the primary user story end-to-end: construct one ModbusTCPTransport, bind an address to it
-per device with ``bus.at(...)``, and have each read and write only its own unit over the one session
-— surviving the first device's close and released by the last. Also pins the shape the addresses now
-live in: no unit_id on a transport, ``modbus_unit_id`` on the device, and no
+Encodes the primary user story end-to-end: construct one ModbusTCPTransport, pass it to several
+devices each with its own ``modbus_unit_id``, and have each read and write only its own unit over
+the one session — surviving the first device's close and released by the last. Also pins the shape
+the addresses now live in: no unit_id on a transport, ``modbus_unit_id`` on the device (with the
+pre-existing ``connection.unit_id`` config key still accepted), and no
 ModbusDriver/TCPConnection/RTUConnection. A second, narrow scenario proves the same one-session
 invariant on the serial path with a mocked pymodbus client, since CI has no RS-485 line.
 Fails until the transport classes exist.
@@ -15,7 +16,6 @@ import time
 from unittest.mock import patch
 
 import pytest
-from pydantic import ValidationError
 from pymodbus.datastore import (
     ModbusDeviceContext,
     ModbusSequentialDataBlock,
@@ -100,8 +100,8 @@ def two_unit_server():
     thread.join(timeout=2.0)
 
 
-def test_two_devices_share_one_connection_bound_by_at(two_unit_server):
-    for retired in ("ModbusDriver", "TCPConnection", "RTUConnection", "ConnectionType"):
+def test_two_devices_share_one_connection(two_unit_server):
+    for retired in ("ModbusDriver", "TCPConnection", "RTUConnection", "ConnectionType", "ModbusUnit"):
         assert not hasattr(modbus_transport, retired)
     for retired in ("TCPConnection", "RTUConnection"):
         assert not hasattr(modbus_package, retired)
@@ -113,30 +113,21 @@ def test_two_devices_share_one_connection_bound_by_at(two_unit_server):
     assert not hasattr(shared_bus, "unit_id")
     assert not hasattr(shared_bus, "modbus_unit_id")
 
-    # A stale connection-block unit_id must name where it moved, not just fail as an extra key.
-    with pytest.raises(ValidationError, match="moved") as stale:
-        ModbusDevice(
-            config=DEVICE_CONFIG,
-            connection={"transport": "tcp", "host": HOST, "port": TEST_PORT, "unit_id": 5},
-        )
-    assert "modbus_unit_id" in str(stale.value)
-
-    # A bare (possibly shared) transport with no address is an error, never a silent unit 1.
-    # ValidationError subclasses ValueError, so match= is what makes this a "named error" gate.
+    # A shared transport with no address is an error, never a silent unit 1.
     with pytest.raises(ValueError, match="modbus_unit_id"):
         ModbusDevice(config=DEVICE_CONFIG, connection=shared_bus, name="unaddressed")
 
-    # Binding the address twice over is ambiguous about which one wins.
-    with pytest.raises(ValueError, match="modbus_unit_id"):
+    # Disagreeing addresses from two sources are a named error, never a silent pick.
+    with pytest.raises(ValueError, match="unit"):
         ModbusDevice(
             config=DEVICE_CONFIG,
-            connection=shared_bus.at(FLOW_UNIT),
+            connection={"transport": "tcp", "host": HOST, "port": TEST_PORT, "unit_id": FLOW_UNIT},
             name="doubly_addressed",
             modbus_unit_id=PUMP_UNIT,
         )
 
-    flow_meter = ModbusDevice(config=DEVICE_CONFIG, connection=shared_bus.at(FLOW_UNIT), name="flow_meter")
-    pump = ModbusDevice(config=DEVICE_CONFIG, connection=shared_bus.at(PUMP_UNIT), name="pump")
+    flow_meter = ModbusDevice(config=DEVICE_CONFIG, connection=shared_bus, modbus_unit_id=FLOW_UNIT, name="flow_meter")
+    pump = ModbusDevice(config=DEVICE_CONFIG, connection=shared_bus, modbus_unit_id=PUMP_UNIT, name="pump")
 
     flow_meter.open()
     pump.open()
@@ -149,12 +140,6 @@ def test_two_devices_share_one_connection_bound_by_at(two_unit_server):
         shared_bus.read_holding_registers(SETPOINT_ADDRESS, 1)
     with pytest.raises(TypeError):
         shared_bus.read_typed("holding", SETPOINT_ADDRESS, "uint16")
-
-    # A bound unit carries its address and refuses a second one.
-    bound_flow = shared_bus.at(FLOW_UNIT)
-    assert bound_flow.read_holding_registers(SETPOINT_ADDRESS, 1) == [FLOW_VALUE]
-    with pytest.raises(TypeError):
-        bound_flow.read_holding_registers(SETPOINT_ADDRESS, 1, unit_id=PUMP_UNIT)
 
     assert flow_meter.read("setpoint").latest == FLOW_VALUE
     assert pump.read("setpoint").latest == PUMP_VALUE
@@ -171,7 +156,7 @@ def test_two_devices_share_one_connection_bound_by_at(two_unit_server):
     pump.close()
     assert not shared_bus.is_open
 
-    # A device that builds its own private transport may default to unit 1's stand-in address.
+    # A device that builds its own private transport may take its address from the constructor.
     solo = ModbusDevice(
         config=DEVICE_CONFIG,
         connection={"transport": "tcp", "host": HOST, "port": TEST_PORT},
@@ -181,6 +166,32 @@ def test_two_devices_share_one_connection_bound_by_at(two_unit_server):
     solo.open()
     assert solo.read("setpoint").latest == FLOW_VALUE
     solo.close()
+
+
+def test_pre_rename_connection_unit_id_still_works(two_unit_server):
+    # Regression gate for existing configs: the connection-block unit_id predates the
+    # top-level modbus_unit_id field and must keep loading and routing, not raise.
+    legacy = ModbusDevice(
+        config=DEVICE_CONFIG,
+        connection={"transport": "tcp", "host": HOST, "port": TEST_PORT, "unit_id": PUMP_UNIT},
+        name="legacy",
+    )
+    assert legacy.modbus_unit_id == PUMP_UNIT
+    legacy.open()
+    legacy.write("setpoint", 3333)
+    assert legacy.read("setpoint").latest == 3333
+    legacy.close()
+
+    config_with_nested = {
+        **DEVICE_CONFIG,
+        "connection": {"transport": "tcp", "host": HOST, "port": TEST_PORT, "unit_id": FLOW_UNIT},
+    }
+    from_config = ModbusDevice(config=config_with_nested, name="legacy_config")
+    assert from_config.modbus_unit_id == FLOW_UNIT
+    from_config.open()
+    # The nested address routes: this device sees the flow unit, not the 3333 just written at pump.
+    assert from_config.read("setpoint").latest != 3333
+    from_config.close()
 
 
 def test_modbus_unit_id_conflict_between_constructor_and_config_is_rejected(two_unit_server):
@@ -197,12 +208,12 @@ def test_modbus_unit_id_conflict_between_constructor_and_config_is_rejected(two_
 
 
 def test_modbus_unit_id_is_read_only(two_unit_server):
-    # No public setter at all: the address is bound once at construction (constructor kwarg,
-    # config field, or an already-bound ModbusUnit) and never reassignable afterward, open or
-    # closed. Reassigning it, even to redirect a live/polling connection, is not an API this
-    # class offers, rather than an error path within one.
+    # No public setter at all: the address is bound once at construction (constructor kwarg
+    # or config) and never reassignable afterward, open or closed. Reassigning it, even to
+    # redirect a live/polling connection, is not an API this class offers, rather than an
+    # error path within one.
     shared_bus = ModbusTCPTransport(host=HOST, port=TEST_PORT)
-    device = ModbusDevice(config=DEVICE_CONFIG, connection=shared_bus.at(FLOW_UNIT), name="reassign_check")
+    device = ModbusDevice(config=DEVICE_CONFIG, connection=shared_bus, modbus_unit_id=FLOW_UNIT, name="reassign_check")
 
     with pytest.raises(AttributeError):
         device.modbus_unit_id = PUMP_UNIT
@@ -218,8 +229,8 @@ def test_two_devices_share_one_serial_port():
         serial_client.return_value.connect.return_value = True
 
         bus = ModbusRTUTransport(port="/dev/ttyUSB0", baudrate=19200)
-        flow = ModbusDevice(config=DEVICE_CONFIG, connection=bus.at(FLOW_UNIT), name="flow_meter")
-        pump = ModbusDevice(config=DEVICE_CONFIG, connection=bus.at(PUMP_UNIT), name="pump")
+        flow = ModbusDevice(config=DEVICE_CONFIG, connection=bus, modbus_unit_id=FLOW_UNIT, name="flow_meter")
+        pump = ModbusDevice(config=DEVICE_CONFIG, connection=bus, modbus_unit_id=PUMP_UNIT, name="pump")
 
         flow.open()
         pump.open()

--- a/tests/modbus/test_modbus_shared_bus.py
+++ b/tests/modbus/test_modbus_shared_bus.py
@@ -3,9 +3,8 @@
 Encodes the primary user story end-to-end: construct one ModbusTCPTransport, pass it to several
 devices each with its own ``unit_id``, and have each read and write only its own unit over
 the one session — surviving the first device's close and released by the last. Also pins the shape
-the addresses now live in: no unit_id on a transport, ``unit_id`` on the device (with the
-pre-existing ``connection.unit_id`` config key still accepted), and no
-ModbusDriver/TCPConnection/RTUConnection. A second, narrow scenario proves the same one-session
+the addresses live in: no unit_id on a transport, ``unit_id`` on the device (from the constructor
+kwarg or the config's ``connection.unit_id``), and no ModbusDriver/TCPConnection/RTUConnection. A second, narrow scenario proves the same one-session
 invariant on the serial path with a mocked pymodbus client, since CI has no RS-485 line.
 Fails until the transport classes exist.
 """
@@ -167,9 +166,9 @@ def test_two_devices_share_one_connection(two_unit_server):
     solo.close()
 
 
-def test_pre_rename_connection_unit_id_still_works(two_unit_server):
-    # Regression gate for existing configs: the connection-block unit_id predates the
-    # top-level unit_id field and must keep loading and routing, not raise.
+def test_connection_block_unit_id_addresses_the_device(two_unit_server):
+    # Regression gate for existing configs: connection.unit_id is the canonical config
+    # location for the address and must keep loading and routing, not raise.
     legacy = ModbusDevice(
         config=DEVICE_CONFIG,
         connection={"transport": "tcp", "host": HOST, "port": TEST_PORT, "unit_id": PUMP_UNIT},
@@ -194,15 +193,18 @@ def test_pre_rename_connection_unit_id_still_works(two_unit_server):
 
 
 def test_unit_id_conflict_between_constructor_and_config_is_rejected(two_unit_server):
-    config_with_address = {**DEVICE_CONFIG, "unit_id": FLOW_UNIT}
-    connection = {"transport": "tcp", "host": HOST, "port": TEST_PORT}
+    config_with_address = {
+        **DEVICE_CONFIG,
+        "connection": {"transport": "tcp", "host": HOST, "port": TEST_PORT, "unit_id": FLOW_UNIT},
+    }
 
-    # Constructor kwarg disagrees with the config field: a named error, not a silent override.
+    # Constructor kwarg disagrees with the config's connection block: a named error, not a
+    # silent override.
     with pytest.raises(ValueError, match="unit_id"):
-        ModbusDevice(config=config_with_address, connection=connection, unit_id=PUMP_UNIT)
+        ModbusDevice(config=config_with_address, unit_id=PUMP_UNIT)
 
     # Agreeing values are not a conflict.
-    device = ModbusDevice(config=config_with_address, connection=connection, unit_id=FLOW_UNIT)
+    device = ModbusDevice(config=config_with_address, unit_id=FLOW_UNIT)
     assert device.unit_id == FLOW_UNIT
 
 


### PR DESCRIPTION
@
## Summary

Simplifies the #409 shared-bus API and removes its config break. `ModbusUnit`/`.at()` added a ~110-line forwarding wrapper and three competing address sources whose arbitration needed three helpers and four error paths; the moved-key validator also broke every existing config using `connection.unit_id`. This drops `ModbusUnit` entirely (the device stores `unit_id` and passes it per wire op; `check_unit_id()` keeps the 0-255/0-247 range validation), collapses connection resolution to transport/dict/config-block plus one guard (a shared transport requires an explicit address), keeps `connection.unit_id` as the one config location for the address exactly as released configs already write it (a conflicting constructor value raises), and names the address `unit_id` across the whole surface: constructor kwarg, read-only property, config field, and transport wire ops.

Shared-bus usage becomes: `ModbusDevice(config=..., connection=transport, unit_id=2)`.

Refs #409, #262

## Type of change

- [X] Refactor (`refactor`)

## Verification

`just check-python` clean; full suite passes (1852 passed). New regression test `test_connection_block_unit_id_addresses_the_device` pins the `connection.unit_id` path end-to-end against the sim server, and `tests/modbus/configs/test_readwrite_device.json` keeps the nested form so an integration test exercises it.

## Tests

- [X] Unit tests added or updated

## Checklist

- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(driver): add support for Keysight E36300`)
- [X] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [X] Documentation updated if user-facing behavior changed
- [X] Code follows the style/conventions of the surrounding code

## Notes for reviewers

Based on the #409 branch so the diff shows only the simplification. If accepted, merge this into #409 (or retarget this PR to main and close #409). The transport stays address-blind: two devices explicitly claiming the same unit_id on one transport are not detected, same as `.at()` allowed.
@