### PR TITLE
chore(ci): remove python 3.10 from test matrices

### DIFF
--- a/.github/workflows/build-check-test.yml
+++ b/.github/workflows/build-check-test.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [depot-ubuntu-latest-4, depot-windows-2022-4, depot-macos-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     # Run every step under bash so the bash-syntax steps below (e.g. the
     # `uv lock --check` guard) work on Windows runners, which default to pwsh.
     defaults:

--- a/.github/workflows/latest-deps-test.yml
+++ b/.github/workflows/latest-deps-test.yml
@@ -22,8 +22,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Bounds of supported Python only; the full matrix runs in PR CI.
-        python-version: ["3.10", "3.14"]
+        # Bounds of the CI-tested Python range only; the full matrix runs in PR CI.
+        python-version: ["3.11", "3.14"]
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
Closes #436.

Removes 3.10 from the `build-check-test` matrix and bumps the `latest-deps-test` lower bound to 3.11, making 3.11 the lowest CI-tested version. CI-only by design: `requires-python` floors stay `>=3.10`, so 3.10 remains claimed but untested until support is dropped for real (breaking change, separate work).

Stacked on #435 (both touch the same matrix block); retargets `main` when that merges. Remove the branch-protection required checks for the `(..., 3.10)` job names alongside the runner-label renames from #435.