### PR TITLE
chore(ethernetip): upgrade rust-ethernet-ip to 1.2.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,39 +27,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "async-stream"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "async-trait"
-version = "0.1.89"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,19 +208,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
-name = "env_logger"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
-dependencies = [
- "humantime",
- "is-terminal",
- "log",
- "regex",
- "termcolor",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -283,7 +237,6 @@ checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
- "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -305,17 +258,6 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
 
 [[package]]
 name = "futures-io"
@@ -352,13 +294,10 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "slab",
 ]
@@ -393,22 +332,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "humantime"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "iana-time-zone"
@@ -507,17 +434,6 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
-]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -904,27 +820,60 @@ dependencies = [
 
 [[package]]
 name = "rust-ethernet-ip"
-version = "0.7.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09472411754c67125542f5d8674dda1d6b41f597b3d4730c2ab472661fa55373"
+checksum = "ea67adbb15cd06a8558d27008e8981faab6dbb1d3715ccc925add4cc6d58226c"
 dependencies = [
- "async-stream",
- "async-trait",
  "bytes",
- "env_logger",
  "futures",
- "lazy_static",
- "libc",
- "log",
  "regex",
+ "rust-ethernet-ip-protocol",
+ "rust-ethernet-ip-tag-path",
+ "rust-ethernet-ip-types",
+ "rust-ethernet-ip-udt",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "tokio",
  "toml",
  "tracing",
  "tracing-subscriber",
  "vergen",
+]
+
+[[package]]
+name = "rust-ethernet-ip-protocol"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "926e29a85603a8f9f67e2e51412b2c7a58242000a243f3e3ded7afa677783d6b"
+dependencies = [
+ "bytes",
+ "rust-ethernet-ip-types",
+]
+
+[[package]]
+name = "rust-ethernet-ip-tag-path"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e412d897cc74334228a5c75298e990d911228fa3e93aba5f554d7b0524270f28"
+
+[[package]]
+name = "rust-ethernet-ip-types"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5762e53bf8aa9296dfec4d14d8e31666004ec12d9e4e6be8ae18b2f3b8ab6cc"
+dependencies = [
+ "bytes",
+ "serde",
+]
+
+[[package]]
+name = "rust-ethernet-ip-udt"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c821a97ceaedb2142c46365c331a197f1694cffa29d2eead84d180f720b647d"
+dependencies = [
+ "rust-ethernet-ip-types",
 ]
 
 [[package]]
@@ -1103,15 +1052,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
-name = "termcolor"
-version = "1.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1201,7 +1141,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -1424,15 +1363,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "winapi-util"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
-dependencies = [
- "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/instro-ethernetip/Cargo.toml
+++ b/crates/instro-ethernetip/Cargo.toml
@@ -23,7 +23,7 @@ default = []
 blocking = ["dep:tokio"]
 
 [dependencies]
-rust-ethernet-ip = { version = "0.7", default-features = false }
+rust-ethernet-ip = { version = "1.2.1", default-features = false }
 thiserror.workspace = true
 tokio = { workspace = true, features = ["rt-multi-thread"], optional = true }
 

--- a/crates/instro-ethernetip/src/error.rs
+++ b/crates/instro-ethernetip/src/error.rs
@@ -41,6 +41,7 @@ impl From<BatchError> for BatchReadError {
             BatchError::SerializationError(msg) => Self::Serialization(msg),
             BatchError::Timeout => Self::Timeout,
             BatchError::Other(msg) => Self::Other(msg),
+            other => Self::Other(other.to_string()),
         }
     }
 }

--- a/crates/instro-ethernetip/src/lib.rs
+++ b/crates/instro-ethernetip/src/lib.rs
@@ -612,9 +612,9 @@ mod tests {
     fn route_path_from_slots_adds_each_backplane_slot() {
         let route_path = route_path_from_slots(&[2, 0]);
 
-        assert_eq!(route_path.slots, vec![2, 0]);
-        assert_eq!(route_path.ports, Vec::<u8>::new());
-        assert_eq!(route_path.addresses, Vec::<String>::new());
+        assert_eq!(route_path.slots(), vec![2, 0]);
+        assert_eq!(route_path.ports(), Vec::<u8>::new());
+        assert_eq!(route_path.addresses(), Vec::<String>::new());
         assert_eq!(route_path.to_cip_bytes(), vec![0x01, 0x02, 0x01, 0x00]);
     }
 


### PR DESCRIPTION
## Summary

- upgrade rust-ethernet-ip from 0.7.0 to 1.2.1
- preserve Instro’s existing ExplicitSession and Python-facing APIs
- handle the upstream non-exhaustive BatchError enum with a forward-compatible fallback
- update RoutePath assertions for the upstream accessor API
- refresh Cargo.lock for the new upstream component crates

I maintain rust-ethernet-ip and am happy to address any upstream compatibility issues surfaced by this upgrade.

Closes #274

## Testing

- cargo +nightly fmt --all --check
- cargo clippy --locked --all-features --all-targets --workspace -- -D warnings
- cargo test --workspace --all-features --all-targets
- cargo test --workspace --all-features --doc
- EtherNet/IP sdist smoke test
- EtherNet/IP isolated wheel/import/type-stub smoke test
- EtherNet/IP Python bindings: 6 passed, 1 deselected, 1 xfailed
- full Python suite: 2075 passed, 2 skipped, 465 deselected, 1 xfailed