### PR TITLE
fix(eload): cache mode only after the driver confirms set_mode

### DIFF
--- a/instro/eload/eload.py
+++ b/instro/eload/eload.py
@@ -221,10 +221,12 @@ class InstroELoad(Instrument):
     @publish_command
     def set_mode(self, mode: LoadMode, channel: int = 1, **kwargs) -> Command:
         """Set the channel's operation mode: CC, CR, CP, or CV. Not all models support every mode."""
-        self._mode = mode
         logger.debug("Sending E-Load set_mode command to '%s' on channel %s", self.name, channel)
         with self._resource_lock:
             self._driver.set_mode(mode=mode, channel=channel)
+            # Cache only once the driver confirms, so a failed set_mode can't leave set_level/set_range
+            # running against a mode the instrument was never put into.
+            self._mode = mode
             timestamp = time.time_ns()
 
         descriptor = f"ch{channel}_mode.cmd" if self.legacy_naming else f"ch{channel}.mode.cmd"

--- a/tests/eload/test_eload_drivers.py
+++ b/tests/eload/test_eload_drivers.py
@@ -192,6 +192,18 @@ def test_nominal_eload_set_mode_delegates() -> None:
     driver.set_mode.assert_called_once_with(mode=LoadMode.CC, channel=2)
 
 
+def test_nominal_eload_set_mode_leaves_mode_unset_when_driver_raises() -> None:
+    driver = _stub_driver()
+    driver.set_mode.side_effect = NotImplementedError("CP not supported")
+    eload = InstroELoad(name="ut", driver=driver)
+
+    with pytest.raises(NotImplementedError):
+        eload.set_mode(LoadMode.CP)
+
+    with pytest.raises(ValueError, match="Mode must be set"):
+        eload.set_level(value=1.0)
+
+
 def test_nominal_eload_set_level_requires_mode() -> None:
     driver = _stub_driver()
     eload = InstroELoad(name="ut", driver=driver)


### PR DESCRIPTION
## Summary

`InstroELoad.set_mode()` assigned `self._mode = mode` before it entered `self._resource_lock` and called `self._driver.set_mode(...)` (`instro/eload/eload.py:224` on `main`). If the driver raised, for example a model that answers CP with `NotImplementedError`, the exception propagated but the cached mode was already updated to a mode the instrument was never put into. The next `set_level()` or `set_range()` then sailed past the `"Mode must be set"` guard and handed that wrong mode to the driver, so the load was driven in CP units while it was still in whatever mode it was actually in.

`open()` already resets `self._mode = None` when `_apply_load_config()` fails, so the config-driven path was covered. Direct `set_mode()` calls had no recovery, and the stale value persisted silently.

The fix moves the assignment inside the lock, after `self._driver.set_mode(...)` returns. `InstroDMM` already does it this way: every one of its setters calls the driver first and only then updates `self._measurement_config` (`instro/dmm/dmm.py:292-365`). ELoad was the outlier.

Fixes #417

## Type of change

- [x] Bug fix (`fix`)
- [ ] New feature (`feat`)
- [ ] Breaking change (`feat!` / `fix!`)
- [ ] Refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] Chore / tooling (`chore`)

## Verification

The new test fails on `main` and passes with the fix. Checking out just the unmodified module under the new test:

```
$ git checkout origin/main -- instro/eload/eload.py
$ uv run --frozen pytest -q tests/eload/test_eload_drivers.py::test_nominal_eload_set_mode_leaves_mode_unset_when_driver_raises
E       Failed: DID NOT RAISE ValueError
1 failed in 0.40s
```

With the fix in place:

```
$ uv run --frozen pytest -q tests/eload/test_eload_drivers.py::test_nominal_eload_set_mode_leaves_mode_unset_when_driver_raises
1 passed in 0.26s
$ uv run --frozen pytest -q tests/eload
56 passed, 2 deselected in 0.51s
$ uv run --frozen pytest -q
2235 passed, 2 skipped, 490 deselected, 1 xfailed in 17.99s
$ uv run --frozen ruff format --check
305 files already formatted
$ uv run --frozen ruff check
All checks passed!
$ uv run --frozen mypy
Success: no issues found in 85 source files
```

`main` at b8f262a gives 2234 passed on the same suite, so the only difference is the added test. The change is pure Python and touches no Rust, so I ran the Python half of `just check` and `just test` rather than the full native build. No hardware was used; the test drives a `MagicMock(spec=ELoadDriverBase)` the same way the surrounding `InstroELoad` tests do.

## Tests

- [x] Unit tests added or updated
- [ ] Existing tests cover this change
- [ ] No tests, explain why:

## Checklist

- [x] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(driver): add support for Keysight E36300`)
- [x] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [x] Documentation updated if user-facing behavior changed
- [x] Code follows the style/conventions of the surrounding code

## Notes for reviewers

No docs change: `docs/guides/instrumentation/eload.mdx` already says the mode must be set before level or range, and this only makes the code hold to that when the driver rejects the mode.

I left the `self._mode = None` rollback in `open()` alone. It still earns its place, because `_apply_load_config()` can fail at `set_range` or `set_level` after `set_mode` legitimately succeeded, and the cache has to be cleared for that case too.

Scoped to #417 only. #416, the atomicity of `_apply_load_config` across separately locked setters, is untouched here: the assignment now sits inside `_resource_lock`, which is where #416 would want it, so that work can build on this rather than undo it.
