### PR TITLE
feat(awg): add awg to idn map

### DIFF
--- a/instro/lib/discover.py
+++ b/instro/lib/discover.py
@@ -67,6 +67,9 @@ _IDN_MAP: dict[tuple[str, str], tuple[str, str, int | None]] = {
     ("SIGLENT TECHNOLOGIES", "SDS1104X-E"): ("scope", "SiglentSDS1000XE", 4),
     ("SIGLENT TECHNOLOGIES", "SDS1202X-E"): ("scope", "SiglentSDS1000XE", 2),
     ("SIGLENT TECHNOLOGIES", "SDS1204X-E"): ("scope", "SiglentSDS1000XE", 4),
+    ("RIGOL TECHNOLOGIES", "DG1022Z"): ("awg", "RigolDG1022Z", 2),
+    ("RIGOL TECHNOLOGIES", "DG1062Z"): ("awg", "RigolDG1022Z", 2),
+    ("AGILENT TECHNOLOGIES", "33521B"): ("awg", "Keysight33521B", 1),
 }
 
 

--- a/instro/lib/discover.py
+++ b/instro/lib/discover.py
@@ -70,6 +70,7 @@ _IDN_MAP: dict[tuple[str, str], tuple[str, str, int | None]] = {
     ("RIGOL TECHNOLOGIES", "DG1022Z"): ("awg", "RigolDG1022Z", 2),
     ("RIGOL TECHNOLOGIES", "DG1062Z"): ("awg", "RigolDG1022Z", 2),
     ("AGILENT TECHNOLOGIES", "33521B"): ("awg", "Keysight33521B", 1),
+    ("KEYSIGHT TECHNOLOGIES", "33521B"): ("awg", "Keysight33521B", 1),
 }
 
 

--- a/tests/lib/test_discover.py
+++ b/tests/lib/test_discover.py
@@ -102,6 +102,7 @@ def test_scan_recognized_scope(idn: str, driver_class: str) -> None:
         ("Rigol Technologies,DG1022Z,DG1ZA000000000,03.01.12", "RigolDG1022Z", 2),
         ("Rigol Technologies,DG1062Z,DG1ZA000000000,03.01.12", "RigolDG1022Z", 2),
         ("Agilent Technologies,33521B,MY52702203,3.03-1.19-2.00-52-00", "Keysight33521B", 1),
+        ("Keysight Technologies,33521B,MY52702203,3.03-1.19-2.00-52-00", "Keysight33521B", 1),
     ],
 )
 def test_scan_recognized_awg(idn: str, driver_class: str, num_channels: int) -> None:

--- a/tests/lib/test_discover.py
+++ b/tests/lib/test_discover.py
@@ -96,6 +96,28 @@ def test_scan_recognized_scope(idn: str, driver_class: str) -> None:
     assert info.driver_class_name == driver_class
 
 
+@pytest.mark.parametrize(
+    "idn,driver_class,num_channels",
+    [
+        ("Rigol Technologies,DG1022Z,DG1ZA000000000,03.01.12", "RigolDG1022Z", 2),
+        ("Rigol Technologies,DG1062Z,DG1ZA000000000,03.01.12", "RigolDG1022Z", 2),
+        ("Agilent Technologies,33521B,MY52702203,3.03-1.19-2.00-52-00", "Keysight33521B", 1),
+    ],
+)
+def test_scan_recognized_awg(idn: str, driver_class: str, num_channels: int) -> None:
+    mock_rm = _rm_mock(("USB0::0x1AB1::0x0642::DG1ZA000000000::INSTR",))
+    with patch("instro.lib.discover.pyvisa.ResourceManager", return_value=mock_rm):
+        with patch("instro.lib.discover.VisaDriver") as mock_driver_cls:
+            mock_driver_cls.return_value.query.return_value = idn
+            result = scan_visa_resources()
+
+    assert len(result.instruments) == 1
+    info = result.instruments[0]
+    assert info.category == "awg"
+    assert info.driver_class_name == driver_class
+    assert info.num_channels == num_channels
+
+
 def test_scan_unrecognized() -> None:
     mock_rm = _rm_mock(("USB0::0xABCD::0x1234::INSTR",))
     with patch("instro.lib.discover.pyvisa.ResourceManager", return_value=mock_rm):


### PR DESCRIPTION
## Summary

This PR adds the supported AWG drivers to the IDN map in the discover tool. This allows the Keysight 333521B and Rigol DG1022Z AWGs to be a recognized instrument.

## Type of change

- [ ] Bug fix (`fix`)
- [x] New feature (`feat`)
- [ ] Breaking change (`feat!` / `fix!`)
- [ ] Refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] Chore / tooling (`chore`)

## Verification

<img width="1071" height="191" alt="Screenshot 2026-09-04 at 1 39 36 PM" src="https://github.com/user-attachments/assets/ad4bc0ad-3b5e-4d14-a3ac-61be057ff118" />

## Tests

- [x] Unit tests added or updated
- [ ] Existing tests cover this change
- [ ] No tests — explain why:

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(driver): add support for Keysight E36300`)
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] Documentation updated if user-facing behavior changed
- [x] Code follows the style/conventions of the surrounding code

## Notes for reviewers

The Rigol DG1022Z uses the same programming as the 1062Z based on the IDN output:

IDN: Rigol Technologies,**DG1062Z**,DG1ZA000000000,03.01.12