### PR TITLE
fix(ci): skip Claude Code Review on release-please PRs

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -28,10 +28,13 @@ jobs:
     # is the load-bearing isolation control: PRs from outside contributors (including
     # anyone opening a flood of hostile PRs) live on fork head repos and never trigger
     # this job -> no API spend and no secret exposure to untrusted code.
+    # Also skip release-please PRs: they are generated changelog/version bumps opened by
+    # the nombotv2 app, which the action rejects as a non-human actor (#471).
     if: |
       (github.event_name == 'pull_request' &&
         github.event.pull_request.draft == false &&
-        github.event.pull_request.head.repo.full_name == github.repository) ||
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        !startsWith(github.event.pull_request.head.ref, 'release-please--')) ||
       (github.event_name == 'issue_comment' &&
         github.event.issue.pull_request != null &&
         startsWith(github.event.comment.body, '@claude review') &&


### PR DESCRIPTION
Closes #471.

**Symptom:** since #469, release-please PRs are opened by the `nombotv2` app and `Claude Code Review` fails on them with `Workflow initiated by non-human actor: nombotv2 (type: Bot)` (run 33819892633 on #470). Not a required check, but a red X on every release PR.

**Cause:** the review job had no guard for release-please branches. It used to run a full review on each release PR only because nominal-bot is a User account.

**Fix:** skip the job when the PR head branch starts with `release-please--`, matching galaxy's `claude-review.yml`. On-demand `@claude review` comments are unaffected because that path is keyed on the commenter, not the PR author.

No test: workflow-only change, YAML verified to parse.