### PR TITLE
docs: add Discord server link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Python library for talking to test instrumentation (power supplies, multimeters,
 [![Docs](https://img.shields.io/badge/docs-instro.nominal.io-419B55)](https://instro.nominal.io)
 [![SDK](https://img.shields.io/badge/sdk-nominal--io.github.io-419B55)](https://nominal-io.github.io/instro/)
 [![Community](https://img.shields.io/badge/community-community.instro.nominal.io-419B55)](https://community.instro.nominal.io)
+[![Discord](https://img.shields.io/badge/discord-join-419B55?logo=discord&logoColor=white)](https://discord.gg/nN4RzhQkr)
 
 ## Quickstart
 

--- a/docs/guides/docs.json
+++ b/docs/guides/docs.json
@@ -250,6 +250,10 @@
       {
         "label": "Community",
         "href": "https://community.instro.nominal.io"
+      },
+      {
+        "label": "Discord",
+        "href": "https://discord.gg/nN4RzhQkr"
       }
     ],
     "primary": {
@@ -273,6 +277,7 @@
   "footer": {
     "socials": {
       "x": "https://x.com/nominal_io",
+      "discord": "https://discord.gg/nN4RzhQkr",
       "github": "https://github.com/nominal-io/instro",
       "linkedin": "https://linkedin.com/company/nominal-io"
     }

--- a/docs/guides/getting-started.mdx
+++ b/docs/guides/getting-started.mdx
@@ -283,13 +283,17 @@ description: "An open-source Python library for interfacing with hardware test e
 
 Build a new instrument type or vendor driver against `Instrument`.
 
-<Columns cols={2}>
+<Columns cols={3}>
   <Card title="Instrument" icon="code" href="/instrumentation/library">
     Create your own Instrument category using the tools in `instro`
   </Card>
 
   <Card title="Request a driver" icon="sparkles" href="https://community.instro.nominal.io/c/driver-feature-requests/9">
-    Start a thread on our community forum
+    Start a thread on the community forum
+  </Card>
+
+  <Card title="Join the Discord" icon="discord" href="https://discord.gg/nN4RzhQkr">
+    Ask questions and chat with other `instro` users
   </Card>
 </Columns>
 


### PR DESCRIPTION
Closes #458

Docs only linked the community forum. Adds the Discord invite to the README badges, the Mintlify navbar and footer socials, and a getting-started card.