### PR TITLE
docs(unstable): add package README

### DIFF
--- a/packages/instro-unstable/README.md
+++ b/packages/instro-unstable/README.md
@@ -1,0 +1,31 @@
+# instro-unstable
+
+In-development categories and abstractions for [`instro`](https://github.com/nominal-io/instro) whose API isn't settled.
+
+Modules live here while their HAL surface is still changing. Once an API stabilizes, the module graduates into the core `instro` package under the same category name and the `unstable` segment drops out of the import path (`InstroAWG` moved this way in `instro` 1.18.0).
+
+## Installation
+
+```bash
+pip install 'instro[unstable]'   # with the instro core
+pip install instro-unstable       # standalone
+```
+
+## Usage
+
+Unstable modules mirror the core `instro` layout with `unstable` inserted after the top-level package name, and run behind the same `Instrument` base as the core HALs:
+
+```python
+from instro.unstable.vna import InstroVNA
+from instro.unstable.vna.drivers import NanoVNAv2Clone
+
+vna = InstroVNA(name="bench", driver=NanoVNAv2Clone(port="COM3"))
+```
+
+Currently shipping: `InstroVNA`, `InstroMotorController`, `InstroFlowController`, the `EspecGL` environmental chamber, a Keithley 2750 `InstroDMM` driver, and the `CanTransport` transport.
+
+API stability is not guaranteed release-to-release; pin to a specific version if you need reproducibility.
+
+## License
+
+[Apache License 2.0](./LICENSE).

--- a/packages/instro-unstable/pyproject.toml
+++ b/packages/instro-unstable/pyproject.toml
@@ -2,6 +2,7 @@
 name = "instro-unstable"
 version = "1.10.0"
 description = "Unstable modules for instro (in-development features)"
+readme = "README.md"
 license = "Apache-2.0"
 license-files = ["LICENSE"]
 requires-python = ">=3.10,<3.15"


### PR DESCRIPTION
## Summary

First of two `Release-As` commits for #476. Carries `Release-As: 1.11.0` for the `instro-unstable` component so release PR #470 ships instro-unstable 1.11.0 instead of 2.0.0. Adds the README the other published workspace packages already have and wires it into `pyproject.toml` so it shows on PyPI.

**Merge order matters:** merge this before #478, and squash with the footer in the commit body:

```
gh pr merge --squash --body "Release-As: 1.11.0"
```

## Type of change

- [x] Documentation (`docs`)

## Verification

Docs-only change; `uv lock --check` unaffected by the `readme` field.

## Tests

- [x] No tests — docs only

## Checklist

- [x] PR title follows Conventional Commits
- [x] Documentation updated