### PR TITLE
fix(ci): mint a GitHub App token for release-please instead of the shared PAT

### DIFF
--- a/.github/workflows/release-please-publish.yml
+++ b/.github/workflows/release-please-publish.yml
@@ -15,11 +15,30 @@ jobs:
     outputs:
       releases_created: ${{ steps.release.outputs.releases_created }}
       paths_released: ${{ steps.release.outputs.paths_released }}
+    env:
+      # `if:` cannot read the secrets context, so resolve availability here.
+      USE_APP_TOKEN: ${{ secrets.NOMBOT_APP_ID != '' && secrets.NOMBOT_PRIVATE_KEY != '' }}
     steps:
+      # A GitHub App installation gets its own API rate limit instead of sharing
+      # nominal-bot's 5,000/hour with Renovate and every other repo (#468). The
+      # token must be minted in this job: app tokens are scrubbed at job boundaries.
+      - name: Get app token for release-please
+        id: app-token
+        if: ${{ env.USE_APP_TOKEN == 'true' }}
+        # A minting failure degrades to the PAT below rather than blocking the release.
+        continue-on-error: true
+        uses: nominal-io/workflow-application-token-action@d8644a5aa546f763f73b94c762b092e088486db7 # 0.0.1
+        with:
+          application_id: ${{ secrets.NOMBOT_APP_ID }}
+          application_private_key: ${{ secrets.NOMBOT_PRIVATE_KEY }}
+          organization: "nominal-io"
+          permissions: "contents:write, pull_requests:write, issues:write"
+          revoke_token: true
+
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         id: release
         with:
-          token: ${{ secrets.NOMBOT_CLASSIC_PERSONAL_ACCESS_TOKEN }}
+          token: ${{ steps.app-token.outputs.token || secrets.NOMBOT_CLASSIC_PERSONAL_ACCESS_TOKEN }}
           config-file: .github/release-please-config.json
           manifest-file: .github/release-please-manifest.json
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,6 +90,8 @@ Docs live in this repo and ship in the same PR as the code change. When a change
 
 release-please opens one `chore(main): release` PR for all packages; each package still gets its own version and tag. Do not add `separate-pull-requests` to `.github/release-please-config.json` (see #466).
 
+release-please authenticates with a short-lived GitHub App installation token minted inside the `release-please` job (`NOMBOT_APP_ID` / `NOMBOT_PRIVATE_KEY`), falling back to `NOMBOT_CLASSIC_PERSONAL_ACCESS_TOKEN` only if those secrets are absent. The app installation has its own API rate limit; the classic PAT shares nominal-bot's 5,000 requests/hour with Renovate and every other repo, which is how releases got rate-limited (#468). Mint the token in the job that uses it: GitHub scrubs app tokens at job boundaries, so one passed via `needs.*.outputs` or a reusable-workflow input arrives empty.
+
 ## Rust crate releases
 
 Pure-Rust crates under `crates/` that are published to crates.io are independent release-please components with `release-type: rust`. Do not add them to the legacy top-level `groups` block; that block is unsupported release-please config and should not be extended.


### PR DESCRIPTION
Closes #468.

**Symptom:** `release-please-publish` failed twice on Sep 3 with `API rate limit already exceeded for user ID 117409387` (nominal-bot). One failure landed after the GitHub release was created but before publish, leaving instro 1.17.0 tagged but not on PyPI until it was deleted and re-run by hand.

**Cause:** the job authenticates with `NOMBOT_CLASSIC_PERSONAL_ACCESS_TOKEN`, which shares nominal-bot's 5,000 requests/hour with Renovate and every other repo's automation.

**Fix:** mint a short-lived GitHub App installation token inside the `release-please` job (same step scout and nominal-client use) and pass it to release-please, falling back to the PAT only when the app secrets are absent. The token is minted in-job because GitHub scrubs app tokens at job boundaries. Downstream publish jobs are unchanged; they use OIDC trusted publishing.

No test: workflow-only change. Verified the YAML parses and that nominal-client's identical step succeeds under the same org secrets.