### PR TITLE
feat(awg): use bulk download for small LAN waveforms

### DIFF
--- a/docs/guides/instrumentation/awg.mdx
+++ b/docs/guides/instrumentation/awg.mdx
@@ -54,6 +54,8 @@ InstroAWG supports programming a channel with the following waveforms: `Sine`, `
 Certain features are only available on particular waveforms. Driver's own their implementation of features in InstroAWG. Consult your specific driver for exact support.
 </Note>
 
+`RigolDG1022Z` uses a bulk transfer for arbitrary waveforms over TCPIP when the complete command is smaller than 32 KiB. USB connections and larger TCPIP payloads use per-point transfers because bulk writes can hang the instrument firmware in those cases.
+
 ## Creating an InstroAWG Instance
 
 ```python

--- a/packages/instro-unstable/instro/unstable/awg/drivers/rigol_dg1022z.py
+++ b/packages/instro-unstable/instro/unstable/awg/drivers/rigol_dg1022z.py
@@ -26,6 +26,7 @@ _HIGH_Z_SENTINEL = 9.9e37
 
 _ARB_MIN_POINTS = 9
 _ARB_MAX_POINTS = 16384
+_ARB_BULK_COMMAND_MAX_BYTES = 32 * 1024
 
 _SAWTOOTH_SYMMETRY_PCT = 100
 _TRIANGLE_SYMMETRY_PCT = 50
@@ -63,7 +64,10 @@ class RigolDG1022Z(AWGDriverBase):
     """SCPI driver for the Rigol DG1022Z two-channel arbitrary waveform generator."""
 
     def __init__(self, visa_resource: str | VisaConfig) -> None:
+        config = visa_resource if isinstance(visa_resource, VisaConfig) else VisaConfig(visa_resource=visa_resource)
         self._visa = VisaDriver(visa_resource)
+        self._arb_bulk_supported = config.visa_resource.upper().startswith("TCPIP")
+        self._write_terminator = config.terminator.write
         self._arb_waveforms: dict[int, Arbitrary] = {}
 
     def open(self) -> None:
@@ -105,11 +109,21 @@ class RigolDG1022Z(AWGDriverBase):
                         f" per download, got {num_points}"
                     )
                 self._write_checked(f":SOUR{channel}:APPL:ARB {waveform.sample_rate_hz}")
-                self._write_checked(f":SOUR{channel}:TRAC:DATA:POIN VOLATILE,{num_points}")
-                for point, sample in enumerate(waveform.samples, start=1):
-                    decimal_value = round((sample + 1) / 2 * 16383)
-                    # error queue is not drained, so checking every point avoids lost error messages in exchange for a longer runtime
-                    self._write_checked(f":SOUR{channel}:TRAC:DATA:VAL VOLATILE,{point},{decimal_value}")
+                bulk_command = None
+                if self._arb_bulk_supported:
+                    data = ",".join(str(sample) for sample in waveform.samples)
+                    bulk_command = f":SOUR{channel}:TRAC:DATA VOLATILE,{data}"
+                if (
+                    bulk_command is not None
+                    and len((bulk_command + self._write_terminator).encode()) < _ARB_BULK_COMMAND_MAX_BYTES
+                ):
+                    self._write_checked(bulk_command)
+                else:
+                    self._write_checked(f":SOUR{channel}:TRAC:DATA:POIN VOLATILE,{num_points}")
+                    for point, sample in enumerate(waveform.samples, start=1):
+                        decimal_value = round((sample + 1) / 2 * 16383)
+                        # error queue is not drained, so checking every point avoids lost error messages in exchange for a longer runtime
+                        self._write_checked(f":SOUR{channel}:TRAC:DATA:VAL VOLATILE,{point},{decimal_value}")
                 self._arb_waveforms[channel] = waveform
             elif isinstance(waveform, StaticValue):
                 self._visa.write(f":SOUR{channel}:FUNC DC")

--- a/tests/unstable/awg/rigol/test_rigol_dg1022z_software.py
+++ b/tests/unstable/awg/rigol/test_rigol_dg1022z_software.py
@@ -26,6 +26,7 @@ from instro.unstable.awg.types import (
 )
 
 _ARB_SAMPLES = (0.0, 0.5, 1.0, -1.0, 0.25, -0.25, 0.75, -0.75, 0.125)
+_OVERSIZED_ARB_SAMPLES = (-0.12345678901234568,) * 1600
 
 _SINE_CARRIER_APPL_RESPONSE = '"SIN,1.000000E+03,5.000000E+00,0.000000E+00,0.000000E+00"'
 _PULSE_CARRIER_APPL_RESPONSE = '"PULSE,1.000000E+03,1.000000E+00,0.000000E+00,0.000000E+00"'
@@ -220,11 +221,26 @@ def test_06_set_waveform_rejects_invalid_input(
     rigol_visa.write.assert_not_called()
 
 
-def test_07_set_waveform_arbitrary_writes_points_individually(
+def test_07_set_waveform_arbitrary_uses_bulk_download_for_small_lan_payload(
     rigol: RigolDG1022Z,
     rigol_visa: MagicMock,
 ) -> None:
     rigol_visa.query.return_value = '0,"No error"'
+
+    rigol.set_waveform(1, Arbitrary(samples=_ARB_SAMPLES, sample_rate_hz=1000000.0))
+
+    assert rigol_visa.write.call_args_list == [
+        call(":SOUR1:APPL:ARB 1000000.0"),
+        call(":SOUR1:TRAC:DATA VOLATILE,0.0,0.5,1.0,-1.0,0.25,-0.25,0.75,-0.75,0.125"),
+    ]
+    assert rigol_visa.query.call_count == 2
+
+
+def test_set_waveform_arbitrary_uses_per_point_download_for_usb(
+    rigol_visa_cls: MagicMock,
+    rigol_visa: MagicMock,
+) -> None:
+    rigol = RigolDG1022Z("USB0::0x1AB1::0x0642::DG1ZA000000000::INSTR")
 
     rigol.set_waveform(1, Arbitrary(samples=_ARB_SAMPLES, sample_rate_hz=1000000.0))
 
@@ -242,6 +258,22 @@ def test_07_set_waveform_arbitrary_writes_points_individually(
         call(":SOUR1:TRAC:DATA:VAL VOLATILE,9,9215"),
     ]
     assert rigol_visa.query.call_count == 11
+
+
+def test_set_waveform_arbitrary_uses_per_point_download_for_oversized_lan_payload(
+    rigol: RigolDG1022Z,
+    rigol_visa: MagicMock,
+) -> None:
+    rigol.set_waveform(1, Arbitrary(samples=_OVERSIZED_ARB_SAMPLES, sample_rate_hz=1000000.0))
+
+    commands = rigol_visa.write.call_args_list
+    assert commands[:2] == [
+        call(":SOUR1:APPL:ARB 1000000.0"),
+        call(":SOUR1:TRAC:DATA:POIN VOLATILE,1600"),
+    ]
+    assert len(commands) == 1602
+    assert all(":TRAC:DATA VOLATILE," not in command.args[0] for command in commands)
+    assert rigol_visa.query.call_count == 1602
 
 
 @pytest.mark.parametrize("num_points", [2, 16385], ids=["too_few", "too_many"])


### PR DESCRIPTION
## Summary

Use the Rigol DG1022Z bulk `:TRAC:DATA` command for arbitrary waveforms sent over TCPIP when the complete command, including the write terminator, is smaller than 32 KiB. USB connections and oversized LAN payloads retain the existing per-point download path.

Document the transport behavior in the AWG guide.

Fixes #331

## Type of change

- [ ] Bug fix (`fix`)
- [x] New feature (`feat`)
- [ ] Breaking change (`feat!` / `fix!`)
- [ ] Refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] Chore / tooling (`chore`)

## Verification

- `uv run --frozen pytest -q tests/unstable/awg/rigol/test_rigol_dg1022z_software.py`: 107 passed
- `uv run --frozen pytest -q`: 2077 passed, 2 skipped, 465 deselected, 1 xfailed
- `uv run --frozen ruff format --check`
- `uv run --frozen ruff check`
- `uv run --frozen mypy`

The mocked tests cover a small TCPIP payload, a USB payload, and an oversized TCPIP payload.

## Tests

- [x] Unit tests added or updated
- [ ] Existing tests cover this change
- [ ] No tests — explain why:

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(driver): add support for Keysight E36300`)
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] Documentation updated if user-facing behavior changed
- [x] Code follows the style/conventions of the surrounding code

## Notes for reviewers

The size gate counts encoded command bytes plus the configured write terminator and requires the result to remain strictly below 32 KiB.