### PR TITLE
feat(psu): add get_operating_mode query for CV/CC/off state

### DIFF
--- a/docs/guides/instrumentation/psu.mdx
+++ b/docs/guides/instrumentation/psu.mdx
@@ -327,6 +327,7 @@ Every measurement/command call produces a channel keyed under `{name}.{descripto
 | `get_output_status(channel=N)` | `ch{N}.enabled` | telemetry |
 | `get_voltage_setpoint(channel=N)` | `ch{N}.voltage.setpoint` | telemetry |
 | `get_current_setpoint(channel=N)` | `ch{N}.current.setpoint` | telemetry |
+| `get_operating_mode(channel=N)` | `ch{N}.operating_mode.cmd` | command |
 | `set_overvoltage_protection_level(channel=N)` | `ch{N}.ovp.cmd` | command |
 | `get_overvoltage_protection_level(channel=N)` | `ch{N}.ovp` | telemetry |
 | `set_overvoltage_protection_enabled(channel=N)` | `ch{N}.ovp.enabled.cmd` | command |
@@ -356,6 +357,7 @@ Every measurement/command call produces a channel keyed under `{name}.{descripto
 | `get_output_status(channel=N)` | Query output enable state (returns Measurement with bool value) |
 | `get_voltage_setpoint(channel=N)` | Read the configured voltage setpoint in volts (not the measured output). May vary from the actual measured voltage outside of constant voltage mode |
 | `get_current_setpoint(channel=N)` | Read the configured current-limit setpoint in amperes (not the measured output). May vary from the actual measured current outside of constant current mode |
+| `get_operating_mode(channel=N)` | Query the regulation mode (returns Command with value `CV`, `CC`, or `OFF`) |
 | `set_overvoltage_protection_level(voltage, channel=N)` | Set the overvoltage protection threshold in volts |
 | `get_overvoltage_protection_level(channel=N)` | Read the overvoltage protection threshold in volts |
 | `set_overvoltage_protection_enabled(enabled, channel=N)` | Enable or disable overvoltage protection |
@@ -439,6 +441,9 @@ def get_voltage_setpoint(self, channel: int) -> float:
 
 def get_current_setpoint(self, channel: int) -> float:
     """Query and return the configured current-limit setpoint in amperes (not the measured output). Output may vary from actual measured current outside of constant current mode."""
+
+def get_operating_mode(self, channel: int) -> OperatingMode:
+    """Query whether `channel` is regulating in constant voltage, constant current, or off."""
 
 def set_overvoltage_protection_level(self, voltage: float, channel: int) -> None:
     """Set the overvoltage protection threshold (volts) on `channel`."""

--- a/instro/psu/__init__.py
+++ b/instro/psu/__init__.py
@@ -2,5 +2,6 @@
 
 from instro.psu.config import PSUConfig
 from instro.psu.psu import InstroPSU, PSUDriverBase
+from instro.psu.types import OperatingMode
 
-__all__ = ["InstroPSU", "PSUDriverBase", "PSUConfig"]
+__all__ = ["InstroPSU", "PSUDriverBase", "PSUConfig", "OperatingMode"]

--- a/instro/psu/drivers/simulated.py
+++ b/instro/psu/drivers/simulated.py
@@ -2,7 +2,7 @@
 
 from instro.lib.exceptions import FeatureNotSupportedError
 from instro.lib.transports.visa import VisaConfig, VisaDriver
-from instro.psu import PSUDriverBase
+from instro.psu import OperatingMode, PSUDriverBase
 
 
 class SimulatedPSU(PSUDriverBase):
@@ -43,6 +43,12 @@ class SimulatedPSU(PSUDriverBase):
 
     def get_current_setpoint(self, channel: int) -> float:
         return self._query_checked_float(f":SOUR{channel}:CURR?")
+
+    def get_operating_mode(self, channel: int) -> OperatingMode:
+        with self._visa.lock():
+            resp = self._visa.query(f":OUTP{channel}:MODE?")
+            self._check_errors()
+        return OperatingMode(resp.strip())
 
     def set_overvoltage_protection_level(self, voltage: float, channel: int) -> None:
         self._write_checked(f":SOUR{channel}:VOLT:PROT {voltage:.3f}")

--- a/instro/psu/psu.py
+++ b/instro/psu/psu.py
@@ -14,6 +14,7 @@ from instro.lib.config import load_config
 from instro.lib.instrument import publish_command, publish_measurement
 from instro.lib.publishers import Publisher
 from instro.psu.config import PSUConfig, resolve_psu_from_config
+from instro.psu.types import OperatingMode
 
 logger = logging.getLogger(__name__)
 
@@ -68,6 +69,10 @@ class PSUDriverBase(abc.ABC):
     def get_current_setpoint(self, channel: int) -> float:
         """Query the configured current-limit setpoint (amperes) on `channel`. Output may vary from actual measured current outside of constant current mode."""
         raise NotImplementedError(f"get_current_setpoint is not implemented for {type(self).__name__}")
+
+    def get_operating_mode(self, channel: int) -> OperatingMode:
+        """Query whether `channel` is regulating in constant voltage, constant current, or off."""
+        raise NotImplementedError(f"get_operating_mode is not implemented for {type(self).__name__}")
 
     def set_overvoltage_protection_level(self, voltage: float, channel: int) -> None:
         """Set the overvoltage protection threshold (volts) on `channel`."""
@@ -314,6 +319,15 @@ class InstroPSU(Instrument):
             legacy_suffix="v_set",
             **kwargs,
         )
+
+    @publish_command
+    def get_operating_mode(self, channel: int, **kwargs) -> Command:
+        """Query whether ``channel`` is regulating in constant voltage, constant current, or off (published as a string)."""
+        with self._resource_lock:
+            mode = self._driver.get_operating_mode(channel=channel)
+            timestamp = time.time_ns()
+
+        return self._package_command(f"ch{channel}.operating_mode.cmd", mode.value, timestamp, **kwargs)
 
     def get_current_setpoint(self, channel: int, **kwargs) -> Measurement | None:
         """Query the configured current-limit setpoint (amperes) on ``channel``. Output may vary from actual measured current outside of constant current mode. Returns ``None`` if unavailable."""

--- a/instro/psu/scpi_sim_server.py
+++ b/instro/psu/scpi_sim_server.py
@@ -94,7 +94,7 @@ class SCPIError(IntEnum):
         return self._message
 
 
-class OperatingMode(Enum):
+class SimOperatingMode(Enum):
     OFF = "OFF"
     CV = "CV"  # voltage regulated
     CC = "CC"  # current regulated
@@ -138,7 +138,7 @@ class SimulatedPSUChannel:
         self.terminal_voltage = 0.0
         self.load_voltage = 0.0
         self.current = 0.0
-        self.mode = OperatingMode.OFF
+        self.mode = SimOperatingMode.OFF
         self.overvoltage_tripped = False
         self.overcurrent_tripped = False
         self.protection_latched = False
@@ -411,7 +411,7 @@ class SimulatedPSU:
     def _query_mode(self, channel: int, args: list[str]) -> str:
         self._update()
         ch = self._require_channel(channel)
-        return ch.mode.value if ch else OperatingMode.OFF.value
+        return ch.mode.value if ch else SimOperatingMode.OFF.value
 
     def _clear_protection_latch(self, channel: int, args: list[str]) -> None:
         ch = self._require_channel(channel)
@@ -514,7 +514,7 @@ class SimulatedPSU:
             ch.terminal_voltage = 0.0
             ch.load_voltage = 0.0
             ch.current = 0.0
-            ch.mode = OperatingMode.OFF
+            ch.mode = SimOperatingMode.OFF
             return
 
         self._update_voltage_source(ch)
@@ -527,7 +527,7 @@ class SimulatedPSU:
             ch.terminal_voltage = 0.0
             ch.load_voltage = 0.0
             ch.current = 0.0
-            ch.mode = OperatingMode.OFF
+            ch.mode = SimOperatingMode.OFF
             return
 
         if ch.overcurrent_protection_enabled and abs(ch.current) > ch.overcurrent_protection_level:
@@ -538,7 +538,7 @@ class SimulatedPSU:
             ch.terminal_voltage = 0.0
             ch.load_voltage = 0.0
             ch.current = 0.0
-            ch.mode = OperatingMode.OFF
+            ch.mode = SimOperatingMode.OFF
             return
 
     def _update_voltage_source(self, ch: SimulatedPSUChannel) -> None:
@@ -558,7 +558,7 @@ class SimulatedPSU:
             i_demand = (v_set - emf) / r_total
 
         if i_demand <= i_limit:
-            ch.mode = OperatingMode.CV
+            ch.mode = SimOperatingMode.CV
             ch.current = i_demand
             if ch.remote_sense:
                 ch.load_voltage = v_set
@@ -567,7 +567,7 @@ class SimulatedPSU:
                 ch.terminal_voltage = v_set
                 ch.load_voltage = v_set - i_demand * r_probe
         else:
-            ch.mode = OperatingMode.CC
+            ch.mode = SimOperatingMode.CC
             ch.current = i_limit
             if math.isfinite(r_load):
                 ch.load_voltage = ch.current * r_load + emf

--- a/instro/psu/scpi_sim_server.py
+++ b/instro/psu/scpi_sim_server.py
@@ -408,6 +408,11 @@ class SimulatedPSU:
         ch = self._require_channel(channel)
         return 1 if (ch and ch.output_enabled) else 0
 
+    def _query_mode(self, channel: int, args: list[str]) -> str:
+        self._update()
+        ch = self._require_channel(channel)
+        return ch.mode.value if ch else OperatingMode.OFF.value
+
     def _clear_protection_latch(self, channel: int, args: list[str]) -> None:
         ch = self._require_channel(channel)
         if ch is None:
@@ -641,6 +646,7 @@ _SCPI_COMMANDS = (
     _SCPICommand("OUTPut[:STATe]", SimulatedPSU._set_output, query=SimulatedPSU._query_output),
     _SCPICommand("OUTPut:PROTection:CLEar", SimulatedPSU._clear_protection_latch),
     _SCPICommand("OUTPut:PROTection:TRIPped", query=SimulatedPSU._query_protection_tripped),
+    _SCPICommand("OUTPut:MODE", query=SimulatedPSU._query_mode),
     _SCPICommand("MEASure:VOLTage", query=SimulatedPSU._measure_voltage),
     _SCPICommand("MEASure:CURRent", query=SimulatedPSU._measure_current),
     _SCPICommand(

--- a/instro/psu/types.py
+++ b/instro/psu/types.py
@@ -1,0 +1,11 @@
+"""PSU shared types."""
+
+from enum import Enum
+
+
+class OperatingMode(Enum):
+    """PSU regulation state: which quantity is currently being held constant, or off."""
+
+    CONSTANT_VOLTAGE = "CV"
+    CONSTANT_CURRENT = "CC"
+    OFF = "OFF"

--- a/tests/psu/simulated/test_simulated_psu_hardware.py
+++ b/tests/psu/simulated/test_simulated_psu_hardware.py
@@ -6,6 +6,7 @@ import pytest
 
 from instro.lib.exceptions import FeatureNotSupportedError
 from instro.lib.transports import VisaConfig
+from instro.psu import OperatingMode
 from instro.psu.drivers.simulated import SimulatedPSU
 from instro.psu.scpi_sim_server import SimulatedPSU as SimulatedPSUSimulator
 from instro.psu.scpi_sim_server import SimulatedPSUServer
@@ -131,6 +132,24 @@ def test_get_current_setpoint(driver: SimulatedPSU, channel: int, current_limit:
     driver.set_current_limit(current_limit, channel=channel)
 
     assert driver.get_current_setpoint(channel=channel) == pytest.approx(current_limit)
+
+
+@pytest.mark.parametrize(
+    ("current_limit", "voltage", "enabled", "expected_mode"),
+    [
+        (1.0, 6.0, True, OperatingMode.CONSTANT_VOLTAGE),
+        (0.001, 6.0, True, OperatingMode.CONSTANT_CURRENT),
+        (1.0, 6.0, False, OperatingMode.OFF),
+    ],
+)
+def test_get_operating_mode(
+    driver: SimulatedPSU, current_limit: float, voltage: float, enabled: bool, expected_mode: OperatingMode
+) -> None:
+    driver.set_current_limit(current_limit, channel=1)
+    driver.set_voltage(voltage, channel=1)
+    driver.output_enable(enabled, channel=1)
+
+    assert driver.get_operating_mode(channel=1) == expected_mode
 
 
 @pytest.mark.parametrize(
@@ -493,6 +512,12 @@ def test_get_voltage_setpoint_invalid_channel(driver: SimulatedPSU, invalid_chan
 def test_get_current_setpoint_invalid_channel(driver: SimulatedPSU, invalid_channel: int) -> None:
     with pytest.raises(RuntimeError, match="Header suffix out of range"):
         driver.get_current_setpoint(channel=invalid_channel)
+
+
+@pytest.mark.parametrize("invalid_channel", [3])
+def test_get_operating_mode_invalid_channel(driver: SimulatedPSU, invalid_channel: int) -> None:
+    with pytest.raises(RuntimeError, match="Header suffix out of range"):
+        driver.get_operating_mode(channel=invalid_channel)
 
 
 @pytest.mark.parametrize(("invalid_channel", "enabled"), [(3, True)])

--- a/tests/psu/simulated/test_simulated_psu_software.py
+++ b/tests/psu/simulated/test_simulated_psu_software.py
@@ -7,6 +7,7 @@ import pytest
 
 from instro.lib.exceptions import FeatureNotSupportedError
 from instro.lib.transports import VisaConfig
+from instro.psu import OperatingMode
 from instro.psu.drivers.simulated import SimulatedPSU
 
 
@@ -89,6 +90,13 @@ def test_simulated_get_current_setpoint_queries_channel_command(sim: SimulatedPS
 
     assert sim.get_current_setpoint(channel=1) == pytest.approx(0.5)
     assert sim_visa.query.call_args_list == [call(":SOUR1:CURR?"), call(":SYST:ERR?")]
+
+
+def test_simulated_get_operating_mode_queries_channel_command(sim: SimulatedPSU, sim_visa: MagicMock) -> None:
+    sim_visa.query.side_effect = ["CV", '0,"No error"']
+
+    assert sim.get_operating_mode(channel=2) == OperatingMode.CONSTANT_VOLTAGE
+    assert sim_visa.query.call_args_list == [call(":OUTP2:MODE?"), call(":SYST:ERR?")]
 
 
 def test_simulated_output_enable_writes_on_and_off(sim: SimulatedPSU, sim_visa: MagicMock) -> None:

--- a/tests/psu/test_psu_drivers.py
+++ b/tests/psu/test_psu_drivers.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from instro.psu import InstroPSU, PSUDriverBase
+from instro.psu.types import OperatingMode
 
 # --- PSUDriverBase ---
 
@@ -54,6 +55,13 @@ def test_psu_driver_base_setpoint_getters_raise_not_implemented(
 ) -> None:
     with pytest.raises(NotImplementedError, match=f"{method_name} is not implemented for _BaseOnlyPSUDriver"):
         getattr(base_only_psu_driver, method_name)(*args, channel=1)
+
+
+def test_psu_driver_base_get_operating_mode_raises_not_implemented(
+    base_only_psu_driver: _BaseOnlyPSUDriver,
+) -> None:
+    with pytest.raises(NotImplementedError, match="get_operating_mode is not implemented for _BaseOnlyPSUDriver"):
+        base_only_psu_driver.get_operating_mode(channel=1)
 
 
 @pytest.mark.parametrize(
@@ -120,6 +128,7 @@ def _stub_driver() -> MagicMock:
     driver.get_output_status.return_value = True
     driver.get_voltage_setpoint.return_value = 5.0
     driver.get_current_setpoint.return_value = 1.5
+    driver.get_operating_mode.return_value = OperatingMode.CONSTANT_VOLTAGE
     driver.get_overvoltage_protection_level.return_value = 15.0
     driver.get_overvoltage_protection_enabled.return_value = True
     driver.get_overvoltage_protection_delay.return_value = 0.25
@@ -204,6 +213,14 @@ def test_nominal_psu_get_current_setpoint_returns_measurement() -> None:
     driver.get_current_setpoint.assert_called_once_with(channel=1)
     assert measurement is not None
     assert measurement.channel_data["ut.ch1.current.setpoint"] == [1.5]
+
+
+def test_nominal_psu_get_operating_mode_returns_command() -> None:
+    driver = _stub_driver()
+    psu = InstroPSU(name="ut", driver=driver, num_channels=1)
+    command = psu.get_operating_mode(channel=1)
+    driver.get_operating_mode.assert_called_once_with(channel=1)
+    assert command.channel_data["ut.ch1.operating_mode.cmd"] == "CV"
 
 
 def test_nominal_psu_set_current_limit_delegates() -> None:

--- a/tests/psu/test_scpi_sim_server.py
+++ b/tests/psu/test_scpi_sim_server.py
@@ -745,6 +745,27 @@ def test_infinite_resistance_load_stays_in_cv_mode(psu: SimulatedPSU) -> None:
     assert psu.process_scpi_command(":MEAS:VOLT?") == pytest.approx(5.0, rel=0.05)
 
 
+def test_mode_query_reports_off_when_output_disabled(psu: SimulatedPSU) -> None:
+    assert psu.process_scpi_command(":OUTP:MODE?") == OperatingMode.OFF.value
+
+
+def test_mode_query_reports_cv_when_voltage_regulated(psu: SimulatedPSU) -> None:
+    psu.process_scpi_command(":CURR 1.0")
+    psu.process_scpi_command(":VOLT 5.0")
+    psu.process_scpi_command(":OUTP ON")
+
+    assert psu.process_scpi_command(":OUTP:MODE?") == OperatingMode.CV.value
+
+
+def test_mode_query_reports_cc_when_current_clamped(psu: SimulatedPSU) -> None:
+    psu.channels[0].load = SimulatedLoad(resistance=0.1, probe_resistance=0.0)
+    psu.process_scpi_command(":CURR 1.0")
+    psu.process_scpi_command(":VOLT 5.0")
+    psu.process_scpi_command(":OUTP ON")
+
+    assert psu.process_scpi_command(":OUTP:MODE?") == OperatingMode.CC.value
+
+
 @pytest.mark.parametrize(
     "command",
     [

--- a/tests/psu/test_scpi_sim_server.py
+++ b/tests/psu/test_scpi_sim_server.py
@@ -10,8 +10,8 @@ import pytest
 from textual.widgets import Input
 
 from instro.psu.scpi_sim_server import (
-    OperatingMode,
     SCPIError,
+    SimOperatingMode,
     SimulatedLoad,
     SimulatedPSU,
     SimulatedPSUApp,
@@ -574,7 +574,7 @@ def test_current_limit_can_enter_cc_without_ocp_trip(psu: SimulatedPSU) -> None:
     psu.process_scpi_command(":CURR:PROT:STAT ON")
     psu.process_scpi_command(":OUTP ON")
 
-    assert psu.channels[0].mode == OperatingMode.CC
+    assert psu.channels[0].mode == SimOperatingMode.CC
     assert psu.channels[0].output_enabled is True
     assert psu.channels[0].overcurrent_tripped is False
 
@@ -689,7 +689,7 @@ def test_cv_mode_measures_setpoint_voltage(psu: SimulatedPSU) -> None:
     psu.process_scpi_command(":VOLT 5.0")
     psu.process_scpi_command(":OUTP ON")
 
-    assert psu.channels[0].mode == OperatingMode.CV
+    assert psu.channels[0].mode == SimOperatingMode.CV
     assert psu.process_scpi_command(":MEAS:VOLT?") == pytest.approx(5.0, rel=0.05)
 
 
@@ -699,7 +699,7 @@ def test_current_limit_clamps_into_cc_mode(psu: SimulatedPSU) -> None:
     psu.process_scpi_command(":VOLT 5.0")
     psu.process_scpi_command(":OUTP ON")
 
-    assert psu.channels[0].mode == OperatingMode.CC
+    assert psu.channels[0].mode == SimOperatingMode.CC
     assert psu.process_scpi_command(":MEAS:CURR?") == pytest.approx(1.0, rel=0.05)
 
 
@@ -718,7 +718,7 @@ def test_zero_resistance_load_enters_cc_mode(psu: SimulatedPSU) -> None:
     psu.process_scpi_command(":VOLT 5.0")
     psu.process_scpi_command(":OUTP ON")
 
-    assert psu.channels[0].mode == OperatingMode.CC
+    assert psu.channels[0].mode == SimOperatingMode.CC
     assert psu.process_scpi_command(":MEAS:CURR?") == pytest.approx(1.0, rel=0.05)
     assert psu.process_scpi_command(":MEAS:VOLT?") == pytest.approx(0.0, abs=0.01)
 
@@ -729,7 +729,7 @@ def test_zero_resistance_load_at_matching_emf_stays_in_cv_mode(psu: SimulatedPSU
     psu.process_scpi_command(":VOLT 5.0")
     psu.process_scpi_command(":OUTP ON")
 
-    assert psu.channels[0].mode == OperatingMode.CV
+    assert psu.channels[0].mode == SimOperatingMode.CV
     assert psu.process_scpi_command(":MEAS:CURR?") == pytest.approx(0.0, abs=0.01)
     assert psu.process_scpi_command(":MEAS:VOLT?") == pytest.approx(5.0, rel=0.05)
 
@@ -740,13 +740,13 @@ def test_infinite_resistance_load_stays_in_cv_mode(psu: SimulatedPSU) -> None:
     psu.process_scpi_command(":VOLT 5.0")
     psu.process_scpi_command(":OUTP ON")
 
-    assert psu.channels[0].mode == OperatingMode.CV
+    assert psu.channels[0].mode == SimOperatingMode.CV
     assert psu.process_scpi_command(":MEAS:CURR?") == pytest.approx(0.0, abs=0.01)
     assert psu.process_scpi_command(":MEAS:VOLT?") == pytest.approx(5.0, rel=0.05)
 
 
 def test_mode_query_reports_off_when_output_disabled(psu: SimulatedPSU) -> None:
-    assert psu.process_scpi_command(":OUTP:MODE?") == OperatingMode.OFF.value
+    assert psu.process_scpi_command(":OUTP:MODE?") == SimOperatingMode.OFF.value
 
 
 def test_mode_query_reports_cv_when_voltage_regulated(psu: SimulatedPSU) -> None:
@@ -754,7 +754,7 @@ def test_mode_query_reports_cv_when_voltage_regulated(psu: SimulatedPSU) -> None
     psu.process_scpi_command(":VOLT 5.0")
     psu.process_scpi_command(":OUTP ON")
 
-    assert psu.process_scpi_command(":OUTP:MODE?") == OperatingMode.CV.value
+    assert psu.process_scpi_command(":OUTP:MODE?") == SimOperatingMode.CV.value
 
 
 def test_mode_query_reports_cc_when_current_clamped(psu: SimulatedPSU) -> None:
@@ -763,7 +763,7 @@ def test_mode_query_reports_cc_when_current_clamped(psu: SimulatedPSU) -> None:
     psu.process_scpi_command(":VOLT 5.0")
     psu.process_scpi_command(":OUTP ON")
 
-    assert psu.process_scpi_command(":OUTP:MODE?") == OperatingMode.CC.value
+    assert psu.process_scpi_command(":OUTP:MODE?") == SimOperatingMode.CC.value
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Adds a method on the InstroPSU class that gets the operating mode: constant voltage, constant current, or off. These are enumerated as CC, CV, or OFF. 

## Type of change

- [ ] Bug fix (`fix`)
- [X] New feature (`feat`)
- [ ] Breaking change (`feat!` / `fix!`)
- [ ] Refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] Chore / tooling (`chore`)

## Verification

I've updated the SimulatedPSU driver and the sim to handle this case. See video below:

https://github.com/user-attachments/assets/cbc90c71-6289-4e8c-895b-3d72ff56f6c8

## Tests

- [X] Unit tests added or updated
- [ ] Existing tests cover this change
- [ ] No tests — explain why:

## Checklist

- [X] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(driver): add support for Keysight E36300`)
- [X] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [X] Documentation updated if user-facing behavior changed
- [X] Code follows the style/conventions of the surrounding code

## Notes for reviewers

None.
