### PR TITLE
fix(daq): wait for a full fresh batch in read_batch()

### DIFF
--- a/instro/daq/daq.py
+++ b/instro/daq/daq.py
@@ -1118,8 +1118,17 @@ class InstroDAQ(Instrument):
                     )
                 analog[alias] = Measurement({key: source.channel_data[key]}, source.timestamps, source.tags)
         elif analog_aliases:
-            # Just use the get_channel defaults here. Directly call get_channel for more customization
-            analog = {alias: self.get_channel(alias) for alias in analog_aliases}
+            # Size get_channel params to wait for one full batch of samples based on
+            hw_timing = self.ai_hw_timing_config
+            length = hw_timing.samples_per_channel if hw_timing else 1
+            batch_duration_s = length / hw_timing.sample_rate if hw_timing else self.background_interval
+            timeout = max(10.0, 2 * batch_duration_s)
+
+            # Block once for a fresh batch, then get data for all other channels from that batch
+            analog = {
+                alias: self.get_channel(alias, length, wait_for_new_samples=(i == 0), timeout=timeout)
+                for i, alias in enumerate(analog_aliases)
+            }
 
         # Digital pass
         # NOTE: Planning on ripping out port support

--- a/instro/daq/daq.py
+++ b/instro/daq/daq.py
@@ -1118,7 +1118,7 @@ class InstroDAQ(Instrument):
                     )
                 analog[alias] = Measurement({key: source.channel_data[key]}, source.timestamps, source.tags)
         elif analog_aliases:
-            # Size get_channel params to wait for one full batch of samples based on
+            # Size get_channel params to wait for one full batch of samples based on timing config
             hw_timing = self.ai_hw_timing_config
             length = hw_timing.samples_per_channel if hw_timing else 1
             batch_duration_s = length / hw_timing.sample_rate if hw_timing else self.background_interval


### PR DESCRIPTION
## Summary

We want the new `read_batch` method to be the standard, easy way for reading data from a DAQ. I previously implemented it to just use the `get_channel` defaults under the hood but am now realizing this is not the correct way to write this. We should be trying to read one entire batch of samples. This PR makes it so that `read_batch` reads one full batch for all channels passed in when called on a DAQ running a background daemon.

## Type of change

- [x] Bug fix (`fix`)
- [ ] New feature (`feat`)
- [ ] Breaking change (`feat!` / `fix!`)
- [ ] Refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] Chore / tooling (`chore`)

## Verification

All sw tests pass. Also verified that the T7 hardware tests still pass as well.

## Tests

- [ ] Unit tests added or updated
- [ ] Existing tests cover this change
- [x] No tests — explain why:
Reworking previous implementation to have better and more expected behavior

## Checklist

- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(driver): add support for Keysight E36300`)
- [ ] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] Documentation updated if user-facing behavior changed
- [ ] Code follows the style/conventions of the surrounding code

## Notes for reviewers

_Optional — call out specific files, edge cases, or decisions you'd like eyes on._
