### PR TITLE
chore(ci): migrate workflows to depot runners

### DIFF
--- a/.github/workflows/build-check-test.yml
+++ b/.github/workflows/build-check-test.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [depot-ubuntu-latest-4, depot-windows-2022-4, depot-macos-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     # Run every step under bash so the bash-syntax steps below (e.g. the
     # `uv lock --check` guard) work on Windows runners, which default to pwsh.
     defaults:

--- a/.github/workflows/build-check-test.yml
+++ b/.github/workflows/build-check-test.yml
@@ -32,7 +32,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install just
         uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
-      # `rustup` is available by default on GitHub runners
+      # Depot runner images are built from GitHub's runner images, so `rustup`
+      # is preinstalled there too
       - name: Install Rust
         run: rustup show
       - name: Cache Rust build output
@@ -72,7 +73,8 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install just
         uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
-      # `rustup` is available by default on GitHub runners
+      # Depot runner images are built from GitHub's runner images, so `rustup`
+      # is preinstalled there too
       - name: Install Rust
         run: rustup show
       # `check-rust` runs `cargo +nightly fmt`, which needs its own toolchain + component.

--- a/.github/workflows/build-check-test.yml
+++ b/.github/workflows/build-check-test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [depot-ubuntu-latest-4, depot-windows-2022-4, depot-macos-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     # Run every step under bash so the bash-syntax steps below (e.g. the
     # `uv lock --check` guard) work on Windows runners, which default to pwsh.
@@ -61,7 +61,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [depot-ubuntu-latest-4, depot-windows-2022-4, depot-macos-latest]
     # Run every step under bash so the bash-syntax steps below work on
     # Windows runners, which default to pwsh.
     defaults:

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -36,7 +36,7 @@ jobs:
         github.event.issue.pull_request != null &&
         startsWith(github.event.comment.body, '@claude review') &&
         contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association))
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -18,7 +18,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install uv

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   check-examples-drift:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install uv

--- a/.github/workflows/latest-deps-test.yml
+++ b/.github/workflows/latest-deps-test.yml
@@ -22,8 +22,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Bounds of supported Python only; the full matrix runs in PR CI.
-        python-version: ["3.10", "3.14"]
+        # Bounds of the CI-tested Python range only; the full matrix runs in PR CI.
+        python-version: ["3.11", "3.14"]
     defaults:
       run:
         shell: bash

--- a/.github/workflows/latest-deps-test.yml
+++ b/.github/workflows/latest-deps-test.yml
@@ -37,7 +37,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install just
         uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4.0.0
-      # `rustup` is available by default on GitHub runners
+      # Depot runner images are built from GitHub's runner images, so `rustup`
+      # is preinstalled there too
       - name: Install Rust
         run: rustup show
       - name: Cache Rust build output

--- a/.github/workflows/latest-deps-test.yml
+++ b/.github/workflows/latest-deps-test.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   latest-deps-test:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest-4
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   lint-pr-title:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: lint pr name

--- a/.github/workflows/release-please-publish.yml
+++ b/.github/workflows/release-please-publish.yml
@@ -11,7 +11,7 @@ name: release-please-publish
 
 jobs:
   release-please:
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
       paths_released: ${{ steps.release.outputs.paths_released }}
@@ -26,7 +26,7 @@ jobs:
   publish-python:
     needs: release-please
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
@@ -72,7 +72,7 @@ jobs:
   publish-crates:
     needs: release-please
     if: ${{ needs.release-please.outputs.releases_created == 'true' }}
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest-4
     environment: crates-io-release
 
     permissions:
@@ -122,15 +122,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          - os: depot-ubuntu-latest-4
             target: x86_64
-          - os: ubuntu-latest
+          - os: depot-ubuntu-latest-4
             target: aarch64
-          - os: macos-latest
+          - os: depot-macos-latest
             target: x86_64
-          - os: macos-latest
+          - os: depot-macos-latest
             target: aarch64
-          - os: windows-latest
+          - os: depot-windows-2022-4
             target: x64
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -151,7 +151,7 @@ jobs:
   build-eip-sdist:
     needs: release-please
     if: ${{ needs.release-please.outputs.releases_created == 'true' && contains(needs.release-please.outputs.paths_released, 'packages/instro-ethernetip') }}
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Build EtherNet/IP sdist
@@ -181,7 +181,7 @@ jobs:
       - build-eip-wheels
       - build-eip-sdist
     if: ${{ needs.release-please.outputs.releases_created == 'true' && contains(needs.release-please.outputs.paths_released, 'packages/instro-ethernetip') }}
-    runs-on: ubuntu-latest
+    runs-on: depot-ubuntu-latest
     permissions:
       actions: read
       id-token: write


### PR DESCRIPTION
Closes #434.

Swaps every `runs-on` in `.github/workflows/` from GitHub-hosted to Depot runners: `depot-ubuntu-latest` for light jobs, `depot-ubuntu-latest-4` / `depot-windows-2022-4` for compile-heavy jobs (matching GitHub's 4-vCPU standard runners), `depot-macos-latest` (arm64, same as GitHub's `macos-latest`) for macOS.

Before merging:
- Connect the Depot GitHub app to the `nominal-io` org (Depot dashboard -> GitHub Actions runners), or every job will queue forever.
- Update branch-protection required checks: matrix job names change, e.g. `check-and-test (ubuntu-latest, 3.12)` -> `check-and-test (depot-ubuntu-latest-4, 3.12)`.

Notes:
- PyPI/crates.io Trusted Publishing is unaffected: OIDC claims are repo+workflow scoped, not runner scoped, and Depot runners support `id-token: write`.
- `eip-wheel-*` artifact names embed `matrix.os` and therefore change; the `eip-*` download pattern in `publish-eip` still matches.