### PR TITLE
feat(lib): modified FilePublisher 

### DIFF
--- a/instro/lib/publishers/files.py
+++ b/instro/lib/publishers/files.py
@@ -1,62 +1,98 @@
-"""File-based publishers (JSON, JSONL, CSV, Avro)."""
+"""File-based publishers for JSON, JSONL, CSV, and Avro output.
+
+This module defines the publisher classes used to persist Measurement and Command
+records to disk. Each format is handled by a dedicated writer that owns a
+file-like object and writes serialized records with the appropriate data model.
+"""
 
 import csv
 import json
 import math
 import warnings
+from abc import ABC, abstractmethod
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Literal, Protocol
+from tempfile import NamedTemporaryFile
+from typing import IO, Any, AnyStr, Generic, Literal, cast
 
 import fastavro
 
 from instro.lib.types import Command, Measurement
 
 
-class FileWriter(Protocol):
-    file_path: Path
+class FileWriter(Generic[AnyStr], ABC):
+    """Abstract base class for format-specific file writers.
 
-    def write(self, data: Measurement | Command): ...
+    Concrete subclasses provide the serialization logic for a specific output
+    format while sharing the same file lifecycle contract: the writer owns a
+    file-like object and exposes a standard ``write``, ``open``, and ``close``
+    interface.
+    """
 
-    def open(self): ...
+    def __init__(self, file: IO[AnyStr]) -> None:
+        """Initialize the writer with an open file-like object.
 
-    def close(self): ...
+        Args:
+            file: The text or binary stream that will receive serialized records.
+        """
+        self._file: IO[AnyStr] = file
+
+    @abstractmethod
+    def write(self, data: Measurement | Command) -> None:
+        """Write a Measurement or Command record to the underlying stream."""
+
+    def open(self) -> None:
+        """Open the writer's file handle.
+
+        This base implementation is intentionally a no-op because the stream is
+        expected to be opened by the publisher before the writer is constructed.
+        """
+        pass
+
+    def close(self) -> None:
+        """Close the underlying file-like object."""
+        self._file.close()
 
 
 class FilePublisher:
+    """Coordinate writing Measurement and Command records to a configured output.
+
+    The publisher can be created either from a pre-opened file-like object or from
+    a directory path and filename arguments. When no directory is provided, it
+    creates a persistent temporary file so callers can publish without managing a
+    filesystem path manually.
+    """
+
     def __init__(
         self,
-        directory: str | Path,
-        format: Literal["json", "jsonl", "csv", "avro"] = "avro",
+        directory: str | Path | None = None,
+        format: Literal["json", "jsonl", "csv", "avro"] = "jsonl",
         custom_file_name: str | None = None,
-    ):
-        """Write Measurement/Command data to a file.
+        *,
+        file: IO[Any] | None = None,
+    ) -> None:
+        """Create a publisher bound to a stream, a file path, or a temporary file.
 
         Args:
-            directory: Output directory.
-            format: ``"jsonl"``, ``"csv"``, ``"avro"`` (default), or ``"json"`` (deprecated).
-            custom_file_name: Filename without extension; defaults to ``measurements-<UTC-timestamp>``.
+            directory: Directory where output files should be created. If omitted,
+                a temporary file is created instead.
+            format: Output format, one of ``"json"``, ``"jsonl"``, ``"csv"``, or
+                ``"avro"``.
+            custom_file_name: Optional filename stem used when writing to disk.
+            file: Optional pre-opened file-like object. When supplied, it takes
+                precedence over path-based construction and cannot be combined
+                with ``directory`` or ``custom_file_name``.
         """
-        self.directory = Path(directory)
+        if file is not None and (directory is not None or custom_file_name is not None):
+            raise ValueError("file cannot be combined with directory or custom_file_name")
+
+        self.directory = Path(directory) if directory is not None else None
         self.format = format
         self.custom_file_name = custom_file_name
-        self._writer: FileWriter
+        self._writer: FileWriter[Any]
+        self.file_path: Path | None = None
 
-        # Determine file name
-        if custom_file_name is None:
-            # Create timestamp suffix in YYYY-MM-DD-hh-mm-ss format
-            timestamp_suffix = datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
-            file_name = f"measurements-{timestamp_suffix}"
-        else:
-            file_name = custom_file_name
-
-        # Add file extension
-        file_name = f"{file_name}.{format}"
-
-        # Create full file path
-        self.file_path = self.directory / file_name
-
-        # Initialize appropriate writer based on format
+        writer_class: type[FileWriter[Any]]
         if format == "json":
             warnings.warn(
                 'FilePublisher format="json" rewrites the whole file on every publish and is deprecated; '
@@ -64,18 +100,61 @@ class FilePublisher:
                 DeprecationWarning,
                 stacklevel=2,
             )
-            self._writer = JsonFileWriter(self.file_path)
+            writer_class = JsonFileWriter
+            mode = "w+"
         elif format == "jsonl":
-            self._writer = JsonlFileWriter(self.file_path)
+            writer_class = JsonlFileWriter
+            mode = "a"
         elif format == "csv":
-            self._writer = CsvFileWriter(self.file_path)
+            writer_class = CsvFileWriter
+            mode = "a"
         elif format == "avro":
-            self._writer = AvroFileWriter(self.file_path)
+            writer_class = AvroFileWriter
+            mode = "wb"
         else:
             raise ValueError(f"Unsupported format: {format}")
 
+        if file is not None:
+            self._writer = writer_class(file)
+            return
+
+        newline = "" if format == "csv" else None
+        if self.directory is None:
+            stream = cast(
+                IO[Any],
+                NamedTemporaryFile(
+                    mode=mode,
+                    prefix=f"{custom_file_name}-" if custom_file_name is not None else "measurements-",
+                    suffix=f".{format}",
+                    newline=newline,
+                    delete=False,
+                ),
+            )
+            self.file_path = Path(stream.name)
+            self.directory = self.file_path.parent
+        else:
+            file_name = custom_file_name
+            if file_name is None:
+                file_name = f"measurements-{datetime.now():%Y-%m-%d-%H-%M-%S}"
+            self.file_path = self.directory / f"{file_name}.{format}"
+            self.file_path.parent.mkdir(parents=True, exist_ok=True)
+            if format == "json" and self.file_path.exists():
+                mode = "r+"
+            stream = open(self.file_path, mode, newline=newline)
+        try:
+            self._writer = writer_class(stream)
+        except Exception:
+            stream.close()
+            raise
+
     def publish(self, data: Measurement | Command, **kwargs):
-        """Publish data to file using the appropriate writer."""
+        """Publish one Measurement or Command using the configured writer.
+
+        Args:
+            data: The Measurement or Command instance to store.
+            **kwargs: Additional arguments accepted for compatibility with the
+                publisher interface.
+        """
         SHARED_PUBLISHER_WARNING = (
             "If you're attempting to publish from multiple instruments, consider using SharedPublisher. "
             "See https://instro.nominal.io/instrumentation/publishers#sharedpublisher for more information."
@@ -93,41 +172,39 @@ class FilePublisher:
 
             raise
 
-    def open(self):
-        # Stubbing out open method for when we opt to refactor this to use a file handle
-        pass
+    def open(self) -> None:
+        """Open the underlying writer if it owns a file handle."""
+        self._writer.open()
 
     def close(self):
-        """Close the publisher and ensure all data is written."""
+        """Close the underlying writer and flush any buffered data."""
         self._writer.close()
 
 
-class JsonFileWriter:
-    """Handles JSON format writing with proper file management."""
+class JsonFileWriter(FileWriter[str]):
+    """Write JSON records as a complete array on disk.
 
-    def __init__(self, file_path: Path):
-        self.file_path = file_path
-        self._ensure_file_exists()
+    Each publish operation reloads the file, appends the new record, and writes
+    the updated list back to disk. This preserves the existing array-based JSON
+    format and maintains compatibility with older consumers.
+    """
 
-    def _ensure_file_exists(self):
-        """Create directory and file if they don't exist."""
-        self.file_path.parent.mkdir(parents=True, exist_ok=True)
-        if not self.file_path.exists():
-            # Create empty file with proper JSON structure
-            with open(self.file_path, "w") as f:
-                f.write("[]")  # Start with empty JSON array
+    def __init__(self, file: IO[str]) -> None:
+        """Initialize the JSON writer and seed an empty array when needed."""
+        super().__init__(file)
+        self._file.seek(0, 2)
+        if self._file.tell() == 0:
+            self._file.write("[]")
+            self._file.flush()
 
-    def write(self, data: Measurement | Command):
-        """Append data to JSON file."""
+    def write(self, data: Measurement | Command) -> None:
+        """Append a Measurement or Command payload to the JSON array."""
         # Read existing content
+        self._file.seek(0)
         try:
-            with open(self.file_path, "r") as f:
-                content = f.read().strip()
-                if content:
-                    existing_data = json.loads(content)
-                else:
-                    existing_data = []
-        except (json.JSONDecodeError, FileNotFoundError):
+            content = self._file.read().strip()
+            existing_data = json.loads(content) if content else []
+        except json.JSONDecodeError:
             existing_data = []
 
         # Append new data
@@ -137,16 +214,10 @@ class JsonFileWriter:
             existing_data = [existing_data, data.__dict__]
 
         # Write back to file
-        with open(self.file_path, "w") as f:
-            json.dump(existing_data, f, indent=2)
-
-    def open(self):
-        # Stubbing out open method for when we opt to refactor this to use a file handle
-        pass
-
-    def close(self):
-        """Close the file writer."""
-        pass
+        self._file.seek(0)
+        self._file.truncate()
+        json.dump(existing_data, self._file, indent=2)
+        self._file.flush()
 
 
 def _json_safe(value: Any) -> Any:
@@ -159,49 +230,33 @@ def _json_safe(value: Any) -> Any:
     return value
 
 
-class JsonlFileWriter:
-    """Handles newline-delimited JSON writing with a persistent file handle."""
+class JsonlFileWriter(FileWriter[str]):
+    """Write newline-delimited JSON records to a persistent stream."""
 
-    def __init__(self, file_path: Path):
-        self.file_path = file_path
-        self._ensure_file_exists()
-        self._file = open(self.file_path, "a")
-
-    def _ensure_file_exists(self):
-        """Create directory if it doesn't exist."""
-        self.file_path.parent.mkdir(parents=True, exist_ok=True)
-
-    def write(self, data: Measurement | Command):
-        """Append data as one JSON line, mapping non-finite floats to null."""
+    def write(self, data: Measurement | Command) -> None:
+        """Append one JSON object as a single newline-delimited record."""
         self._file.write(json.dumps(_json_safe(data.__dict__), allow_nan=False) + "\n")
         self._file.flush()
 
-    def open(self):
-        pass
 
-    def close(self):
-        """Close the file writer."""
-        self._file.close()
+class CsvFileWriter(FileWriter[str]):
+    """Write Measurement and Command data as CSV rows.
 
+    One row is emitted per channel value. The writer ensures the CSV header is
+    created once per file and then appends each sample in the canonical order.
+    """
 
-class CsvFileWriter:
-    """Handles CSV format writing with a persistent file handle."""
-
-    def __init__(self, file_path: Path):
-        self.file_path = file_path
-        self._ensure_file_exists()
-        self._file = open(self.file_path, "a", newline="")
+    def __init__(self, file: IO[str]) -> None:
+        """Initialize the CSV writer and create the header when needed."""
+        super().__init__(file)
+        self._file.seek(0, 2)
         self._writer = csv.DictWriter(self._file, fieldnames=["timestamp", "channel", "value", "tags"])
-        if self.file_path.stat().st_size == 0:
+        if self._file.tell() == 0:
             self._writer.writeheader()
             self._file.flush()
 
-    def _ensure_file_exists(self):
-        """Create directory if it doesn't exist."""
-        self.file_path.parent.mkdir(parents=True, exist_ok=True)
-
-    def write(self, data: Measurement | Command):
-        """Append data to CSV file."""
+    def write(self, data: Measurement | Command) -> None:
+        """Append a Measurement or Command to the CSV output."""
         if isinstance(data, Measurement):
             self._write_measurement(data)
         elif isinstance(data, Command):
@@ -226,20 +281,18 @@ class CsvFileWriter:
             tags = json.dumps(data.tags) if data.tags else ""
             self._writer.writerow({"timestamp": data.timestamp, "channel": channel_name, "value": value, "tags": tags})
 
-    def open(self):
-        pass
 
-    def close(self):
-        """Close the file writer."""
-        self._file.close()
+class AvroFileWriter(FileWriter[bytes]):
+    """Write Avro records with a schema compatible with the ingest format.
 
+    The writer maintains a fastavro schema and a binary stream, allowing batches
+    of Measurement and Command values to be appended without rewriting the entire
+    file.
+    """
 
-class AvroFileWriter:
-    """Handles Avro format writing with proper file management using fastavro."""
-
-    def __init__(self, file_path: Path):
-        self.file_path = file_path
-        self._ensure_file_exists()
+    def __init__(self, file: IO[bytes]) -> None:
+        """Initialize the Avro writer with a binary stream and schema."""
+        super().__init__(file)
 
         # Define Schema compatible with Nominal Core
         self.schema = {
@@ -255,17 +308,11 @@ class AvroFileWriter:
         }
         self._parsed_schema = fastavro.parse_schema(self.schema)
 
-        # Open file and initialize writer
-        self._file = open(self.file_path, "wb")
         # Using snappy compression requires cramjam package
         self._writer = fastavro.write.Writer(self._file, self._parsed_schema, codec="snappy")
 
-    def _ensure_file_exists(self):
-        """Create directory if it doesn't exist."""
-        self.file_path.parent.mkdir(parents=True, exist_ok=True)
-
-    def write(self, data: Measurement | Command):
-        """Append data to Avro file."""
+    def write(self, data: Measurement | Command) -> None:
+        """Append a Measurement or Command as one or more Avro records."""
         if isinstance(data, Measurement):
             self._write_measurement(data)
         elif isinstance(data, Command):
@@ -296,12 +343,8 @@ class AvroFileWriter:
                 }
             )
 
-    def open(self):
-        # Stubbing out open method for when we opt to refactor this to use a file handle
-        pass
-
-    def close(self):
+    def close(self) -> None:
         """Close the file writer."""
-        if self._file and not self._file.closed:
+        if not self._file.closed:
             self._writer.flush()
-            self._file.close()
+            super().close()

--- a/tests/lib/test_file_publisher.py
+++ b/tests/lib/test_file_publisher.py
@@ -1,5 +1,6 @@
 """Unit tests for FilePublisher JSONL support and JSON deprecation."""
 
+import io
 import json
 import warnings
 
@@ -78,6 +79,45 @@ def test_jsonl_each_line_is_complete_before_close(tmp_path):
     content = (tmp_path / "capture.jsonl").read_text()
     assert content.endswith("\n")
     json.loads(content)
+
+
+def test_jsonl_accepts_file_like_object():
+    stream = io.StringIO()
+    publisher = FilePublisher(file=stream, format="jsonl")
+
+    publisher.publish(_measurement())
+
+    assert publisher.file_path is None
+    assert not stream.closed
+    stream.seek(0)
+    assert json.loads(stream.read()) == {
+        "channel_data": {"channel_a": [1.0, 2.0]},
+        "timestamps": [100, 200],
+        "tags": {"unit": "volts"},
+    }
+
+    publisher.close()
+    assert stream.closed
+
+
+def test_jsonl_defaults_to_temporary_file_when_no_args_are_given():
+    publisher = FilePublisher(format="jsonl")
+
+    try:
+        assert publisher.file_path is not None
+        assert publisher.file_path.exists()
+        publisher.publish(_measurement())
+        publisher.close()
+        assert publisher.file_path.exists()
+        assert publisher.file_path.read_text().endswith("\n")
+        assert json.loads(publisher.file_path.read_text()) == {
+            "channel_data": {"channel_a": [1.0, 2.0]},
+            "timestamps": [100, 200],
+            "tags": {"unit": "volts"},
+        }
+    finally:
+        if publisher.file_path is not None and publisher.file_path.exists():
+            publisher.file_path.unlink()
 
 
 def test_jsonl_close_closes_file_handle(tmp_path):


### PR DESCRIPTION
## Summary
made filewriter to operate on a file-like object. 
updated  all filewriters make use of inheritance. updated FilePublisher for this.

Filepublisher can init from
* filelike object
* nothing (defaults to writing to some tempfile )

## Type of change

- [ ] Bug fix (`fix`)
- [x] New feature (`feat`)
- [ ] Breaking change (`feat!` / `fix!`)
- [ ] Refactor (`refactor`)
- [ ] Documentation (`docs`)
- [ ] Chore / tooling (`chore`)

## Verification

ran tests 
## Tests

- [x] Unit tests added or updated
- [ ] Existing tests cover this change
- [ ] No tests — explain why:

## Checklist

- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(driver): add support for Keysight E36300`)
- [ ] I have read [CONTRIBUTING.md](CONTRIBUTING.md)
- [ ] Documentation updated if user-facing behavior changed
- [ ] Code follows the style/conventions of the surrounding code

## Notes for reviewers

_Optional — call out specific files, edge cases, or decisions you'd like eyes on._
