### PR TITLE
fix(labjack): fix start and timeout inconsistencies

### DIFF
--- a/packages/instro-daq-labjack/instro/daq/drivers/labjack/t_series.py
+++ b/packages/instro-daq-labjack/instro/daq/drivers/labjack/t_series.py
@@ -348,9 +348,8 @@ class LabJackTSeriesDriver(DAQDriverBase):
         if self._global_scan_rate is None:
             raise HWTimingException("No hardware timing configuration exists. Can not call Start")
 
-        if self._streaming_active is True:
-            # TODO add debug logger
-            return
+        if self._streaming_active:
+            raise RuntimeError("A stream is already running. Call stop() before starting a new acquisition.")
 
         # For LabJack, we need to know the channels to start streaming
         channels = self._ai_channels.values()
@@ -420,14 +419,17 @@ class LabJackTSeriesDriver(DAQDriverBase):
     ) -> LabJackData:
         if not self._streaming_active:
             raise RuntimeError("No active scan. Call start() before fetch_analog().")
+        assert self._global_scans_per_read is not None and self._actual_sample_period is not None
+        # fetch time deadline, floored at 5s and dynamic to support low-rate, high-res reads
+        deadline = max(5.0, 2 * self._global_scans_per_read * self._actual_sample_period * 1e-9)
         # Is receiving data from the ljm registered callback.
         try:
-            callback_data = self._data_queue.get(timeout=5)
+            callback_data = self._data_queue.get(timeout=deadline)
             labjack_data, timestamp = callback_data[0], callback_data[1]
             samples, self._points_in_fifo, self.points_in_buffer = labjack_data[0], labjack_data[1], labjack_data[2]
             return LabJackData(data=samples, timestamp=timestamp, dt=self._actual_sample_period)
         except Empty:
-            raise TimeoutError("LabJack timeout. No data received.")
+            raise TimeoutError(f"LabJack timeout. No data received after {deadline:.3g}s.")
 
     def get_actual_sample_rate(self) -> float | None:
         return self._actual_sample_rate

--- a/packages/instro-daq-labjack/instro/daq/drivers/labjack/t_series.py
+++ b/packages/instro-daq-labjack/instro/daq/drivers/labjack/t_series.py
@@ -419,7 +419,10 @@ class LabJackTSeriesDriver(DAQDriverBase):
     ) -> LabJackData:
         if not self._streaming_active:
             raise RuntimeError("No active scan. Call start() before fetch_analog().")
-        assert self._global_scans_per_read is not None and self._actual_sample_period is not None
+        if self._global_scans_per_read is None or self._actual_sample_period is None:
+            raise RuntimeError(
+                "Hardware timing was never configured; call configure_ai_sample_rate() before fetch_analog()."
+            )
         # fetch time deadline, floored at 5s and dynamic to support low-rate, high-res reads
         deadline = max(5.0, 2 * self._global_scans_per_read * self._actual_sample_period * 1e-9)
         # Is receiving data from the ljm registered callback.

--- a/uv.lock
+++ b/uv.lock
@@ -594,7 +594,7 @@ wheels = [
 
 [[package]]
 name = "instro"
-version = "1.10.0"
+version = "1.13.0"
 source = { editable = "." }
 dependencies = [
     { name = "fastavro", extra = ["snappy"] },
@@ -817,7 +817,7 @@ requires-dist = [{ name = "instro", editable = "." }]
 
 [[package]]
 name = "instro-unstable"
-version = "1.5.0"
+version = "1.7.0"
 source = { editable = "packages/instro-unstable" }
 dependencies = [
     { name = "gs-usb" },


### PR DESCRIPTION
## Summary

Fixing two inconsistency bugs with the LabJack instro driver:
1. Calling `start()` twice on all other drivers raises. We should do the same instead of silently returning
2. `fetch_analog` had a hard timeout of 5s which could cause valid acquisition to timeout. We should mirror what the MCC driver does and have a dynamic timeout

## Type of change

- [x] Bug fix (`fix`)
- [ ] New feature (`feat`)
- [ ] Breaking change (`feat!` / `fix!`)
- [ ] Refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] Chore / tooling (`chore`)

## Verification

Verified manually that double start raises and the proper timeout is configured.

## Tests

- [ ] Unit tests added or updated
- [ ] Existing tests cover this change
- [x] No tests — explain why:
Small hardware related consistency bugs not needing overly specific tests

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(driver): add support for Keysight E36300`)
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] Documentation updated if user-facing behavior changed
- [x] Code follows the style/conventions of the surrounding code