### PR TITLE
feat(psu): implement get_voltage_setpoint and get_current_setpoint for SimulatedPSU

### DIFF
--- a/instro/psu/drivers/simulated.py
+++ b/instro/psu/drivers/simulated.py
@@ -38,6 +38,12 @@ class SimulatedPSU(PSUDriverBase):
             self._check_errors()
         return resp.strip() == "1"
 
+    def get_voltage_setpoint(self, channel: int) -> float:
+        return self._query_checked_float(f":SOUR{channel}:VOLT?")
+
+    def get_current_setpoint(self, channel: int) -> float:
+        return self._query_checked_float(f":SOUR{channel}:CURR?")
+
     def set_overvoltage_protection_level(self, voltage: float, channel: int) -> None:
         self._write_checked(f":SOUR{channel}:VOLT:PROT {voltage:.3f}")
 

--- a/tests/psu/simulated/test_simulated_psu_hardware.py
+++ b/tests/psu/simulated/test_simulated_psu_hardware.py
@@ -108,6 +108,32 @@ def test_get_current(driver: SimulatedPSU, channel: int, current_limit: float, v
 
 
 @pytest.mark.parametrize(
+    ("channel", "voltage"),
+    [
+        (1, 6.0),
+        (2, 7.5),
+    ],
+)
+def test_get_voltage_setpoint(driver: SimulatedPSU, channel: int, voltage: float) -> None:
+    driver.set_voltage(voltage, channel=channel)
+
+    assert driver.get_voltage_setpoint(channel=channel) == pytest.approx(voltage)
+
+
+@pytest.mark.parametrize(
+    ("channel", "current_limit"),
+    [
+        (1, 1.0),
+        (2, 1.5),
+    ],
+)
+def test_get_current_setpoint(driver: SimulatedPSU, channel: int, current_limit: float) -> None:
+    driver.set_current_limit(current_limit, channel=channel)
+
+    assert driver.get_current_setpoint(channel=channel) == pytest.approx(current_limit)
+
+
+@pytest.mark.parametrize(
     ("channel", "enabled", "disabled"),
     [
         (1, True, False),
@@ -455,6 +481,18 @@ def test_set_current_limit_invalid_channel(driver: SimulatedPSU, invalid_channel
 def test_get_current_invalid_channel(driver: SimulatedPSU, invalid_channel: int) -> None:
     with pytest.raises(RuntimeError, match="Header suffix out of range"):
         driver.get_current(channel=invalid_channel)
+
+
+@pytest.mark.parametrize("invalid_channel", [3])
+def test_get_voltage_setpoint_invalid_channel(driver: SimulatedPSU, invalid_channel: int) -> None:
+    with pytest.raises(RuntimeError, match="Header suffix out of range"):
+        driver.get_voltage_setpoint(channel=invalid_channel)
+
+
+@pytest.mark.parametrize("invalid_channel", [3])
+def test_get_current_setpoint_invalid_channel(driver: SimulatedPSU, invalid_channel: int) -> None:
+    with pytest.raises(RuntimeError, match="Header suffix out of range"):
+        driver.get_current_setpoint(channel=invalid_channel)
 
 
 @pytest.mark.parametrize(("invalid_channel", "enabled"), [(3, True)])

--- a/tests/psu/simulated/test_simulated_psu_software.py
+++ b/tests/psu/simulated/test_simulated_psu_software.py
@@ -77,6 +77,20 @@ def test_simulated_get_current_queries_channel_command(sim: SimulatedPSU, sim_vi
     assert sim_visa.query.call_args_list == [call(":MEAS1:CURR?"), call(":SYST:ERR?")]
 
 
+def test_simulated_get_voltage_setpoint_queries_channel_command(sim: SimulatedPSU, sim_visa: MagicMock) -> None:
+    sim_visa.query.side_effect = ["5.000", '0,"No error"']
+
+    assert sim.get_voltage_setpoint(channel=2) == pytest.approx(5.0)
+    assert sim_visa.query.call_args_list == [call(":SOUR2:VOLT?"), call(":SYST:ERR?")]
+
+
+def test_simulated_get_current_setpoint_queries_channel_command(sim: SimulatedPSU, sim_visa: MagicMock) -> None:
+    sim_visa.query.side_effect = ["0.500", '0,"No error"']
+
+    assert sim.get_current_setpoint(channel=1) == pytest.approx(0.5)
+    assert sim_visa.query.call_args_list == [call(":SOUR1:CURR?"), call(":SYST:ERR?")]
+
+
 def test_simulated_output_enable_writes_on_and_off(sim: SimulatedPSU, sim_visa: MagicMock) -> None:
     sim.output_enable(True, channel=2)
     sim.output_enable(False, channel=2)


### PR DESCRIPTION
## Summary

This PR address the issue in https://github.com/nominal-io/instro/issues/321, which implements `get_voltage_setpoint()` and `get_current_setpoint()` for the SimulatedPSU driver.

## Type of change

- [ ] Bug fix (`fix`)
- [x] New feature (`feat`)
- [ ] Breaking change (`feat!` / `fix!`)
- [ ] Refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] Chore / tooling (`chore`)

## Verification
<img width="1174" height="349" alt="Screenshot 2026-08-21 at 4 07 39 PM" src="https://github.com/user-attachments/assets/47019c7c-741a-4e46-b54d-c8177dd585d9" />

## Tests
- [x] Unit tests added or updated
- [ ] Existing tests cover this change
- [ ] No tests — explain why:

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(driver): add support for Keysight E36300`)
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] Documentation updated if user-facing behavior changed
- [x] Code follows the style/conventions of the surrounding code

## Notes for reviewers

Modeled after the Rigol800 SCPI commands in this PR: https://github.com/nominal-io/instro/pull/314