### PR TITLE
refactor(opcua): allow lowercased `OpcUaValue` variant aliases

### DIFF
--- a/crates/instro-opcua/src/types.rs
+++ b/crates/instro-opcua/src/types.rs
@@ -1109,7 +1109,7 @@ impl TryFrom<DataValue<ua::Variant>> for OpcUaDataPoint {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum OpcUaValue {
-    #[serde(alias = "boolean")]
+    #[serde(alias = "boolean", alias = "bool")]
     Boolean(bool),
     #[serde(alias = "int8")]
     Int8(i8),
@@ -1332,6 +1332,7 @@ mod tests {
     use open62541::ua::NodeId;
     use open62541_sys::UA_UserTokenPolicy;
     use open62541_sys::UA_UserTokenType;
+    use serde_json::from_str;
 
     use super::*;
 
@@ -1703,6 +1704,29 @@ mod tests {
         };
 
         assert_serde_json_roundtrip_eq(&info);
+    }
+
+    #[test]
+    fn opcua_value_roundtrips_lowercase() {
+        const CASES: &[&str] = &[
+            "{ \"bool\": true }",
+            "{ \"boolean\": true }",
+            "{ \"float\": 1.1 }",
+            "{ \"double\": 2.2 }",
+            "{ \"int8\": -1 }",
+            "{ \"int16\": -2 }",
+            "{ \"int32\": -3 }",
+            "{ \"int64\": -4 }",
+            "{ \"uint8\": 1 }",
+            "{ \"uint16\": 2 }",
+            "{ \"uint32\": 3 }",
+            "{ \"uint64\": 4 }",
+            "{ \"string\": \"test\" }",
+        ];
+
+        for case in CASES {
+            _ = from_str::<OpcUaValue>(case).unwrap_or_else(|_| panic!("lowercase value variant should deserialize: {case}"));
+        }
     }
 
     #[test]

--- a/crates/instro-opcua/src/types.rs
+++ b/crates/instro-opcua/src/types.rs
@@ -1109,18 +1109,31 @@ impl TryFrom<DataValue<ua::Variant>> for OpcUaDataPoint {
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub enum OpcUaValue {
+    #[serde(alias = "boolean")]
     Boolean(bool),
+    #[serde(alias = "int8")]
     Int8(i8),
+    #[serde(alias = "uint8")]
     UInt8(u8),
+    #[serde(alias = "int16")]
     Int16(i16),
+    #[serde(alias = "uint16")]
     UInt16(u16),
+    #[serde(alias = "int32")]
     Int32(i32),
+    #[serde(alias = "uint32")]
     UInt32(u32),
+    #[serde(alias = "int64")]
     Int64(i64),
+    #[serde(alias = "uint64")]
     UInt64(u64),
+    #[serde(alias = "float")]
     Float(f32),
+    #[serde(alias = "double")]
     Double(f64),
+    #[serde(alias = "string")]
     String(Cow<'static, str>),
+    #[serde(alias = "datetime")]
     DateTime(UtcDateTime),
 }
 

--- a/crates/instro-opcua/src/types.rs
+++ b/crates/instro-opcua/src/types.rs
@@ -1721,11 +1721,15 @@ mod tests {
             ("{ \"uint16\": 2 }", OpcUaValue::UInt16(2)),
             ("{ \"uint32\": 3 }", OpcUaValue::UInt32(3)),
             ("{ \"uint64\": 4 }", OpcUaValue::UInt64(4)),
-            ("{ \"string\": \"test\" }", OpcUaValue::String(Cow::Borrowed("test"))),
+            (
+                "{ \"string\": \"test\" }",
+                OpcUaValue::String(Cow::Borrowed("test")),
+            ),
         ];
 
         for (case, expected) in CASES {
-            let parsed = from_str::<OpcUaValue>(case).unwrap_or_else(|_| panic!("lowercase value variant should deserialize: {case}"));
+            let parsed = from_str::<OpcUaValue>(case)
+                .unwrap_or_else(|_| panic!("lowercase value variant should deserialize: {case}"));
             assert_eq!(&parsed, expected);
         }
     }

--- a/crates/instro-opcua/src/types.rs
+++ b/crates/instro-opcua/src/types.rs
@@ -1708,24 +1708,25 @@ mod tests {
 
     #[test]
     fn opcua_value_roundtrips_lowercase() {
-        const CASES: &[&str] = &[
-            "{ \"bool\": true }",
-            "{ \"boolean\": true }",
-            "{ \"float\": 1.1 }",
-            "{ \"double\": 2.2 }",
-            "{ \"int8\": -1 }",
-            "{ \"int16\": -2 }",
-            "{ \"int32\": -3 }",
-            "{ \"int64\": -4 }",
-            "{ \"uint8\": 1 }",
-            "{ \"uint16\": 2 }",
-            "{ \"uint32\": 3 }",
-            "{ \"uint64\": 4 }",
-            "{ \"string\": \"test\" }",
+        const CASES: &[(&str, OpcUaValue)] = &[
+            ("{ \"bool\": true }", OpcUaValue::Boolean(true)),
+            ("{ \"boolean\": true }", OpcUaValue::Boolean(true)),
+            ("{ \"float\": 1.1 }", OpcUaValue::Float(1.1)),
+            ("{ \"double\": 2.2 }", OpcUaValue::Double(2.2)),
+            ("{ \"int8\": -1 }", OpcUaValue::Int8(-1)),
+            ("{ \"int16\": -2 }", OpcUaValue::Int16(-2)),
+            ("{ \"int32\": -3 }", OpcUaValue::Int32(-3)),
+            ("{ \"int64\": -4 }", OpcUaValue::Int64(-4)),
+            ("{ \"uint8\": 1 }", OpcUaValue::UInt8(1)),
+            ("{ \"uint16\": 2 }", OpcUaValue::UInt16(2)),
+            ("{ \"uint32\": 3 }", OpcUaValue::UInt32(3)),
+            ("{ \"uint64\": 4 }", OpcUaValue::UInt64(4)),
+            ("{ \"string\": \"test\" }", OpcUaValue::String(Cow::Borrowed("test"))),
         ];
 
-        for case in CASES {
-            _ = from_str::<OpcUaValue>(case).unwrap_or_else(|_| panic!("lowercase value variant should deserialize: {case}"));
+        for (case, expected) in CASES {
+            let parsed = from_str::<OpcUaValue>(case).unwrap_or_else(|_| panic!("lowercase value variant should deserialize: {case}"));
+            assert_eq!(&parsed, expected);
         }
     }
 

--- a/uv.lock
+++ b/uv.lock
@@ -594,7 +594,7 @@ wheels = [
 
 [[package]]
 name = "instro"
-version = "1.17.0"
+version = "1.18.1"
 source = { editable = "." }
 dependencies = [
     { name = "fastavro", extra = ["snappy"] },
@@ -817,7 +817,7 @@ requires-dist = [{ name = "instro", editable = "." }]
 
 [[package]]
 name = "instro-unstable"
-version = "1.10.0"
+version = "1.11.0"
 source = { editable = "packages/instro-unstable" }
 dependencies = [
     { name = "gs-usb" },


### PR DESCRIPTION
## Summary

_Briefly describe what this PR does and why. If it fixes an existing issue, link it (e.g. `Fixes #123`)._

Allows for alternatively-cased representations of each of the primitive scalar types.

## Type of change

- [ ] Bug fix (`fix`)
- [ ] New feature (`feat`)
- [ ] Breaking change (`feat!` / `fix!`)
- [x] Refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] Chore / tooling (`chore`)

## Verification

_How did you verify this change works? Provide evidence the reviewer can evaluate without reproducing your setup — e.g. test output, screenshots, logs, repro steps + result. If the change is hardware-specific and you don't have the device, say so._

Minor validation added in unit tests, just a minor behavioral tweak.

## Tests

- [x] Unit tests added or updated
- [ ] Existing tests cover this change
- [ ] No tests — explain why:
Added tests for all lower-case field variants (minus datetime, deferring that one since I still need to understand the ser/des behavior of that one more)

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(driver): add support for Keysight E36300`)
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] Documentation updated if user-facing behavior changed
- [x] Code follows the style/conventions of the surrounding code

## Notes for reviewers

_Optional — call out specific files, edge cases, or decisions you'd like eyes on._
