### PR TITLE
feat(opcua): capture node DataType during browse and metadata reads

### DIFF
--- a/crates/instro-opcua/src/browse.rs
+++ b/crates/instro-opcua/src/browse.rs
@@ -22,11 +22,10 @@ use std::pin::Pin;
 use anyhow::Context as _;
 use anyhow::Result;
 use anyhow::bail;
-use open62541::ScalarValue;
-use open62541::VariantValue;
 use open62541::ua;
 
 use super::client::OpcUaClient;
+use super::client::data_type_from_value;
 use super::types::BrowsePath;
 use super::types::OpcUaNode;
 use super::types::OpcUaNodeClass;
@@ -35,10 +34,21 @@ use super::types::QualifiedBrowseName;
 
 const DEFAULT_MAX_BROWSE_NODES: usize = 1_000_000;
 
+const DATA_TYPE_READ_BATCH_SIZE: usize = 1_000;
+
 /// A trait for browsing a single node and returning its children.
 pub trait Browse {
     /// Browse a single node and return its children.
     fn browse_node(&self, node_id: OpcUaNodeId) -> impl Future<Output = Result<Vec<OpcUaNode>>>;
+
+    /// Populates `data_type` for every `Variable` node in `nodes` (recursively,
+    /// including children). The default does nothing; `browse_node` never populates
+    /// `data_type`, `browse_all*` calls this once per tree.
+    fn fill_data_types(&self, nodes: &mut [OpcUaNode]) -> impl Future<Output = ()> {
+        async {
+            let _ = nodes;
+        }
+    }
 }
 
 /// A trait for browsing all nodes in a subtree and returning a list of all nodes.
@@ -83,7 +93,7 @@ impl<T: Browse> BrowseAll for T {
         let mut ancestors = HashSet::new();
         ancestors.insert(node_id.clone());
         let mut visited = 0;
-        browse_recursive(
+        let mut nodes = browse_recursive(
             self,
             node_id,
             0,
@@ -93,7 +103,11 @@ impl<T: Browse> BrowseAll for T {
             &mut visited,
             DEFAULT_MAX_BROWSE_NODES,
         )
-        .await
+        .await?;
+
+        self.fill_data_types(&mut nodes).await;
+
+        Ok(nodes)
     }
 }
 
@@ -115,7 +129,7 @@ impl Browse for OpcUaClient {
             }
         }
 
-        let mut nodes: Vec<OpcUaNode> = all_refs
+        let nodes: Vec<OpcUaNode> = all_refs
             .into_iter()
             .filter_map(|reference| {
                 let id = reference.node_id().node_id();
@@ -148,60 +162,58 @@ impl Browse for OpcUaClient {
             })
             .collect();
 
-        self.fill_variable_data_types(&mut nodes).await;
-
         Ok(nodes)
     }
-}
 
-impl OpcUaClient {
-    /// Reads the `DataType` attribute for every `Variable` node in `nodes` in a single
-    /// batched request. Failures are logged and leave `data_type` as `None`.
-    async fn fill_variable_data_types(&self, nodes: &mut [OpcUaNode]) {
-        let variables = nodes
-            .iter_mut()
-            .filter(|node| matches!(node.node_class, OpcUaNodeClass::Variable))
-            .collect::<Vec<_>>();
-
-        if variables.is_empty() {
-            return;
+    async fn fill_data_types(&self, nodes: &mut [OpcUaNode]) {
+        // Collect (`node_id`, `data_type` slot) pairs for every `Variable` node in the
+        // tree. Node and slot borrows are disjoint fields, so both can be held.
+        fn collect_variables<'a>(
+            nodes: &'a mut [OpcUaNode],
+            out: &mut Vec<(&'a OpcUaNodeId, &'a mut Option<OpcUaNodeId>)>,
+        ) {
+            for node in nodes.iter_mut() {
+                if matches!(node.node_class, OpcUaNodeClass::Variable) {
+                    out.push((&node.node_id, &mut node.data_type));
+                }
+                collect_variables(&mut node.children, out);
+            }
         }
 
-        let pairs = variables
-            .iter()
-            .map(|node| (node.node_id.clone().into(), ua::AttributeId::DATATYPE))
-            .collect::<Vec<_>>();
+        let mut variables = Vec::new();
+        collect_variables(nodes, &mut variables);
 
-        let values = match self.read_many_attributes(&pairs).await {
-            Ok(values) => values,
-            Err(error) => {
+        for chunk in variables.chunks_mut(DATA_TYPE_READ_BATCH_SIZE) {
+            let pairs = chunk
+                .iter()
+                .map(|(node_id, _)| ((*node_id).clone().into(), ua::AttributeId::DATATYPE))
+                .collect::<Vec<_>>();
+
+            let values = match self.read_many_attributes(&pairs).await {
+                Ok(values) => values,
+                Err(error) => {
+                    tracing::warn!(
+                        target: "opcua::browse",
+                        error = ?error,
+                        "failed to read data types for browsed variable nodes"
+                    );
+                    continue;
+                }
+            };
+
+            if values.len() != chunk.len() {
                 tracing::warn!(
                     target: "opcua::browse",
-                    error = ?error,
-                    "failed to read data types for browsed variable nodes"
+                    expected = chunk.len(),
+                    actual = values.len(),
+                    "data type read returned unexpected number of results; leaving data types unset"
                 );
-                return;
+                continue;
             }
-        };
 
-        if values.len() != variables.len() {
-            tracing::warn!(
-                target: "opcua::browse",
-                expected = variables.len(),
-                actual = values.len(),
-                "data type read returned unexpected number of results; leaving data types unset"
-            );
-            return;
-        }
-
-        for (node, value) in variables.into_iter().zip(values) {
-            node.data_type = value
-                .value()
-                .and_then(|variant| match variant.to_value() {
-                    VariantValue::Scalar(ScalarValue::NodeId(id)) => Some(id),
-                    _ => None,
-                })
-                .and_then(|id| OpcUaNodeId::try_from(&id).ok());
+            for ((_, data_type), value) in chunk.iter_mut().zip(values) {
+                **data_type = data_type_from_value(&value);
+            }
         }
     }
 }
@@ -1015,5 +1027,67 @@ mod tests {
         let cycle_len = 500;
         let (browser, root) = long_cycle(cycle_len);
         assert!(browser.browse(root, None).is_err());
+    }
+
+    /// `browse_all` invokes `fill_data_types` exactly once, over the whole
+    /// (recursively flattened) tree of browsed nodes.
+    #[test]
+    fn browse_all_fills_data_types_once_for_all_variables() {
+        use std::sync::atomic::AtomicUsize;
+        use std::sync::atomic::Ordering;
+
+        struct CountingBrowser {
+            inner: MockBrowser,
+            calls: AtomicUsize,
+            variables_seen: AtomicUsize,
+        }
+
+        impl CountingBrowser {
+            fn count_variables(nodes: &[OpcUaNode]) -> usize {
+                nodes
+                    .iter()
+                    .map(|node| {
+                        usize::from(matches!(node.node_class, OpcUaNodeClass::Variable))
+                            .saturating_add(Self::count_variables(&node.children))
+                    })
+                    .sum()
+            }
+        }
+
+        impl Browse for CountingBrowser {
+            async fn browse_node(&self, node_id: OpcUaNodeId) -> Result<Vec<OpcUaNode>> {
+                self.inner.browse_node(node_id).await
+            }
+
+            async fn fill_data_types(&self, nodes: &mut [OpcUaNode]) {
+                self.calls.fetch_add(1, Ordering::SeqCst);
+                self.variables_seen
+                    .fetch_add(Self::count_variables(nodes), Ordering::SeqCst);
+            }
+        }
+
+        // 1 -> [var(2), obj(3)], 3 -> [var(4), var(5)]: variables at both levels,
+        // one of them nested under an Object child.
+        let mut inner = MockBrowser::new();
+        inner.add_children(nid(1), vec![var(2), obj(3)]);
+        inner.add_children(nid(3), vec![var(4), var(5)]);
+        let browser = CountingBrowser {
+            inner,
+            calls: AtomicUsize::new(0),
+            variables_seen: AtomicUsize::new(0),
+        };
+
+        let runtime = Builder::new_current_thread()
+            .enable_all()
+            .max_blocking_threads(1)
+            .build()
+            .expect("failed to build tokio runtime");
+        let nodes = runtime
+            .block_on(browser.browse_all(nid(1), None))
+            .expect("browse_all should succeed");
+
+        assert_eq!(browser.calls.load(Ordering::SeqCst), 1);
+        assert_eq!(browser.variables_seen.load(Ordering::SeqCst), 3);
+        assert_eq!(count_nodes(&nodes), 4);
     }
 }

--- a/crates/instro-opcua/src/browse.rs
+++ b/crates/instro-opcua/src/browse.rs
@@ -184,6 +184,16 @@ impl OpcUaClient {
             }
         };
 
+        if values.len() != variables.len() {
+            tracing::warn!(
+                target: "opcua::browse",
+                expected = variables.len(),
+                actual = values.len(),
+                "data type read returned unexpected number of results; leaving data types unset"
+            );
+            return;
+        }
+
         for (node, value) in variables.into_iter().zip(values) {
             node.data_type = value
                 .value()

--- a/crates/instro-opcua/src/browse.rs
+++ b/crates/instro-opcua/src/browse.rs
@@ -22,6 +22,8 @@ use std::pin::Pin;
 use anyhow::Context as _;
 use anyhow::Result;
 use anyhow::bail;
+use open62541::ScalarValue;
+use open62541::VariantValue;
 use open62541::ua;
 
 use super::client::OpcUaClient;
@@ -113,7 +115,7 @@ impl Browse for OpcUaClient {
             }
         }
 
-        let nodes = all_refs
+        let mut nodes: Vec<OpcUaNode> = all_refs
             .into_iter()
             .filter_map(|reference| {
                 let id = reference.node_id().node_id();
@@ -140,12 +142,57 @@ impl Browse for OpcUaClient {
                     display_name: reference.display_name().text().to_string(),
                     node_class,
                     browse_path: BrowsePath::from_segment(qualified_browse_name),
+                    data_type: None,
                     children: Vec::new(),
                 })
             })
             .collect();
 
+        self.fill_variable_data_types(&mut nodes).await;
+
         Ok(nodes)
+    }
+}
+
+impl OpcUaClient {
+    /// Reads the `DataType` attribute for every `Variable` node in `nodes` in a single
+    /// batched request. Failures are logged and leave `data_type` as `None`.
+    async fn fill_variable_data_types(&self, nodes: &mut [OpcUaNode]) {
+        let variables = nodes
+            .iter_mut()
+            .filter(|node| matches!(node.node_class, OpcUaNodeClass::Variable))
+            .collect::<Vec<_>>();
+
+        if variables.is_empty() {
+            return;
+        }
+
+        let pairs = variables
+            .iter()
+            .map(|node| (node.node_id.clone().into(), ua::AttributeId::DATATYPE))
+            .collect::<Vec<_>>();
+
+        let values = match self.read_many_attributes(&pairs).await {
+            Ok(values) => values,
+            Err(error) => {
+                tracing::warn!(
+                    target: "opcua::browse",
+                    error = ?error,
+                    "failed to read data types for browsed variable nodes"
+                );
+                return;
+            }
+        };
+
+        for (node, value) in variables.into_iter().zip(values) {
+            node.data_type = value
+                .value()
+                .and_then(|variant| match variant.to_value() {
+                    VariantValue::Scalar(ScalarValue::NodeId(id)) => Some(id),
+                    _ => None,
+                })
+                .and_then(|id| OpcUaNodeId::try_from(&id).ok());
+        }
     }
 }
 
@@ -260,6 +307,7 @@ mod tests {
             display_name: format!("Object {id}"),
             node_class: OpcUaNodeClass::Object,
             browse_path: browse_path(0, browse_name),
+            data_type: None,
             children: Vec::new(),
         }
     }
@@ -272,6 +320,7 @@ mod tests {
             display_name: format!("Variable {id}"),
             node_class: OpcUaNodeClass::Variable,
             browse_path: browse_path(0, browse_name),
+            data_type: None,
             children: Vec::new(),
         }
     }
@@ -284,6 +333,7 @@ mod tests {
             display_name: format!("Method {id}"),
             node_class: OpcUaNodeClass::Method,
             browse_path: browse_path(0, browse_name),
+            data_type: None,
             children: Vec::new(),
         }
     }
@@ -296,6 +346,7 @@ mod tests {
             display_name: format!("View {id}"),
             node_class: OpcUaNodeClass::View,
             browse_path: browse_path(0, browse_name),
+            data_type: None,
             children: Vec::new(),
         }
     }

--- a/crates/instro-opcua/src/client.rs
+++ b/crates/instro-opcua/src/client.rs
@@ -68,6 +68,7 @@ use super::types::OpcUaDataPoint;
 use super::types::OpcUaMonitoredItemConfig;
 use super::types::OpcUaNode;
 use super::types::OpcUaNodeClass;
+use super::types::OpcUaNodeMetadata;
 use super::types::OpcUaPki;
 use super::types::OpcUaSample;
 use super::types::OpcUaSecurityMode;
@@ -142,8 +143,20 @@ impl<'nodes> OpcUaNodeReadBatch<'nodes> {
     }
 }
 
+/// Decodes a `DataType` attribute read result into an [`OpcUaNodeId`].
+/// Returns `None` when the value is unset, has a bad status, or is not a scalar `NodeId`.
+pub(crate) fn data_type_from_value(value: &DataValue<ua::Variant>) -> Option<OpcUaNodeId> {
+    value
+        .value()
+        .and_then(|variant| match variant.to_value() {
+            VariantValue::Scalar(ScalarValue::NodeId(id)) => Some(id),
+            _ => None,
+        })
+        .and_then(|id| OpcUaNodeId::try_from(&id).ok())
+}
+
 fn decode_node_class_variant(
-    value: &DataValue<ua::NodeClass>,
+    value: &DataValue<ua::Variant>,
     node_id: &OpcUaNodeId,
 ) -> Result<OpcUaNodeClass> {
     let Some(variant) = value.value() else {
@@ -300,56 +313,75 @@ impl OpcUaClient {
             .collect_vec())
     }
 
-    /// Reads the browse name, display name, and node class for a node.
-    pub async fn read_node_metadata(
-        &self,
-        node_id: &OpcUaNodeId,
-    ) -> Result<(QualifiedBrowseName, String, OpcUaNodeClass)> {
+    /// Reads the browse name, display name, node class, and data type for a node
+    /// in a single batched `Read` request.
+    ///
+    /// `DataType` is reported only by `Variable` nodes; for other node classes (or
+    /// when the server doesn't report it) [`OpcUaNodeMetadata::data_type`] is `None`.
+    pub async fn read_node_metadata(&self, node_id: &OpcUaNodeId) -> Result<OpcUaNodeMetadata> {
         let ua_node_id = ua::NodeId::from(node_id.clone());
+        let attributes = [
+            (ua_node_id.clone(), ua::AttributeId::BROWSENAME),
+            (ua_node_id.clone(), ua::AttributeId::DISPLAYNAME),
+            (ua_node_id.clone(), ua::AttributeId::NODECLASS),
+            (ua_node_id, ua::AttributeId::DATATYPE),
+        ];
 
-        let browse_name_value = self
-            .read_attribute(&ua_node_id, ua::AttributeId::BROWSENAME_T)
+        let values = self
+            .read_many_attributes(&attributes)
             .await
-            .with_context(|| format!("reading browse name for node {node_id}"))?;
-        let browse_name = browse_name_value.scalar_value().with_context(|| {
-            format!(
-                "browse name attribute for node {node_id} was not readable: {:?}",
-                browse_name_value.status()
-            )
-        })?;
+            .with_context(|| format!("reading metadata for node {node_id}"))?;
 
-        let display_name_value = self
-            .read_attribute(&ua_node_id, ua::AttributeId::DISPLAYNAME_T)
-            .await
-            .with_context(|| format!("reading display name for node {node_id}"))?;
+        let values_len = values.len();
+        let Ok(
+            [
+                browse_name_value,
+                display_name_value,
+                node_class_value,
+                data_type_value,
+            ],
+        ) = <[DataValue<ua::Variant>; 4]>::try_from(values)
+        else {
+            bail!("read result length does not match attribute list length: {values_len} != 4");
+        };
 
-        let display_name = display_name_value.scalar_value().with_context(|| {
-            format!(
-                "display name attribute for node {node_id} was not readable: {:?}",
-                display_name_value.status()
-            )
-        })?;
+        let browse_name = browse_name_value
+            .value()
+            .and_then(|variant| variant.as_scalar::<ua::QualifiedName>())
+            .with_context(|| {
+                format!(
+                    "browse name attribute for node {node_id} was not readable: {:?}",
+                    browse_name_value.status()
+                )
+            })?;
 
-        let node_class_value = self
-            .read_attribute(&ua_node_id, ua::AttributeId::NODECLASS_T)
-            .await
-            .with_context(|| format!("reading node class for node {node_id}"))?;
+        let display_name = display_name_value
+            .value()
+            .and_then(|variant| variant.as_scalar::<ua::LocalizedText>())
+            .with_context(|| {
+                format!(
+                    "display name attribute for node {node_id} was not readable: {:?}",
+                    display_name_value.status()
+                )
+            })?;
 
-        let node_class = node_class_value
-            .scalar_value()
-            .with_context(|| format!("node class attribute for node {node_id} was not readable"));
+        let node_class = match node_class_value
+            .value()
+            .and_then(|variant| variant.as_scalar::<ua::NodeClass>())
+        {
+            Some(node_class) => OpcUaNodeClass::from(node_class),
+            None => decode_node_class_variant(&node_class_value, node_id)?,
+        };
 
-        Ok((
-            QualifiedBrowseName {
+        Ok(OpcUaNodeMetadata {
+            browse_name: QualifiedBrowseName {
                 namespace_index: browse_name.namespace_index(),
                 name: browse_name.name().to_string(),
             },
-            display_name.text().to_string(),
-            match node_class {
-                Ok(node_class) => OpcUaNodeClass::from(node_class),
-                Err(_) => decode_node_class_variant(&node_class_value, node_id)?,
-            },
-        ))
+            display_name: display_name.text().to_string(),
+            node_class,
+            data_type: data_type_from_value(&data_type_value),
+        })
     }
 
     /// Starts a server-push subscription for the given `nodes`, invoking

--- a/crates/instro-opcua/src/client.rs
+++ b/crates/instro-opcua/src/client.rs
@@ -1150,6 +1150,7 @@ mod subscription_loop_tests {
             display_name: name.to_owned(),
             node_class: OpcUaNodeClass::Variable,
             browse_path: BrowsePath::from_segment(QualifiedBrowseName::new(1, name.to_owned())),
+            data_type: None,
             children: Vec::new(),
         }
     }

--- a/crates/instro-opcua/src/types.rs
+++ b/crates/instro-opcua/src/types.rs
@@ -860,6 +860,17 @@ pub struct OpcUaNode {
     pub children: Vec<OpcUaNode>,
 }
 
+/// Node metadata read from the server's address space via a single batched
+/// attribute read (`BrowseName`, `DisplayName`, `NodeClass`, `DataType`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OpcUaNodeMetadata {
+    pub browse_name: QualifiedBrowseName,
+    pub display_name: String,
+    pub node_class: OpcUaNodeClass,
+    /// `DataType` attribute; `None` for non-`Variable` nodes or when the server doesn't report one.
+    pub data_type: Option<OpcUaNodeId>,
+}
+
 impl OpcUaNode {
     /// Human-readable name of the node's data type: the builtin OPC-UA type name for
     /// namespace-0 builtin types, otherwise the canonical node id string.

--- a/crates/instro-opcua/src/types.rs
+++ b/crates/instro-opcua/src/types.rs
@@ -854,7 +854,63 @@ pub struct OpcUaNode {
     /// The namespace-qualified browse path to this node.
     #[serde(default)]
     pub browse_path: BrowsePath,
+    /// The `DataType` attribute of a `Variable` node; `None` for other node classes or when unknown.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub data_type: Option<OpcUaNodeId>,
     pub children: Vec<OpcUaNode>,
+}
+
+impl OpcUaNode {
+    /// Human-readable name of the node's data type: the builtin OPC-UA type name for
+    /// namespace-0 builtin types, otherwise the canonical node id string.
+    pub fn data_type_name(&self) -> Option<Cow<'static, str>> {
+        let data_type = self.data_type.as_ref()?;
+        Some(match builtin_data_type_name(data_type) {
+            Some(name) => Cow::Borrowed(name),
+            None => Cow::Owned(data_type.to_string()),
+        })
+    }
+}
+
+fn builtin_data_type_name(data_type: &OpcUaNodeId) -> Option<&'static str> {
+    if data_type.namespace() != 0 {
+        return None;
+    }
+    let NodeIdKind::Numeric(id) = data_type.kind() else {
+        return None;
+    };
+    Some(match *id {
+        1 => "Boolean",
+        2 => "SByte",
+        3 => "Byte",
+        4 => "Int16",
+        5 => "UInt16",
+        6 => "Int32",
+        7 => "UInt32",
+        8 => "Int64",
+        9 => "UInt64",
+        10 => "Float",
+        11 => "Double",
+        12 => "String",
+        13 => "DateTime",
+        14 => "Guid",
+        15 => "ByteString",
+        16 => "XmlElement",
+        17 => "NodeId",
+        18 => "ExpandedNodeId",
+        19 => "StatusCode",
+        20 => "QualifiedName",
+        21 => "LocalizedText",
+        22 => "Structure",
+        23 => "DataValue",
+        24 => "BaseDataType",
+        25 => "DiagnosticInfo",
+        26 => "Number",
+        27 => "Integer",
+        28 => "UInteger",
+        29 => "Enumeration",
+        _ => return None,
+    })
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -1882,6 +1938,7 @@ mod tests {
             display_name: "Objects".into(),
             node_class: OpcUaNodeClass::Object,
             browse_path: BrowsePath::from_segment(QualifiedBrowseName::new(0, "Objects".into())),
+            data_type: None,
             children: vec![OpcUaNode {
                 node_id: OpcUaNodeId::string(2, "Temp".into()),
                 browse_name: "Temperature".into(),
@@ -1891,11 +1948,32 @@ mod tests {
                     2,
                     "Temperature".into(),
                 )),
+                data_type: Some(OpcUaNodeId::numeric(0, 11)),
                 children: vec![],
             }],
         };
 
         assert_serde_json_roundtrip_eq(&browse);
+    }
+
+    #[test]
+    fn data_type_name_maps_builtin_and_falls_back_to_node_id() {
+        let mut node = OpcUaNode {
+            node_id: OpcUaNodeId::string(2, "Temp".into()),
+            browse_name: "Temp".into(),
+            display_name: "Temp".into(),
+            node_class: OpcUaNodeClass::Variable,
+            browse_path: BrowsePath::default(),
+            data_type: None,
+            children: vec![],
+        };
+        assert_eq!(node.data_type_name(), None);
+
+        node.data_type = Some(OpcUaNodeId::numeric(0, 11));
+        assert_eq!(node.data_type_name().as_deref(), Some("Double"));
+
+        node.data_type = Some(OpcUaNodeId::numeric(3, 1001));
+        assert_eq!(node.data_type_name().as_deref(), Some("ns=3;i=1001"));
     }
 
     #[test]

--- a/crates/instro-opcua/tests/client_harness.rs
+++ b/crates/instro-opcua/tests/client_harness.rs
@@ -66,6 +66,7 @@ fn opcua_node(
         display_name: browse_name.to_owned(),
         node_class,
         browse_path: BrowsePath::from_segment(QualifiedBrowseName::new(1, browse_name.to_owned())),
+        data_type: None,
         children: Vec::new(),
     })
 }

--- a/crates/instro-opcua/tests/client_harness.rs
+++ b/crates/instro-opcua/tests/client_harness.rs
@@ -374,6 +374,11 @@ async fn browse_node_and_browse_all_return_test_hierarchy() -> Result<()> {
         "Temperature has no children in this test server",
     );
     assert_eq!(temperature.browse_path.to_string(), "/2:Temperature");
+    assert_eq!(
+        temperature.data_type_name().as_deref(),
+        Some("Double"),
+        "DataType attribute of Temperature should be read during browse"
+    );
 
     let flow = tree
         .iter()
@@ -399,6 +404,7 @@ async fn browse_node_and_browse_all_return_test_hierarchy() -> Result<()> {
         .context("browse_all omitted Inner folder")?;
     assert_eq!(inner.node_class, OpcUaNodeClass::Object);
     assert_eq!(inner.browse_path.to_string(), "/2:Inner");
+    assert_eq!(inner.data_type, None);
 
     let pressure = inner
         .children
@@ -407,6 +413,7 @@ async fn browse_node_and_browse_all_return_test_hierarchy() -> Result<()> {
         .context("browse_all omitted nested Pressure node")?;
     assert_eq!(pressure.node_class, OpcUaNodeClass::Variable);
     assert_eq!(pressure.browse_path.to_string(), "/2:Inner/2:Pressure");
+    assert_eq!(pressure.data_type_name().as_deref(), Some("UInt32"));
 
     let status = inner
         .children

--- a/crates/instro-opcua/tests/client_harness.rs
+++ b/crates/instro-opcua/tests/client_harness.rs
@@ -428,10 +428,19 @@ async fn browse_node_and_browse_all_return_test_hierarchy() -> Result<()> {
         &NodeIdKind::ByteString(b"inner-status-id".to_vec())
     );
 
-    let (metadata_name, display_name, node_class) = client.read_node_metadata(&sensors_id).await?;
-    assert_eq!(metadata_name.name, "Sensors");
-    assert_eq!(display_name, "Sensors");
-    assert_eq!(node_class, OpcUaNodeClass::Object);
+    let metadata = client.read_node_metadata(&sensors_id).await?;
+    assert_eq!(metadata.browse_name.name, "Sensors");
+    assert_eq!(metadata.display_name, "Sensors");
+    assert_eq!(metadata.node_class, OpcUaNodeClass::Object);
+    assert_eq!(metadata.data_type, None);
+
+    let temperature_metadata = client.read_node_metadata(&temperature.node_id).await?;
+    assert_eq!(temperature_metadata.node_class, OpcUaNodeClass::Variable);
+    assert_eq!(
+        temperature_metadata.data_type,
+        Some(OpcUaNodeId::numeric(0, 11)),
+        "read_node_metadata should report the DataType attribute of a Variable node"
+    );
 
     client.disconnect().await?;
     Ok(())


### PR DESCRIPTION
## Summary

- `OpcUaNode` gains `data_type: Option<OpcUaNodeId>` (`#[serde(default, skip_serializing_if = "Option::is_none")]`, so existing serialized trees still deserialize and non-variables don't emit the key).
- `OpcUaNode::data_type_name() -> Option<Cow<'static, str>>` maps ns=0 builtin type ids (`i=1..=29`: `Boolean`, `Int32`, `Double`, `String`, …) to their names and falls back to the canonical node id string for custom types.
- `Browse for OpcUaClient::browse_node` now issues one batched `read_many_attributes(DATATYPE)` for the `Variable` children of each browsed node (one extra request per browse level, zero when a level has no variables). A failed read is logged and leaves `data_type = None` rather than failing the browse.

## Type of change

- [x] New feature (`feat`)

## Verification

`cargo check/clippy -p instro-opcua --all-targets --all-features`, `cargo +nightly fmt --check`, `cargo test -p instro-opcua`: 73 unit + 6 `client_harness` tests pass. Not exercised against a real server beyond the harness.

## Tests

- [x] Unit tests added or updated — serde roundtrip includes `data_type`; new `data_type_name_maps_builtin_and_falls_back_to_node_id`.

## Checklist

- [x] PR title follows Conventional Commits
- [x] I have read CONTRIBUTING.md
- [x] Documentation updated if user-facing behavior changed (crate-internal API; no user docs affected)
- [x] Code follows the style/conventions of the surrounding code

## Notes for reviewers

Adding a public struct field is technically a breaking change for downstream struct literals