### PR TITLE
feat(awg): expand config to extra features

### DIFF
--- a/docs/guides/instrumentation/awg.mdx
+++ b/docs/guides/instrumentation/awg.mdx
@@ -150,6 +150,8 @@ Inside each `ChannelConfig` object, the following fields are filled:
 
 Shape parameters carry the same bounds the Python `Waveform` definitions enforce (positive `frequency_hz`, `duty_cycle_pct` within 0–100, a pulse whose `width_s + delay_s` fits inside the period, and so on). A modulation `baseband_shape` carries the same bounds as a carrier waveform. These are checked when the config is parsed.
 
+A channel may enable at most one of `modulation`, `burst`, or `sweep`. All three blocks can be present together, but only one may carry `"enable": true` — more than one is rejected when the config is parsed. A block with `"enable": false` still has its other settings applied.
+
 `output_enable` cannot be set from the configuration file. You must explicitly call `output_enable(channel, True)` to enable output. Enabling `modulation`, `burst`, or `sweep` from the config does not turn the output on.
 
 An optional top-level `timing` section (`{"poll_interval": 1.0}`) sets the background daemon's polling interval. Pass `autostart=True` to start the connection, apply the `channels` config, and start polling immediately:

--- a/docs/guides/instrumentation/awg.mdx
+++ b/docs/guides/instrumentation/awg.mdx
@@ -135,7 +135,7 @@ awg = InstroAWG(config="bench_awg.json")
 
 `channels` is a required dictionary and must be non-empty. It is keyed by channel numbers represented as strings. Each channel can be represented once in `channels`. Duplicate channels will raise an error.
 
-Each entry is applied on `open()`, through `set_waveform`, `set_amplitude`, and `set_offset`. It is applied once per session: repeated `open()` calls do not reapply it. A `close()` followed by another `open()` does reapply it, overwriting any channel state you set manually in between, but note that `close()` also closes the instance's publishers — so reuse after `close()` is only safe with no publishers attached. Construct a new `InstroAWG` to reconnect. Building an `InstroAWG` does not `open()` or `start()` the instrument unless you pass `autostart=True`.
+Each entry is applied on `open()`, through `set_waveform`, `set_amplitude`, `set_offset`, `set_modulation`/`modulation_enable`, `set_burst*`/`burst_enable`, and `set_sweep*`/`sweep_enable`. It is applied once per session: repeated `open()` calls do not reapply it. A `close()` followed by another `open()` does reapply it, overwriting any channel state you set manually in between, but note that `close()` also closes the instance's publishers — so reuse after `close()` is only safe with no publishers attached. Construct a new `InstroAWG` to reconnect. Building an `InstroAWG` does not `open()` or `start()` the instrument unless you pass `autostart=True`.
 
 Inside each `ChannelConfig` object, the following fields are filled:
 - **`waveform`** (required): one of `sine`, `square`, `sawtooth`, `triangle`, `pulse`, `arbitrary`, or `static_value`, discriminated by a `shape` field. `arbitrary`'s `samples` accepts either an inline array of at least 2 floats normalized to `[-1.0, 1.0]`, or a string path to a CSV file containing them; `sample_rate_sas` is the sample rate in samples per second.
@@ -144,10 +144,13 @@ Inside each `ChannelConfig` object, the following fields are filled:
 
 - **`amplitude`** (optional): `{"value": <float>, "unit": "VPP" | "VP" | "VRMS" | "DBM"}`; `unit` defaults to `VPP`.
 - **`offset`** (optional): DC offset in volts.
+- **`modulation`** (optional): `{"type": {"name": <ModulationType>, "magnitude": <float>}, "baseband_shape": <waveform>, "enable": <bool>}`. `magnitude` means whatever the modulation type says it means — depth for AM, frequency deviation for FM, and so on. See `set_modulation`. `baseband_shape` takes any of the waveform shapes listed above.
+- **`burst`** (optional): `{"type": <BurstType>, "enable": <bool>, "trigger_source": ..., "delay": ..., "gate_polarity": ..., "ncycles": ..., "period": ...}`. Only `type` and `enable` are required. The rest are mode-specific and are skipped when omitted, so `gate_polarity` only applies to a `GATED` burst.
+- **`sweep`** (optional): `{"type": <SweepType>, "enable": <bool>, "trigger_source": ..., "start_frequency": ..., "end_frequency": ..., "sweep_time": ..., "start_hold_time": ..., "stop_hold_time": ..., "return_time": ...}`. Only `type` and `enable` are required. The rest are skipped when omitted.
 
-Shape parameters carry the same bounds the Python `Waveform` definitions enforce (positive `frequency_hz`, `duty_cycle_pct` within 0–100, a pulse whose `width_s + delay_s` fits inside the period, and so on). These are checked when the config is parsed.
+Shape parameters carry the same bounds the Python `Waveform` definitions enforce (positive `frequency_hz`, `duty_cycle_pct` within 0–100, a pulse whose `width_s + delay_s` fits inside the period, and so on). A modulation `baseband_shape` carries the same bounds as a carrier waveform. These are checked when the config is parsed.
 
-`output_enable` cannot be set from the configuration file. You must explicitly call `output_enable(channel, True)` to enable output.
+`output_enable` cannot be set from the configuration file. You must explicitly call `output_enable(channel, True)` to enable output. Enabling `modulation`, `burst`, or `sweep` from the config does not turn the output on.
 
 An optional top-level `timing` section (`{"poll_interval": 1.0}`) sets the background daemon's polling interval. Pass `autostart=True` to start the connection, apply the `channels` config, and start polling immediately:
 

--- a/packages/instro-unstable/instro/unstable/awg/awg.py
+++ b/packages/instro-unstable/instro/unstable/awg/awg.py
@@ -413,6 +413,47 @@ class InstroAWG(Instrument):
                 self.set_amplitude(channel, channel_config.amplitude.value, channel_config.amplitude.unit)
             if channel_config.offset is not None:
                 self.set_offset(channel, channel_config.offset)
+            if channel_config.modulation is not None:
+                modulation = channel_config.modulation
+                self.set_modulation(
+                    channel,
+                    modulation.type.name,
+                    build_waveform(modulation.baseband_shape),
+                    modulation.type.magnitude,
+                )
+                self.modulation_enable(channel, modulation.enable)
+            if channel_config.burst is not None:
+                burst = channel_config.burst
+                self.set_burst(channel, burst.type)
+                if burst.trigger_source is not None:
+                    self.set_burst_trigger(channel, burst.trigger_source)
+                if burst.delay is not None:
+                    self.set_burst_delay(channel, burst.delay)
+                if burst.gate_polarity is not None:
+                    self.set_burst_gate_polarity(channel, burst.gate_polarity)
+                if burst.ncycles is not None:
+                    self.set_burst_ncycles(channel, burst.ncycles)
+                if burst.period is not None:
+                    self.set_burst_period(channel, burst.period)
+                self.burst_enable(channel, burst.enable)
+            if channel_config.sweep is not None:
+                sweep = channel_config.sweep
+                self.set_sweep(channel, sweep.type)
+                if sweep.trigger_source is not None:
+                    self.set_sweep_trigger(channel, sweep.trigger_source)
+                if sweep.start_frequency is not None:
+                    self.set_sweep_start_freq(channel, sweep.start_frequency)
+                if sweep.end_frequency is not None:
+                    self.set_sweep_end_freq(channel, sweep.end_frequency)
+                if sweep.sweep_time is not None:
+                    self.set_sweep_time(channel, sweep.sweep_time)
+                if sweep.start_hold_time is not None:
+                    self.set_sweep_start_hold_time(channel, sweep.start_hold_time)
+                if sweep.stop_hold_time is not None:
+                    self.set_sweep_stop_hold_time(channel, sweep.stop_hold_time)
+                if sweep.return_time is not None:
+                    self.set_sweep_return_time(channel, sweep.return_time)
+                self.sweep_enable(channel, sweep.enable)
         self._channel_config_applied = True
 
     def close(self) -> None:

--- a/packages/instro-unstable/instro/unstable/awg/config.py
+++ b/packages/instro-unstable/instro/unstable/awg/config.py
@@ -275,6 +275,17 @@ class ChannelConfig(BaseModel):
         build_waveform(self.waveform)
         return self
 
+    @model_validator(mode="after")
+    def _check_at_most_one_mode_enabled(self) -> ChannelConfig:
+        """Reject more than one enabled mode, since ``open()`` applies them in order and only the last one survives."""
+        modes = {"modulation": self.modulation, "burst": self.burst, "sweep": self.sweep}
+        enabled = [name for name, mode in modes.items() if mode is not None and mode.enable]
+        if len(enabled) > 1:
+            raise ValueError(
+                f"only one of modulation, burst, or sweep can be enabled per channel, got {' and '.join(enabled)}"
+            )
+        return self
+
 
 class AWGConfig(BaseModel):
     """Validated config for constructing an InstroAWG from JSON."""

--- a/packages/instro-unstable/instro/unstable/awg/config.py
+++ b/packages/instro-unstable/instro/unstable/awg/config.py
@@ -19,11 +19,17 @@ from instro.lib.types import DeviceInfo
 from instro.unstable.awg.types import (
     AmplitudeMeasurementUnit,
     Arbitrary,
+    BurstTriggerSource,
+    BurstType,
+    GatePolarity,
+    ModulationType,
     Pulse,
     Sawtooth,
     Sine,
     Square,
     StaticValue,
+    SweepTriggerSource,
+    SweepType,
     Triangle,
     Waveform,
 )
@@ -36,15 +42,19 @@ __all__ = [
     "AWGConfig",
     "AmplitudeConfig",
     "ArbitraryConfig",
+    "BurstConfig",
     "ChannelConfig",
     "DeviceInfo",
     "FilePublisherConfig",
+    "ModulationConfig",
+    "ModulationTypeConfig",
     "NominalCorePublisherConfig",
     "PulseConfig",
     "SawtoothConfig",
     "SineConfig",
     "SquareConfig",
     "StaticValueConfig",
+    "SweepConfig",
     "TimingConfig",
     "TriangleConfig",
     "VisaDriverConfig",
@@ -190,6 +200,64 @@ class AmplitudeConfig(BaseModel):
     unit: AmplitudeMeasurementUnit = AmplitudeMeasurementUnit.VPP
 
 
+class ModulationTypeConfig(BaseModel):
+    """Modulation type and its magnitude; magnitude's meaning varies by ``name`` (see ``InstroAWG.set_modulation``)."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    name: ModulationType
+    magnitude: float
+
+
+class ModulationConfig(BaseModel):
+    """Carrier modulation config; maps to ``InstroAWG.set_modulation``/``modulation_enable``."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    type: ModulationTypeConfig
+    baseband_shape: WaveformConfigType
+    enable: bool
+
+    @model_validator(mode="after")
+    def _check_baseband_is_buildable(self) -> ModulationConfig:
+        """Build and discard the baseband waveform so its shape-parameter bounds reject a bad config here, not mid-``open()``."""
+        build_waveform(self.baseband_shape)
+        return self
+
+
+class BurstConfig(BaseModel):
+    """Burst config; maps to InstroAWG's ``set_burst*``/``burst_enable`` setters.
+
+    ``trigger_source``/``delay``/``gate_polarity``/``ncycles``/``period`` are mode-specific
+    (e.g. ``gate_polarity`` only applies to GATED bursts) and are skipped when omitted.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    type: BurstType
+    enable: bool
+    trigger_source: BurstTriggerSource | None = None
+    delay: float | None = None
+    gate_polarity: GatePolarity | None = None
+    ncycles: int | None = None
+    period: float | None = None
+
+
+class SweepConfig(BaseModel):
+    """Sweep config; maps to InstroAWG's ``set_sweep*``/``sweep_enable`` setters.
+
+    All fields besides ``type``/``enable`` are optional and skipped when omitted.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+    type: SweepType
+    enable: bool
+    trigger_source: SweepTriggerSource | None = None
+    start_frequency: float | None = None
+    end_frequency: float | None = None
+    sweep_time: float | None = None
+    start_hold_time: float | None = None
+    stop_hold_time: float | None = None
+    return_time: float | None = None
+
+
 class ChannelConfig(BaseModel):
     """Initial per-channel state applied on ``open()``; the channel stays silent until its output is explicitly enabled."""
 
@@ -197,6 +265,9 @@ class ChannelConfig(BaseModel):
     waveform: WaveformConfigType
     amplitude: AmplitudeConfig | None = None
     offset: float | None = None
+    modulation: ModulationConfig | None = None
+    burst: BurstConfig | None = None
+    sweep: SweepConfig | None = None
 
     @model_validator(mode="after")
     def _check_waveform_is_buildable(self) -> ChannelConfig:

--- a/tests/unstable/awg/test_awg_config_hardware.py
+++ b/tests/unstable/awg/test_awg_config_hardware.py
@@ -2,10 +2,11 @@
 
 One shared test script against real hardware for every supported AWG vendor: the `awg`
 fixture is parametrized by `driver_name`, and only the per-vendor config in `CONFIGS`
-changes between runs (VISA resource, channel count). Test bodies read their
-expectations back out of `awg._config` wherever possible, so most tests are identical
-for every vendor; the few places where AWG capability genuinely differs (IDN string,
-channel count) branch explicitly on `driver_name`.
+changes between runs (VISA resource, channel count, sweep spacing, whether a
+start-hold-time is declared). Test bodies read their expectations back out of
+`awg._config` wherever possible, so most tests are identical for every vendor; the few
+places where AWG capability genuinely differs (IDN string, channel count, sweep
+start-hold-time support) branch explicitly on `driver_name`.
 """
 
 from __future__ import annotations
@@ -45,10 +46,20 @@ NUM_CHANNELS: dict[str, int] = {
 TEST_FREQUENCY_HZ = 1000.0
 TEST_AMPLITUDE_VPP = 1.0
 TEST_OFFSET_V = 0.25
+TEST_MOD_MAGNITUDE = 50.0
+TEST_MOD_BASEBAND_HZ = 100.0
+TEST_BURST_NCYCLES = 5
+TEST_BURST_PERIOD_S = 0.01
+TEST_SWEEP_START_HZ = 100.0
+TEST_SWEEP_END_HZ = 900.0
+TEST_SWEEP_TIME_S = 1.0
+TEST_SWEEP_HOLD_TIME_S = 0.1
+TEST_SWEEP_RETURN_TIME_S = 0.1
 
 FREQUENCY_TOLERANCE_REL = 1e-4
 AMPLITUDE_TOLERANCE_REL = 0.01
 PHASE_TOLERANCE_DEG = 0.1
+TIME_TOLERANCE_REL = 0.01
 
 
 # ---------------------------------------------------------------------------
@@ -56,11 +67,30 @@ PHASE_TOLERANCE_DEG = 0.1
 # ---------------------------------------------------------------------------
 
 
-def _channel_1_config() -> dict:
+def _channel_1_config(sweep_type: str, include_start_hold_time: bool) -> dict:
+    sweep = {
+        "type": sweep_type,
+        "enable": False,
+        "start_frequency": TEST_SWEEP_START_HZ,
+        "end_frequency": TEST_SWEEP_END_HZ,
+        "sweep_time": TEST_SWEEP_TIME_S,
+        "stop_hold_time": TEST_SWEEP_HOLD_TIME_S,
+        "return_time": TEST_SWEEP_RETURN_TIME_S,
+    }
+    if include_start_hold_time:
+        sweep["start_hold_time"] = TEST_SWEEP_HOLD_TIME_S
+
     return {
         "waveform": {"shape": "sine", "frequency_hz": TEST_FREQUENCY_HZ, "phase_deg": 0.0},
         "amplitude": {"value": TEST_AMPLITUDE_VPP, "unit": "VPP"},
         "offset": TEST_OFFSET_V,
+        "modulation": {
+            "type": {"name": "AM", "magnitude": TEST_MOD_MAGNITUDE},
+            "baseband_shape": {"shape": "sine", "frequency_hz": TEST_MOD_BASEBAND_HZ, "phase_deg": 0.0},
+            "enable": False,
+        },
+        "burst": {"type": "NCYCLE", "enable": False, "ncycles": TEST_BURST_NCYCLES, "period": TEST_BURST_PERIOD_S},
+        "sweep": sweep,
     }
 
 
@@ -72,7 +102,12 @@ _CHANNEL_2_CONFIG = {
 
 
 def _make_config(driver_name: str) -> dict:
-    channels = {"1": _channel_1_config()}
+    channels = {
+        "1": _channel_1_config(
+            sweep_type="STEP" if driver_name == RIGOL else "LINEAR",
+            include_start_hold_time=driver_name == RIGOL,
+        )
+    }
     if driver_name == RIGOL:
         channels["2"] = _CHANNEL_2_CONFIG
 
@@ -101,6 +136,12 @@ CONFIGS: dict[str, dict] = {RIGOL: _make_config(RIGOL), KEYSIGHT: _make_config(K
 
 
 def _measurement_value(measurement: Measurement | None) -> float:
+    assert measurement is not None
+    return measurement.latest
+
+
+def _measurement_label(measurement: Measurement | None) -> str:
+    """Categorical reads (modulation/burst/sweep type) publish the enum's ``value``, not the enum."""
     assert measurement is not None
     return measurement.latest
 
@@ -194,11 +235,104 @@ def test_04_config_applies_waveform_amplitude_and_offset_on_channel_1(awg: Instr
 
 
 # ---------------------------------------------------------------------------
+# Modulation
+# ---------------------------------------------------------------------------
+
+
+def test_05_config_applies_modulation_without_enabling(awg: InstroAWG) -> None:
+    modulation = awg._config.channels["1"].modulation
+
+    assert _measurement_label(awg.get_modulation_type(1)) == modulation.type.name.value
+    assert _measurement_value(awg.get_modulation_state(1)) == 0.0
+
+
+def test_06_modulation_enable_toggle(awg: InstroAWG) -> None:
+    try:
+        awg.modulation_enable(1, True)
+        assert _measurement_value(awg.get_modulation_state(1)) == 1.0
+    finally:
+        awg.modulation_enable(1, False)
+
+    assert _measurement_value(awg.get_modulation_state(1)) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Burst
+# ---------------------------------------------------------------------------
+
+
+def test_07_config_applies_burst_without_enabling(awg: InstroAWG) -> None:
+    burst = awg._config.channels["1"].burst
+
+    assert _measurement_label(awg.get_burst_type(1)) == burst.type.value
+    assert _measurement_value(awg.get_burst_ncycles(1)) == burst.ncycles
+    assert _measurement_value(awg.get_burst_period(1)) == pytest.approx(burst.period, rel=TIME_TOLERANCE_REL)
+    assert _measurement_value(awg.get_burst_state(1)) == 0.0
+
+
+def test_08_burst_enable_toggle(awg: InstroAWG) -> None:
+    try:
+        awg.burst_enable(1, True)
+        assert _measurement_value(awg.get_burst_state(1)) == 1.0
+    finally:
+        awg.burst_enable(1, False)
+
+    assert _measurement_value(awg.get_burst_state(1)) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Sweep
+# ---------------------------------------------------------------------------
+
+
+def test_09_config_applies_sweep_without_enabling(awg: InstroAWG) -> None:
+    sweep = awg._config.channels["1"].sweep
+
+    assert _measurement_label(awg.get_sweep_type(1)) == sweep.type.value
+    assert _measurement_value(awg.get_sweep_start_freq(1)) == pytest.approx(
+        sweep.start_frequency, rel=FREQUENCY_TOLERANCE_REL
+    )
+    assert _measurement_value(awg.get_sweep_end_freq(1)) == pytest.approx(
+        sweep.end_frequency, rel=FREQUENCY_TOLERANCE_REL
+    )
+    assert _measurement_value(awg.get_sweep_time(1)) == pytest.approx(sweep.sweep_time, rel=TIME_TOLERANCE_REL)
+    assert _measurement_value(awg.get_sweep_stop_hold_time(1)) == pytest.approx(
+        sweep.stop_hold_time, rel=TIME_TOLERANCE_REL
+    )
+    assert _measurement_value(awg.get_sweep_return_time(1)) == pytest.approx(sweep.return_time, rel=TIME_TOLERANCE_REL)
+    assert _measurement_value(awg.get_sweep_state(1)) == 0.0
+
+
+def test_10_sweep_enable_toggle(awg: InstroAWG) -> None:
+    try:
+        awg.sweep_enable(1, True)
+        assert _measurement_value(awg.get_sweep_state(1)) == 1.0
+    finally:
+        awg.sweep_enable(1, False)
+
+    assert _measurement_value(awg.get_sweep_state(1)) == 0.0
+
+
+# ---------------------------------------------------------------------------
 # Vendor capability differences
 # ---------------------------------------------------------------------------
 
 
-def test_05_channel_count_differs_by_instrument(awg: InstroAWG, driver_name: str) -> None:
+def test_11_sweep_start_hold_time_support_differs_by_instrument(awg: InstroAWG, driver_name: str) -> None:
+    """The 33521B has no :HTIMe:STARt node; only DG1022Z declares/roundtrips start_hold_time."""
+    if driver_name == KEYSIGHT:
+        with pytest.raises(NotImplementedError):
+            awg.set_sweep_start_hold_time(1, TEST_SWEEP_HOLD_TIME_S)
+        with pytest.raises(NotImplementedError):
+            awg.get_sweep_start_hold_time(1)
+    else:
+        sweep = awg._config.channels["1"].sweep
+        assert _measurement_value(awg.get_sweep_start_hold_time(1)) == pytest.approx(
+            sweep.start_hold_time, rel=TIME_TOLERANCE_REL
+        )
+
+
+def test_12_channel_count_differs_by_instrument(awg: InstroAWG, driver_name: str) -> None:
     """The 33521B has 1 physical channel; the DG1022Z has 2, and channel 2's config was applied too."""
     if driver_name == KEYSIGHT:
         with pytest.raises(ValueError, match="channel"):

--- a/tests/unstable/awg/test_awg_config_software.py
+++ b/tests/unstable/awg/test_awg_config_software.py
@@ -822,3 +822,80 @@ def test_malformed_modulation_baseband_rejected_at_validation(valid_config):
     }
     with pytest.raises(Exception, match="duty_cycle_pct must be between 0 and 100"):
         InstroAWG(config=config)
+
+
+_MODULATION_BLOCK = {
+    "type": {"name": "AM", "magnitude": 50.0},
+    "baseband_shape": {"shape": "sine", "frequency_hz": 100.0, "phase_deg": 0.0},
+    "enable": True,
+}
+_BURST_BLOCK = {"type": "NCYCLE", "enable": True}
+_SWEEP_BLOCK = {"type": "LINEAR", "enable": True}
+
+
+@pytest.mark.parametrize(
+    ("blocks", "expected"),
+    [
+        ({"modulation": _MODULATION_BLOCK, "burst": _BURST_BLOCK}, "modulation and burst"),
+        ({"modulation": _MODULATION_BLOCK, "sweep": _SWEEP_BLOCK}, "modulation and sweep"),
+        ({"burst": _BURST_BLOCK, "sweep": _SWEEP_BLOCK}, "burst and sweep"),
+        (
+            {"modulation": _MODULATION_BLOCK, "burst": _BURST_BLOCK, "sweep": _SWEEP_BLOCK},
+            "modulation and burst and sweep",
+        ),
+    ],
+)
+def test_multiple_enabled_modes_rejected_at_validation(valid_config, blocks, expected):
+    """open() applies modulation, burst, then sweep, so enabling more than one silently drops all but the last."""
+    config = {
+        **valid_config,
+        "channels": {
+            "1": {"waveform": {"shape": "sine", "frequency_hz": 1000.0, "phase_deg": 0.0}, **blocks},
+        },
+    }
+    with pytest.raises(
+        Exception, match=f"only one of modulation, burst, or sweep can be enabled per channel, got {expected}"
+    ):
+        InstroAWG(config=config)
+
+
+def test_one_enabled_mode_alongside_disabled_modes_is_accepted(valid_config):
+    """Only `enable` counts: a configured-but-disabled block still gets its setters applied."""
+    config = {
+        **valid_config,
+        "channels": {
+            "1": {
+                "waveform": {"shape": "sine", "frequency_hz": 1000.0, "phase_deg": 0.0},
+                "modulation": {**_MODULATION_BLOCK, "enable": False},
+                "burst": {**_BURST_BLOCK, "enable": True},
+                "sweep": {**_SWEEP_BLOCK, "enable": False},
+            }
+        },
+    }
+    with _patch_driver() as mock_cls:
+        awg = InstroAWG(config=config)
+        awg.open()
+
+    mock_driver = mock_cls.return_value
+    mock_driver.modulation_enable.assert_called_once_with(channel=1, enable=False)
+    mock_driver.burst_enable.assert_called_once_with(1, True)
+    mock_driver.sweep_enable.assert_called_once_with(1, False)
+
+
+def test_modes_are_validated_per_channel_not_across_channels(valid_config):
+    """One enabled mode on each of two channels is fine; the limit is per channel."""
+    waveform = {"shape": "sine", "frequency_hz": 1000.0, "phase_deg": 0.0}
+    config = {
+        **valid_config,
+        "channels": {
+            "1": {"waveform": waveform, "burst": _BURST_BLOCK},
+            "2": {"waveform": waveform, "sweep": _SWEEP_BLOCK},
+        },
+    }
+    with _patch_driver() as mock_cls:
+        awg = InstroAWG(config=config)
+        awg.open()
+
+    mock_driver = mock_cls.return_value
+    mock_driver.burst_enable.assert_called_once_with(1, True)
+    mock_driver.sweep_enable.assert_called_once_with(2, True)

--- a/tests/unstable/awg/test_awg_config_software.py
+++ b/tests/unstable/awg/test_awg_config_software.py
@@ -14,6 +14,7 @@ from instro.unstable.awg.config import build_waveform
 from instro.unstable.awg.types import (
     AmplitudeMeasurementUnit,
     Arbitrary,
+    ModulationType,
     Pulse,
     Sawtooth,
     Sine,
@@ -691,3 +692,133 @@ def test_arbitrary_samples_relative_path_resolves_against_cwd(valid_config, tmp_
         channel=1, waveform=Arbitrary(samples=(-1.0, 0.0, 1.0, 0.0), sample_rate_sas=50.0)
     )
     assert awg._config.model_dump(mode="json")["channels"]["1"]["waveform"]["samples"] == "samples.csv"
+
+
+def test_open_applies_modulation(valid_config):
+    config = {
+        **valid_config,
+        "channels": {
+            "1": {
+                "waveform": {"shape": "sine", "frequency_hz": 1000.0, "phase_deg": 0.0},
+                "modulation": {
+                    "type": {"name": "AM", "magnitude": 50.0},
+                    "baseband_shape": {
+                        "shape": "square",
+                        "frequency_hz": 100.0,
+                        "duty_cycle_pct": 50.0,
+                        "phase_deg": 0.0,
+                    },
+                    "enable": True,
+                },
+            }
+        },
+    }
+    with _patch_driver() as mock_cls:
+        awg = InstroAWG(config=config)
+        awg.open()
+
+    mock_driver = mock_cls.return_value
+    mock_driver.set_modulation.assert_called_once_with(
+        channel=1,
+        mod_type=ModulationType.AM,
+        shape=Square(frequency_hz=100.0, duty_cycle_pct=50.0, phase_deg=0.0),
+        magnitude=50.0,
+    )
+    mock_driver.modulation_enable.assert_called_once_with(channel=1, enable=True)
+
+
+def test_open_applies_burst_partial_fields_skip_none_setters(valid_config):
+    config = {
+        **valid_config,
+        "channels": {
+            "1": {
+                "waveform": {"shape": "sine", "frequency_hz": 1000.0, "phase_deg": 0.0},
+                "burst": {"type": "NCYCLE", "enable": True, "ncycles": 5},
+            }
+        },
+    }
+    with _patch_driver() as mock_cls:
+        awg = InstroAWG(config=config)
+        awg.open()
+
+    mock_driver = mock_cls.return_value
+    mock_driver.set_burst.assert_called_once()
+    mock_driver.set_burst_ncycles.assert_called_once_with(1, 5)
+    mock_driver.burst_enable.assert_called_once_with(1, True)
+    mock_driver.set_burst_trigger.assert_not_called()
+    mock_driver.set_burst_delay.assert_not_called()
+    mock_driver.set_burst_gate_polarity.assert_not_called()
+    mock_driver.set_burst_period.assert_not_called()
+
+
+def test_open_applies_sweep_partial_fields_skip_none_setters(valid_config):
+    config = {
+        **valid_config,
+        "channels": {
+            "1": {
+                "waveform": {"shape": "sine", "frequency_hz": 1000.0, "phase_deg": 0.0},
+                "sweep": {"type": "LINEAR", "enable": True, "start_frequency": 100.0, "end_frequency": 200.0},
+            }
+        },
+    }
+    with _patch_driver() as mock_cls:
+        awg = InstroAWG(config=config)
+        awg.open()
+
+    mock_driver = mock_cls.return_value
+    mock_driver.set_sweep.assert_called_once()
+    mock_driver.set_sweep_start_freq.assert_called_once_with(1, 100.0)
+    mock_driver.set_sweep_end_freq.assert_called_once_with(1, 200.0)
+    mock_driver.sweep_enable.assert_called_once_with(1, True)
+    mock_driver.set_sweep_trigger.assert_not_called()
+    mock_driver.set_sweep_time.assert_not_called()
+    mock_driver.set_sweep_start_hold_time.assert_not_called()
+    mock_driver.set_sweep_stop_hold_time.assert_not_called()
+    mock_driver.set_sweep_return_time.assert_not_called()
+
+
+def test_explicit_null_modulation_burst_and_sweep_are_accepted(valid_config):
+    """The INSTRO-598 example spells the unused blocks as explicit nulls."""
+    config = {
+        **valid_config,
+        "channels": {
+            "1": {
+                "waveform": {"shape": "sine", "frequency_hz": 1000.0, "phase_deg": 0.0},
+                "modulation": None,
+                "burst": None,
+                "sweep": None,
+            }
+        },
+    }
+    with _patch_driver() as mock_cls:
+        awg = InstroAWG(config=config)
+        awg.open()
+
+    mock_driver = mock_cls.return_value
+    mock_driver.set_modulation.assert_not_called()
+    mock_driver.set_burst.assert_not_called()
+    mock_driver.set_sweep.assert_not_called()
+
+
+def test_malformed_modulation_baseband_rejected_at_validation(valid_config):
+    """The baseband waveform carries the same types.py bounds as a carrier waveform."""
+    config = {
+        **valid_config,
+        "channels": {
+            "1": {
+                "waveform": {"shape": "sine", "frequency_hz": 1000.0, "phase_deg": 0.0},
+                "modulation": {
+                    "type": {"name": "AM", "magnitude": 50.0},
+                    "baseband_shape": {
+                        "shape": "square",
+                        "frequency_hz": 100.0,
+                        "duty_cycle_pct": 500.0,
+                        "phase_deg": 0.0,
+                    },
+                    "enable": True,
+                },
+            }
+        },
+    }
+    with pytest.raises(Exception, match="duty_cycle_pct must be between 0 and 100"):
+        InstroAWG(config=config)


### PR DESCRIPTION
## Summary

This PR expands the AWG config in https://github.com/nominal-io/instro/pull/448 to cover burst, sweep, and modulation.

## Type of change

- [ ] Bug fix (`fix`)
- [x] New feature (`feat`)
- [ ] Breaking change (`feat!` / `fix!`)
- [ ] Refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] Chore / tooling (`chore`)

## Verification

Hardware tests:
<img width="1068" height="539" alt="Screenshot 2026-09-01 at 2 28 35 PM" src="https://github.com/user-attachments/assets/159a2cac-006e-429f-bf03-e9f7d6ffa8dc" />

Software tests:
<img width="1070" height="697" alt="Screenshot 2026-09-01 at 2 28 19 PM" src="https://github.com/user-attachments/assets/2c1dad62-82a0-4b80-a92c-19abb45e9c54" />

## Tests

- [x] Unit tests added or updated
- [ ] Existing tests cover this change
- [ ] No tests — explain why:

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(driver): add support for Keysight E36300`)
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] Documentation updated if user-facing behavior changed
- [x] Code follows the style/conventions of the surrounding code

## Notes for reviewers