### PR TITLE
docs(psu): add extra detail to setpoint getters in psu.py

### DIFF
--- a/docs/guides/instrumentation/psu.mdx
+++ b/docs/guides/instrumentation/psu.mdx
@@ -349,13 +349,13 @@ Every measurement/command call produces a channel keyed under `{name}.{descripto
 | `open()` | Establish the connection to the PSU |
 | `close()` | Disconnect from PSU and close all publishers |
 | `set_voltage(voltage, channel=N)` | Set voltage setpoint in volts |
-| `get_voltage(channel=N)` | Read measured output voltage in volts |
+| `get_voltage(channel=N)` | Read measured output voltage in volts. May vary from the voltage setpoint outside of constant voltage mode |
 | `set_current_limit(current_limit, channel=N)` | Set current limit in amperes |
-| `get_current(channel=N)` | Read measured output current in amperes |
+| `get_current(channel=N)` | Read measured output current in amperes. May vary from the current-limit setpoint outside of constant current mode |
 | `output_enable(enable, channel=N)` | Enable (True) or disable (False) the output |
 | `get_output_status(channel=N)` | Query output enable state (returns Measurement with bool value) |
-| `get_voltage_setpoint(channel=N)` | Read the configured voltage setpoint in volts (not the measured output) |
-| `get_current_setpoint(channel=N)` | Read the configured current-limit setpoint in amperes (not the measured output) |
+| `get_voltage_setpoint(channel=N)` | Read the configured voltage setpoint in volts (not the measured output). May vary from the actual measured voltage outside of constant voltage mode |
+| `get_current_setpoint(channel=N)` | Read the configured current-limit setpoint in amperes (not the measured output). May vary from the actual measured current outside of constant current mode |
 | `set_overvoltage_protection_level(voltage, channel=N)` | Set the overvoltage protection threshold in volts |
 | `get_overvoltage_protection_level(channel=N)` | Read the overvoltage protection threshold in volts |
 | `set_overvoltage_protection_enabled(enabled, channel=N)` | Enable or disable overvoltage protection |
@@ -420,13 +420,13 @@ def set_voltage(self, voltage: float, channel: int) -> None:
     """Set the output voltage (volts) on `channel`."""
 
 def get_voltage(self, channel: int) -> float:
-    """Query and return the measured output voltage in volts."""
+    """Query and return the measured output voltage in volts. Output may vary from voltage setpoint outside of constant voltage mode."""
 
 def set_current_limit(self, current_limit: float, channel: int) -> None:
     """Set the current limit (amperes) on `channel`."""
 
 def get_current(self, channel: int) -> float:
-    """Query and return the measured output current in amperes."""
+    """Query and return the measured output current in amperes. Output may vary from current-limit setpoint outside of constant current mode."""
 
 def output_enable(self, enable: bool, channel: int) -> None:
     """Enable or disable the output on `channel`."""
@@ -435,10 +435,10 @@ def get_output_status(self, channel: int) -> bool:
     """Query and return the output enable status on `channel`."""
 
 def get_voltage_setpoint(self, channel: int) -> float:
-    """Query and return the configured voltage setpoint in volts (not the measured output)."""
+    """Query and return the configured voltage setpoint in volts (not the measured output). Output may vary from actual measured voltage outside of constant voltage mode."""
 
 def get_current_setpoint(self, channel: int) -> float:
-    """Query and return the configured current-limit setpoint in amperes (not the measured output)."""
+    """Query and return the configured current-limit setpoint in amperes (not the measured output). Output may vary from actual measured current outside of constant current mode."""
 
 def set_overvoltage_protection_level(self, voltage: float, channel: int) -> None:
     """Set the overvoltage protection threshold (volts) on `channel`."""

--- a/instro/psu/psu.py
+++ b/instro/psu/psu.py
@@ -38,7 +38,7 @@ class PSUDriverBase(abc.ABC):
 
     @abc.abstractmethod
     def get_voltage(self, channel: int) -> float:
-        """Query the measured output voltage (volts) on `channel`."""
+        """Query the measured output voltage (volts) on `channel`. Output may vary from voltage setpoint outside of constant voltage mode."""
         raise NotImplementedError(f"get_voltage is not implemented for {type(self).__name__}")
 
     @abc.abstractmethod
@@ -48,7 +48,7 @@ class PSUDriverBase(abc.ABC):
 
     @abc.abstractmethod
     def get_current(self, channel: int) -> float:
-        """Query the measured output current (amperes) on `channel`."""
+        """Query the measured output current (amperes) on `channel`. Output may vary from current-limit setpoint outside of constant current mode."""
         raise NotImplementedError(f"get_current is not implemented for {type(self).__name__}")
 
     @abc.abstractmethod
@@ -62,11 +62,11 @@ class PSUDriverBase(abc.ABC):
         raise NotImplementedError(f"get_output_status is not implemented for {type(self).__name__}")
 
     def get_voltage_setpoint(self, channel: int) -> float:
-        """Query the configured voltage setpoint (volts) on `channel`."""
+        """Query the configured voltage setpoint (volts) on `channel`. Output may vary from actual measured voltage outside of constant voltage mode."""
         raise NotImplementedError(f"get_voltage_setpoint is not implemented for {type(self).__name__}")
 
     def get_current_setpoint(self, channel: int) -> float:
-        """Query the configured current-limit setpoint (amperes) on `channel`."""
+        """Query the configured current-limit setpoint (amperes) on `channel`. Output may vary from actual measured current outside of constant current mode."""
         raise NotImplementedError(f"get_current_setpoint is not implemented for {type(self).__name__}")
 
     def set_overvoltage_protection_level(self, voltage: float, channel: int) -> None:
@@ -262,7 +262,7 @@ class InstroPSU(Instrument):
         )
 
     def get_voltage(self, channel: int, **kwargs) -> Measurement | None:
-        """Measure the voltage (volts) sensed at ``channel`` terminals. Returns ``None`` if unavailable."""
+        """Measure the voltage (volts) sensed at ``channel`` terminals. Output may vary from voltage setpoint outside of constant voltage mode. Returns ``None`` if unavailable."""
         return self._execute_measurement(
             self._driver.get_voltage, channel=channel, channel_suffix="voltage", legacy_suffix="v", **kwargs
         )
@@ -279,7 +279,7 @@ class InstroPSU(Instrument):
         )
 
     def get_current(self, channel: int, **kwargs) -> Measurement | None:
-        """Measure the current (amperes) flowing through ``channel``. Returns ``None`` if unavailable."""
+        """Measure the current (amperes) flowing through ``channel``. Output may vary from current-limit setpoint outside of constant current mode. Returns ``None`` if unavailable."""
         return self._execute_measurement(
             self._driver.get_current, channel=channel, channel_suffix="current", legacy_suffix="i", **kwargs
         )
@@ -306,7 +306,7 @@ class InstroPSU(Instrument):
         )
 
     def get_voltage_setpoint(self, channel: int, **kwargs) -> Measurement | None:
-        """Query the configured voltage setpoint (volts) on ``channel``. Returns ``None`` if unavailable."""
+        """Query the configured voltage setpoint (volts) on ``channel``. Output may vary from actual measured voltage outside of constant voltage mode. Returns ``None`` if unavailable."""
         return self._execute_measurement(
             self._driver.get_voltage_setpoint,
             channel=channel,
@@ -316,7 +316,7 @@ class InstroPSU(Instrument):
         )
 
     def get_current_setpoint(self, channel: int, **kwargs) -> Measurement | None:
-        """Query the configured current-limit setpoint (amperes) on ``channel``. Returns ``None`` if unavailable."""
+        """Query the configured current-limit setpoint (amperes) on ``channel``. Output may vary from actual measured current outside of constant current mode. Returns ``None`` if unavailable."""
         return self._execute_measurement(
             self._driver.get_current_setpoint,
             channel=channel,


### PR DESCRIPTION
## Summary

This PR adds documentation details to `get_voltage_setpoint()` and `get_current_setpoint()`. We explicitly state that the voltage setpoint is only active in constant voltage mode and current setpoint is only active in constant current mode. 

## Type of change

- [ ] Bug fix (`fix`)
- [ ] New feature (`feat`)
- [ ] Breaking change (`feat!` / `fix!`)
- [ ] Refactor (`refactor`)
- [x] Documentation (`docs`)
- [ ] Chore / tooling (`chore`)

## Verification

`just test-python` and `just check-python` returns all tests are passing. 

<img width="586" height="107" alt="Screenshot 2026-08-24 at 3 33 47 PM" src="https://github.com/user-attachments/assets/1acfc731-c547-4d9c-b8f2-4cd8d1447920" />

<img width="1650" height="60" alt="Screenshot 2026-08-24 at 3 36 03 PM" src="https://github.com/user-attachments/assets/24a7ab7a-29c6-4918-b074-fe3278b80234" />
## Tests

- [ ] Unit tests added or updated
- [ ] Existing tests cover this change
- [x] No tests — explain why: This PR only touches documentation changes so no functionality was touched or edited.

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(driver): add support for Keysight E36300`)
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] Documentation updated if user-facing behavior changed
- [x] Code follows the style/conventions of the surrounding code

## Notes for reviewers